### PR TITLE
reduced total logo width from 100px to 95px

### DIFF
--- a/themes/devopsdays-legacy/layouts/event/single.html
+++ b/themes/devopsdays-legacy/layouts/event/single.html
@@ -35,7 +35,7 @@
       {{ range where $sponsors "level" .id }}
         {{ $s :=  (index $.Site.Data.sponsors .id) }}
         {{ if isset $.Site.Data.sponsors .id }}
-          <a href = "{{ $s.url }}"><img alt = "{{ .id }}" src = "/img/sponsors/{{ .id }}.png" class="img-responsive company-logo" width = "100px"></a>
+          <a href = "{{ $s.url }}"><img alt = "{{ .id }}" src = "/img/sponsors/{{ .id }}.png" class="img-responsive company-logo" width = "95px"></a>
         {{ end }}
       {{ end }}
       <div class = "sponsor-cta">


### PR DESCRIPTION
For #108 

I'm not sure this is the "right" way to do this compared to changing the width of the div, but reducing the total size of the logos by 5px makes them 3 wide on desktop browsers.