### PR TITLE
Added event_map short code

### DIFF
--- a/content/events/sample-event/location.md
+++ b/content/events/sample-event/location.md
@@ -5,7 +5,7 @@ type = "event"
 draft = true
 
 +++
-<h4>
 
 Information about the venue including address, map/direction, parking/transit, and any hotel group discount codes.
-<p>
+
+<!-- {{< event_map >}} -->

--- a/layouts/shortcodes/event_map.html
+++ b/layouts/shortcodes/event_map.html
@@ -1,0 +1,36 @@
+{{ $path := split .Page.Source.File.Path "/" }}
+{{ $event_slug := index $path 1 }}
+{{ $e :=  (index .Page.Site.Data.events $event_slug) }}
+
+{{ $coords := split $e.coordinates "," }}
+{{ $lat := index $coords 0 }}
+{{ $lng := index $coords 1 }}
+
+<link href="/css/googlemaps.css" rel="stylesheet">
+
+<div id="map_canvas" style="width: 550px; height: 265px"></div>
+
+<script type="text/javascript" language="javascript">
+  function initMap() {
+    var mapDiv = document.getElementById("map_canvas");
+    var position = new google.maps.LatLng({{ $lat | safeJS }}, {{ $lng | safeJS }});
+
+    var map = new google.maps.Map(mapDiv, {
+      center: position,
+      zoom: 14,
+      mapTypeID: google.maps.MapTypeId.ROADMAP
+    });
+
+    var marker = new google.maps.Marker({
+      position: position,
+      map: map,
+      title: "{{ $e.location | safeJS }}",
+    });
+  }
+
+  window.onload = function() {
+    initMap();
+  };  
+</script>
+
+<script type="text/javascript" src="http://maps.google.com/maps/api/js?key=AIzaSyC1bvNK9qFJGEhoWNbQuojmJJ1Tg0DoOew"></script>


### PR DESCRIPTION
We've already got the event lat+lon and a location name. I figured it would be nice if we used these to generate a map on each event's location page via a shortcode.

Organizers will just need to ensure their lat+lon and location (venue name) are correct in the YAML, then uncomment the event_map shortcode in location.md.