### PR TITLE
layouts: add year to event page header

### DIFF
--- a/themes/devopsdays-legacy/layouts/event/single.html
+++ b/themes/devopsdays-legacy/layouts/event/single.html
@@ -15,7 +15,7 @@
 <div class = "container-fluid">
   <div class="row">
 		<div class="col-md-8">
-      <h1> {{ $e.city }} - {{ title .Title }} </h1>
+      <h1> {{ $e.city }} {{ $e.year }} - {{ title .Title }} </h1>
       <!-- Main navigation -->
       <div class="submenu">
         <h3>


### PR DESCRIPTION
When comparing the legacy layout with the output of the devops-webby, I
found we are missing the year in the new template. This is useful when
navigating the same event or any event across multiple years as the
header did not show it.