### PR TITLE
Migrate Toronto 2016 program to new site.

### DIFF
--- a/content/events/2016-toronto/program.md
+++ b/content/events/2016-toronto/program.md
@@ -34,20 +34,21 @@ type = "event"
 <div class="span-2">10:00-10:15</div><div class="span-4 box last">Opening Welcome</div>
 
 <div class="span-2">10:15-10:45</div><div class="span-4 box last">
-    <a href="../proposals/keynote/">Coming soon</a><br />
+    <a href="/events/2016-toronto/proposals/keynote/">Coming soon</a><br />
     <em>John Willis</em>, <a href="https://twitter.com/botchagalupe" target="_blank">@botchagalupe</a>
     Keynote<br />
 </div>
 
 <div class="span-2">10:50-11:20</div><div class="span-4 box last">
-    <a href="../proposals/How%20Brazil's%20government%20kept%20us%20up%20at%20night/">How Brazil's government kept us up at night</a><br />
-    <em>Hany Fahim</em>, <a href="https://twitter.com/iHandroid" target="_blank">@iHandroid</a>
+    <a href="/events/2016-toronto/proposals/How%20Brazil's%20government%20kept%20us%20up%20at%20night/">How Brazil's government kept us up at night</a><br />
+    <em>Hany Fahim</em>, <a href="https://twitter.com/iHandroid" target="_blank">@iHandroid</a><br />
+    <br />
 </div>
 
 <div class="span-2">11:20-11:30</div><div class="span-4 box last">Break</div>
 
 <div class="span-2">11:30-12:00</div><div class="span-4 box last">
-    <a href="../proposals/From%20Commit%20To%20Production%20And%20Beyond%20-%20The%20Continuous%20Delivery%20Pipeline/">From Commit To Production And Beyond - The Continuous Delivery Pipeline</a><br />
+    <a href="/events/2016-toronto/proposals/From%20Commit%20To%20Production%20And%20Beyond%20-%20The%20Continuous%20Delivery%20Pipeline/">From Commit To Production And Beyond - The Continuous Delivery Pipeline</a><br />
     <em>Arthur Maltson</em>, <a href="https://twitter.com/amaltson" target="_blank">@amaltson</a>
 </div>
 
@@ -55,42 +56,41 @@ type = "event"
 
 <div class="span-2">13:00-13:30</div><div class="span-4 box last">
     Ignites<br />
-    <a href="../proposals/Being%20an%20introvert%20and%20at%20a%20conference,%20not%20as%20hellish%20as%20you%20think%20it%20is/">Being an introvert and at a conference, not as hellish as you think it is</a><br />
+    <a href="/events/2016-toronto/proposals/Being%20an%20introvert%20and%20at%20a%20conference%20not%20as%20hellish%20as%20you%20think%20it%20is/">Being an introvert and at a conference, not as hellish as you think it is</a><br />
     <em>JJ Asghar</em>, <a href="https://twitter.com/jjasghar" target="_blank">@jjasghar</a><br /><br />
     
-    <a href="../proposals/Why%20we%20should%20be%20excited%20about%20Azure%20Stack/">Why we should be excited about Azure Stack</a><br />
+    <a href="/events/2016-toronto/proposals/Why%20we%20should%20be%20excited%20about%20Azure%20Stack/">Why we should be excited about Azure Stack</a><br />
     <em>Max Yermakhanov</em>, <a href="https://twitter.com/yermax" target="_blank">@yermax</a><br /><br />
 
-    <a href="../proposals/Devops%20Evolution%20at%20Nulogy/">Devops Evolution at Nulogy</a><br />
+    <a href="/events/2016-toronto/proposals/Devops%20Evolution%20at%20Nulogy/">Devops Evolution at Nulogy</a><br />
     <em>Ian Penney</em>, <a href="https://twitter.com/cr03" target="_blank">@cr03</a><br /><br />
 
-    <a href="../proposals/Public%20Postmortem%20on%20After%20Hours%20Maintenance%20Gone%20Awry/">Public Postmortem on After Hours Maintenance Gone Awry</a><br />
+    <a href="/events/2016-toronto/proposals/Public%20Postmortem%20on%20After%20Hours%20Maintenance%20Gone%20Awry/">Public Postmortem on After Hours Maintenance Gone Awry</a><br />
     <em>Jason Shaw</em>, <a href="https://twitter.com/jasonious" target="_blank">@jasonious</a>
 </div>
 
 <div class="span-2">13:35-14:05</div><div class="span-4 box last">
-    <a href="../proposals/Containers%20will%20not%20fix%20your%20broken%20culture%20(and%20other%20hard%20truths)/">Containers will not fix your broken culture (and other hard truths)</a><br />
+    <a href="/events/2016-toronto/proposals/Containers%20will%20not%20fix%20your%20broken%20culture%20(and%20other%20hard%20truths)/">Containers will not fix your broken culture (and other hard truths)</a><br />
     <em>Bridget Kromhout</em>, <a href="https://twitter.com/bridgetkromhout" target="_blank">@bridgetkromhout</a>
 </div>
 
 
-<div class="span-2">14:05-14:40</div><div class="span-4 box last">Open Space Opening</div>
+<div class="span-2">14:05-14:40</div><div class="span-4 box last"><strong><a href="/pages/open-space-format">Open Space Opening</a></strong></div>
 
-<div class="span-2">14:40-15:25</div><div class="span-4 box last">Open Space #1</div>
+<div class="span-2">14:40-15:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #1</div>
 
 <div class="span-2">15:25-15:40</div><div class="span-4 box last">Break</div>
 
-<div class="span-2">15:40-16:25</div><div class="span-4 box last">Open Space #2</div>
+<div class="span-2">15:40-16:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #2</div>
 
 <div class="span-2">16:25-16:40</div><div class="span-4 box last">Break</div>
 
-<div class="span-2">16:40-17:25</div><div class="span-4 box last">Open Space #3</div>
+<div class="span-2">16:40-17:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #3</div>
 
 <div class="span-2">17:45-20:30</div><div class="span-4 box last"><strong>Happy Hour - details to come</strong></div>
 
 
 </div>
-
 
 <div class="span-7 append-bottom border">
 
@@ -103,20 +103,25 @@ type = "event"
 <div class="span-2">10:00-10:15</div><div class="span-4 box last">Opening Welcome</div>
 
 <div class="span-2">10:15-10:45</div><div class="span-4 box last">
-    <a href="../proposals/Scaling%20out%20Continuous%20Delivery/">Scaling out Continuous Delivery</a><br />
+    <a href="/events/2016-toronto/proposals/Scaling%20out%20Continuous%20Delivery/">Scaling out Continuous Delivery</a><br />
     <em>John Arthorne</em>, <a href="https://twitter.com/jarthorne" target="_blank">@jarthorne</a>
 </div>
 
 <div class="span-2">10:50-11:20</div><div class="span-4 box last">
-    <a href="../proposals/Why%20We%20Threw%205%20Months%20of%20Work%20in%20the%20Trash%20or%20How%20we%20Failed%20at%20adopting%20DevOps/">Why We Threw 5 Months of Work in the Trash; or How we Failed at adopting DevOps</a><br />
+    <a href="/events/2016-toronto/proposals/Why%20We%20Threw%205%20Months%20of%20Work%20in%20the%20Trash%20or%20How%20we%20Failed%20at%20adopting%20DevOps/">Why We Threw 5 Months of Work in the Trash; or How we Failed at adopting DevOps</a><br />
     <em>Sina Jahan</em>
 </div>
 
 <div class="span-2">11:20-11:30</div><div class="span-4 box last">Break</div>
 
 <div class="span-2">11:30-12:00</div><div class="span-4 box last">
-    <a href="../proposals/Agile%20databases/">Agile databases</a><br />
-    <em>Jeff Zohrab</em>
+    <a href="/events/2016-toronto/proposals/Agile%20databases/">Agile databases</a><br />
+    <em>Jeff Zohrab</em><br />
+    <br />
+    <br />
+    <br />
+    <br />
+    <br />
 </div>
 
 <div class="span-2">12:00-13:00</div><div class="span-4 box last">Lunch</div>
@@ -124,35 +129,39 @@ type = "event"
 <div class="span-2">13:00-13:30</div><div class="span-4 box last">
     Ignites<br />
 
-    <a href="../proposals/Supporting%20Developers%20Through%20DevOps/">Supporting Developers Through DevOps</a><br />
+    <a href="/events/2016-toronto/proposals/Supporting%20Developers%20Through%20DevOps/">Supporting Developers Through DevOps</a><br />
     <em>Roderick Randolph</em><br /><br />
 
-    <a href="../proposals/dotfiles.CI/">dotfiles.CI</a><br />
+    <a href="/events/2016-toronto/proposals/dotfiles.CI/">dotfiles.CI</a><br />
     <em>Will Weaver</em>, <a href="https://twitter.com/buildingbananas" target="_blank">@buildingbananas</a><br /><br />
 
-    <a href="../proposals/Feeling%20the%20burn/">Feeling the burn?</a><br />
+    <a href="/events/2016-toronto/proposals/Feeling%20the%20burn/">Feeling the burn?</a><br />
     <em>Jason Harley</em>, <a href="https://twitter.com/redmind" target="_blank">@redmind</a><br /><br />
  
-    <a href="../proposals/Are%20YOU%20the%20Change%20Agent%20your%20Organization%20is%20Looking%20For/">Are YOU the Change Agent your Organization is Looking For…?</a><br />
-    <em>Drew Nienaber</em>, <a href="https://twitter.com/DrewNienaber" target="_blank">@DrewNienaber</a>
+    <a href="/events/2016-toronto/proposals/Are%20YOU%20the%20Change%20Agent%20your%20Organization%20is%20Looking%20For/">Are YOU the Change Agent your Organization is Looking For…?</a><br />
+    <em>Drew Nienaber</em>, <a href="https://twitter.com/DrewNienaber" target="_blank">@DrewNienaber</a><br />
+    <br />
+    <br />
+    <br />
+    <br />
 </div>
 
 <div class="span-2">13:35-14:05</div><div class="span-4 box last">
-    <a href="../proposals/Waterboy%20-%20our%20robot%20coworker/">Waterboy - our robot coworker</a><br />
+    <a href="/events/2016-toronto/proposals/Waterboy%20-%20our%20robot%20coworker/">Waterboy - our robot coworker</a><br />
     <em>Sean Walberg</em>, <a href="https://twitter.com/seanwalberg" target="_blank">@seanwalberg</a>
 </div>
 
-<div class="span-2">14:05-14:40</div><div class="span-4 box last">Open Space Opening</div>
+<div class="span-2">14:05-14:40</div><div class="span-4 box last"><strong><a href="/pages/open-space-format">Open Space Opening</a></strong></div>
 
-<div class="span-2">14:40-15:25</div><div class="span-4 box last">Open Space #1</div>
+<div class="span-2">14:40-15:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #1</div>
 
 <div class="span-2">15:25-15:40</div><div class="span-4 box last">Break</div>
 
-<div class="span-2">15:40-16:25</div><div class="span-4 box last">Open Space #2</div>
+<div class="span-2">15:40-16:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #2</div>
 
 <div class="span-2">16:25-16:40</div><div class="span-4 box last">Break</div>
 
-<div class="span-2">16:40-17:25</div><div class="span-4 box last">Open Space #3</div>
+<div class="span-2">16:40-17:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #3</div>
 
 <div class="span-2">17:30-17:45</div><div class="span-4 box last"><strong>Closing Day & Farewell</strong></div>
 

--- a/content/events/2016-toronto/proposals/Agile databases.md
+++ b/content/events/2016-toronto/proposals/Agile databases.md
@@ -1,0 +1,33 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Jeff Zohrab"
+
++++
+
+### Agile Databases
+
+**Abstract:**
+
+Databases are almost always a pain point for development, especially when it comes to agile. In this talk, I'll discuss what I feel are the main points that need to be considered for successful database development:
+
++ each dev should have their own development database, and should create database change scripts
++ changes should be easily integrated
++ baselining
++ the difference between reference and test data
++ handling schema vs code changes
++ testing
++ backwards compatibility checks
++ database refactoring
+
+For lack of a better tool (at least, at the time!), I wrote a cross-platform database development tool in Python that can/should be able to work with any database for which suitable drivers exist, and implementations are available for MySQL and Postgres. I'll use that as a demo. With this tool (version 0.1 of it, anyway), I had a team of 6 devs destroying and rebuilding their dev databases as needed with a single click, running their dev tests on their dedicated instances, and deploying to multiple QA and integration environments.
+
+I think that this topic is interesting in general as it highlights the need to pull pain points forward and deal with them. Paraphrasing Jez Humble -- or maybe exactly quoting him per <a href="http://evan.bottch.com/2010/05/26/continuous-integration-if-something-hurts-do-it-more-often/" target="_blank">Continuous Integration – If Something Hurts, Do It More Often</a> -- database things hurt, and so they need to be done as much as possible. Unfortunately, many tools don't address these needs, and advice on the net can end up being problematic (eg the tip "your db change script should check if a column exists before adding it" can end up avoiding one trouble but causing another).
+
+**Speaker:**
+
+Jeff Zohrab
+
+I've been in tech for a few decades now, and was an early adopter with XP designed testing frameworks for VB and C++. I've worked on small, big, and huge projects on the development side as dev, team lead, and architect, and have recently started working with a Japanese company to instill DevOps practices into their culture.

--- a/content/events/2016-toronto/proposals/Are YOU the Change Agent your Organization is Looking For.md
+++ b/content/events/2016-toronto/proposals/Are YOU the Change Agent your Organization is Looking For.md
@@ -1,0 +1,20 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Drew Nienaber"
+
++++
+
+### Are YOU the Change Agent your Organization is Looking For…?
+
+**Abstract:**
+
+For most organizations, DevOps means a change, both to your process and your way of thinking. Change is hard and being the one to introduce change into your organization is even more difficult. In this Ignite, I’ll talk about the assumptions we make about change, the universal truths we accept about change, the questions to ask yourself before initiating change and four approaches to bringing it. With the help of the book Change Anything: The New Science of Personal Success, I’ll show how you can be the transformer & revolutionary you’ve always dreamed of being.
+
+**Speaker:**
+
+Drew Nienaber, <a href="https://twitter.com/DrewNienaber" target="_blank">@DrewNienaber</a>
+
+I'm (Drew) a sales guy, but don't hate me for that. I'm also a craft beer aficionado, a dad and a Nawlins boy desperately looking for Zapps chips in Colorado.

--- a/content/events/2016-toronto/proposals/Being an introvert and at a conference not as hellish as you think it is.md
+++ b/content/events/2016-toronto/proposals/Being an introvert and at a conference not as hellish as you think it is.md
@@ -1,0 +1,33 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "JJ Asghar"
+
++++
+
+### Being an introvert and at a conference, not as hellish as you think it is
+
+**Abstract:**
+
+I'd like to give some advice on how to deal with conferences as an introvert.
+Over the last couple years I've grown and learned to engage with the tech community
+in ways that an introvert would find challenging. This talk will hopefully help
+the audience avoid some of the landmines that I have stepped on.
+
+I want to help out my fellow introverts to realize that it's OK to be an introvert
+at big conferences. We can enjoy them too.
+
+**Speaker:**
+
+JJ Asghar, <a href="https://twitter.com/jjasghar" target="_blank">@jjasghar</a>
+
+JJ is a Sr. Partner Engineer at Chef, he was also the PTL for the Openstack-Chef
+project. He lives in Austin, Texas and has been part of the OpenStack community since Diablo's release.
+
+He enjoys a good strong stout, hoppy IPA, and some Dwarf Fortress. He's a member
+of the Church of Emacs, and usually chooses Ubuntu over CentOS.
+
+He's a father and husband, if he's not trying to automate his job away he's
+trying to convince his daughters to "let the bot's do the work for them."

--- a/content/events/2016-toronto/proposals/Containers will not fix your broken culture (and other hard truths).md
+++ b/content/events/2016-toronto/proposals/Containers will not fix your broken culture (and other hard truths).md
@@ -1,0 +1,28 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Bridget Kromhout"
+
++++
+
+### Containers will not fix your broken culture (and other hard truths)
+
+**Abstract:**
+
+Containers will not fix your broken culture. Microservices won’t prevent your two-pizza teams from needing to have conversations with one another over that pizza. No amount of industrial-strength job scheduling makes your organization immune to Conway's Law.
+
+Does this mean that devops has failed? Not in the slightest. It means that while the unscrupulous might try to sell us devops, we can't buy it. We have to live it; change is a choice we make every day, through our actions of listening empathetically and acting compassionately. Iterative improvement starts somewhere for us all; let’s talk about it.
+
+Tools are essential, but how we implement the tools and grow the culture and practices in our organizations needs even more attention. Whether you’re just starting to implement technical and organizational change, or facing the prospect that you already have legacy microservices, it's worth considering the why and the how of our behaviors, not just the what.
+
+Making thoughtful decisions about tools and architecture can help. Containers prove to be a useful boundary object, and deconstructing systems to human-scale allows us to comprehend their complexity. We succeed when we share responsibility and have agency, when we move past learned helplessness to active listening. But there is no flowchart, no checklist, no shopping list of ticky boxes that will make everything better. "Anyone who says differently is selling something", as The Princess Bride teaches us. Instead, let’s talk about practical, actionable steps that will help. How do we evaluate our progress? How do we know when to course-correct? How do we react when it seems like there's always something new we should have done last month?
+
+Part rant, part devops therapy, this talk will explain in the nerdiest of terms why CAP theorem applies to human interactions too, how oral tradition is like never writing state to disk, and what we can do to avoid sadness as a service.
+
+**Speaker:**
+
+Bridget Kromhout, <a href="https://twitter.com/bridgetkromhout" target="_blank">@bridgetkromhout</a>
+
+Bridget Kromhout is a Principal Technologist for Cloud Foundry at Pivotal. Her CS degree emphasis was in theory, but she now deals with the concrete (if 'cloud' can be considered tangible). After years in site reliability operations (most recently at DramaFever), she traded in oncall for more travel. A frequent speaker at tech conferences, she helps organize the AWS and devops meetups at home in Minneapolis, serves on the program committee for Velocity, and acts as a global core organizer for devopsdays. She podcasts at Arrested DevOps, occasionally blogs at <a href="http://bridgetkromhout.com" target="_blank">bridgetkromhout.com</a>, and is active in a Twitterverse near you.

--- a/content/events/2016-toronto/proposals/Devops Evolution at Nulogy.md
+++ b/content/events/2016-toronto/proposals/Devops Evolution at Nulogy.md
@@ -1,0 +1,32 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Ian Penney"
+
++++
+
+### Devops Evolution at Nulogy
+
+**Abstract:**
+
+At Nulogy, our operations are supported by our Infrastructure team, colloquially known as the "Computer Friends and Justin"
+We are proud to have brought together a team of five veteran hackers with diverse academic and other backgrounds.
+
+We've recently been through a banner year of growth - having aggressively tackled quick wins to greatly improve the reliability of our flagship SaaS Logistics product to the point where it can be sold to large multinational corporations with a real need for "four nines" of uptime.
+
+Everyone on the team is a great fit with our well rounded company culture, but none of us started out in life as Devops Experts. We've learned it, and we want to help you learn it, too.
+
+The company had already been in operation for over ten years by the time we began to embrace DevOps and related practices. How is it possible to beat down technical debt with so many legacy systems, high SLA requirements and entrenched customers practices.
+And more to the point: how will this work make your work/life balance better?
+
+**Speaker:**
+
+Ian Penney, <a href="https://twitter.com/cr03" target="_blank">@cr03</a>
+
+Ian Penney has been working as a Systems Administrator and Systems Manager for over 15 years. He's worked at large companies like the Canadian Broadcasting Corporation and other enterprises through an IBM business partner, as well as with over 200 startups, from coast to coast.
+
+A few years ago, he realized Infrastructure as Code was the future, and so he began focusing on using tools like Chef, Puppet and Ansible.
+
+Most recently he's celebrated his first happy anniversary at Nulogy as the lead of their Infrastructure Team during a rapid transition towards "moar devops" and less risk.

--- a/content/events/2016-toronto/proposals/Feeling the burn.md
+++ b/content/events/2016-toronto/proposals/Feeling the burn.md
@@ -1,0 +1,18 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Jason Harley"
+
++++
+
+### Feeling the burn?
+
+**Abstract:**
+
+Burnout is often thought to be limited to Silicon Valley, but it's a very real problem here in the GTA. In this five minute talk, we'll explore the signs and symptoms of burnout, talk about the guilt, second guessing, and other feelings associated with it and what you can do to help yourself, your co-workers, and your friends in the community.
+
+**Speaker:**
+
+Jason Harley, <a href="https://twitter.com/redmind" target="_blank">@redmind</a>

--- a/content/events/2016-toronto/proposals/From Commit To Production And Beyond - The Continuous Delivery Pipeline.md
+++ b/content/events/2016-toronto/proposals/From Commit To Production And Beyond - The Continuous Delivery Pipeline.md
@@ -1,0 +1,24 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Arthur Maltson"
+
++++
+
+### From Commit To Production And Beyond - The Continuous Delivery Pipeline
+
+**Abstract:**
+
+You've probably heard about Continuous Delivery, and you have definitely heard of DevOps (it is a DevOps conference after all), but how are the two related? Throughout this talk you will learn what Continuous Delivery is and why your organization should strive to achieve it. You will then embark on a Continuous Delivery journey that will highlight the level of DevOps maturity an organization should be at to safely deliver to production on a regular basis and keep it running for the long term.
+
+This talk will give you some ideas of what a Continuous Delivery pipeline looks like and a workflow the Dev, QA and Ops groups may want to follow. Particular attention will be paid to the application life after deployment and ways of managing the complexity of an ever more distributed system.
+
+**Speaker:**
+
+Arthur Maltson, <a href="https://twitter.com/amaltson" target="_blank">@amaltson</a> 
+
+Arthur Maltson is a Software Developer who's 70% Dev and 30% Ops. He's currently practicing DevOps during the day and, as a husband and father he's also doing DadOps at night. Arthur embodies the Full Stack developer with his passion for infrastructure automation, API crafting, front end development and making work fun by introducing and/or building new tools.
+
+In his spare time Arthur spends far too much time trying to keep up with the latest tech. He also occasionally blogs, Tweets and commits to OSS.

--- a/content/events/2016-toronto/proposals/How Brazil's government kept us up at night.md
+++ b/content/events/2016-toronto/proposals/How Brazil's government kept us up at night.md
@@ -1,0 +1,20 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Hany Fahim"
+
++++
+
+### How Brazil's government kept us up at night
+
+**Abstract:**
+
+On the evening of December 16th, 2015, Brazil's government decided to ban the use of the popular WhatsApp platform. Over 93% of Brazil's internet population, roughly 93 million, use WhatsApp as part of their daily lives. The ban forced an uprising and lash back on social media, and the more savvy users began finding ways of circumventing. This talk tells the story of how this ban affected our own team and kept us up all night!
+
+**Speaker:**
+
+Hany Fahim, <a href="https://twitter.com/iHandroid" target="_blank">@iHandroid</a>
+
+Hany Fahim is the Founder and CEO of VM Farms, a 24×7 Operations Team and Cloud Provider. Hany has over 10 years of operations experience, both in building and supporting private and public cloud platforms, as well as Linux and OSS environments. You can reach Hany at <a href="https://twitter.com/iHandroid" target="_blank">@iHandroid</a> and the folks of VM Farms <a href="https://twitter.com/vmfarms" target="_blank">@vmfarms</a>.

--- a/content/events/2016-toronto/proposals/Public Postmortem on After Hours Maintenance Gone Awry.md
+++ b/content/events/2016-toronto/proposals/Public Postmortem on After Hours Maintenance Gone Awry.md
@@ -1,0 +1,20 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Jason Shaw"
+
++++
+
+### Public Postmortem on After Hours Maintenance Gone Awry
+
+**Abstract:**
+
+We needed to add some capacity to a Redis cluster, which would have customer impact, so it was scheduled for after hours. 20 minutes into a 30 minute window, wanted to close open connections, so we stopped a bunch of services. One of them had had some init changes recently, and it turns out they weren't tested and made it to production. What do you do when you're an Admin but the problem is dev code and it's 1am?
+
+**Speaker:**
+
+Jason Shaw, <a href="https://twitter.com/jasonious" target="_blank">@jasonious</a>
+
+Long time Linux SysAdmin with too much empathy for the BOfH style. Currently working on continuous integration and deployment at FreshBooks.

--- a/content/events/2016-toronto/proposals/Scaling out Continuous Delivery.md
+++ b/content/events/2016-toronto/proposals/Scaling out Continuous Delivery.md
@@ -1,0 +1,25 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "John Arthorne"
+
++++
+
+### Scaling out Continuous Delivery
+
+**Abstract:**
+
+Continuous delivery can be a simple practice when you are a small development team with a low scale web application. However, as teams scale up in size, commit and test volumes increase, and production architecture becomes more complex, continuous delivery becomes harder to achieve. Tools that once handled the load begin to fail, individual steps in the delivery process that were once fast turn into bottlenecks, and cultural practices and processes break down.
+
+This talk will describe how Shopify faced these scaling challenges as the team and its application infrastructure grew. A year ago, it could take hours for a developer to go from commit to fully deployment application. In response, the team re-architected its entire delivery pipeline to hand these scaling challenges. We cover how moving to a container-based build and creating the open source Shipit deployment tool allowed the team to regain its continuous delivery cadence.
+
+Today, every developer on a team of hundreds can deliver a change from commit to production in ten minutes. Each deploy includes execution of over 45,000 tests in a massively parallel build farm, and deploying the application to hundreds of servers in multiple data centres. Thirty or more production releases now run in a typical workday, and developer happiness has increased. We will cover the steps taken to get here, the technology choices made, and the stumbling blocks faced along the way.
+
+**Speaker:**
+
+John Arthorne, <a href="https://twitter.com/jarthorne" target="_blank">@jarthorne</a> 
+
+
+John works on the Shopify Production Engineering team, with a specific focus on creating developer tooling to accelerate application delivery. John is a <a href="http://jarthorn.github.io/" target="_blank">frequent speaker</a> at technical conferences in both Europe and North America, serves on conference program committees, is a JavaOne Rock Star, and frequently writes blogs and articles on technical topics. His current interests are in tools and practices for Continuous Delivery, and in highly scalable cloud architectures. Before joining Shopify, John led a team building cloud-based developer tooling for IBM Bluemix, and was a <a href="https://wiki.eclipse.org/User:John_arthorne.ca.ibm.com" target="_blank">prominent leader</a> within the Eclipse open source community.

--- a/content/events/2016-toronto/proposals/Supporting Developers Through DevOps.md
+++ b/content/events/2016-toronto/proposals/Supporting Developers Through DevOps.md
@@ -1,0 +1,20 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Roderick Randolph"
+
++++
+
+### Supporting Developers Through DevOps
+
+**Abstract:**
+
+Devs write code while Ops deploys and supports it, right? That's still the common belief among many developers. How do you change this behavior in a DevOps environment? To influence this change, it starts with setting expectations, education, and equipping developers with tools they actually want to use. Hiring a team of developers and expecting them to embrace DevOps practices won't happen without giving them the proper tools and support they need. During this talk we'll discuss the DevOps journey Capital One is on, the challenges we face, and how we're changing behaviors one developer at a time.
+
+**Speaker:**
+
+Roderick Randolph
+
+Roderick is a Lead Software Engineer at Capital One where he leads all things DevOps for the Capital One Canada business including building, automating, and migrating infrastructure to the cloud. He currently lives in Toronto but is originally from a small town in the State of Virginia.

--- a/content/events/2016-toronto/proposals/Waterboy - our robot coworker.md
+++ b/content/events/2016-toronto/proposals/Waterboy - our robot coworker.md
@@ -1,0 +1,29 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Sean Walberg"
+
++++
+
+### Waterboy - our robot coworker
+
+**Abstract:**
+
+Waterboy is our Hubot instance that provides helpful information for both operations and developers. Our organization is somewhat atypical -- we are an external infrastructure consulting practice embedded into a development organization. This talk will cover:
+
++ How we introduced a chatbot into the organization
++ How we manage the robot and encourage people to contribute
++ How we figure out what goes into the robot
++ How we use ChatOps to facilitate communication between ourselves, and between us and the client.
+
+People attending this talk will get a different perspective on the use of chat in a collaborative environment. It's not just shortcuts to memes, nor is it "hubot please go deploy the site and make me coffee". Chat can be a CLI to your organization. One that empowers employees and helps spread knowledge.
+
+**Speaker:**
+
+Sean Walberg, <a href="https://twitter.com/seanwalberg" target="_blank">@seanwalberg</a> 
+
+I'm a problem solver. A software developer that loves applying software principles to infrastructure automation and web applications.
+
+I wanted to program most of my life, realized I didn't like it during my first job, spent 13 years as a network guy that wrote a lot of code, joined an awesome web startup as a web developer, and have rediscovered my joy for software development. After that ended, I moved into a more devops type role where I can have my feet in both camps. I'm currently with a consulting company that's responsible for the infrastructure and applications at a large American sporting league.

--- a/content/events/2016-toronto/proposals/Why We Threw 5 Months of Work in the Trash or How we Failed at adopting DevOps.md
+++ b/content/events/2016-toronto/proposals/Why We Threw 5 Months of Work in the Trash or How we Failed at adopting DevOps.md
@@ -1,0 +1,20 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Sina Jahan"
+
++++
+
+### Why We Threw 5 Months of Work in the Trash; or How we Failed at adopting DevOps
+
+**Abstract:**
+
+Last summer we started an engineering enablement engagement in Seattle. Very quickly we decided DevOps enablement had a lot of potential and started our work...5 months later the "DevOps" part of work was shot down by management due to lack of result. We will take a look at three main reasons that we failed. These are pitfalls that can happen in any company and any project.
+
+**Speaker:**
+
+Sina Jahan
+
+I'm a developer at ThoughtWorks. I tend to focus on work in the cloud and continuous delivery space, more recently focusing on the use of microservice architectures. I love learning new things and helping people build better systems. I love presenting ideas, meeting people and learning new things, and I find conferences a great way to help that. I've also written a few articles along the way.

--- a/content/events/2016-toronto/proposals/Why we should be excited about Azure Stack.md
+++ b/content/events/2016-toronto/proposals/Why we should be excited about Azure Stack.md
@@ -1,0 +1,18 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Max Yermakhanov"
+
++++
+
+### Why we should be excited about Azure Stack
+
+**Abstract:**
+
+With the upcoming release of Microsoft Azure Stack to the public, we'll talk why we should be excited about this new hybrid cloud platform product that enables your organization to deliver Azure services from your own datacenter to help you achieve more. With Azure Stack, you decide where to keep your data and applications—in your own datacenter or with a hosting service provider. Get the power of cloud services, yet maintain control of your datacenter for true hybrid cloud agility. Azure Stack as a single platform and a single set of APIs across your own data center and the cloud greatly simplifies the process of moving workloads between your own data center and Azure (or maybe add some capacity in the cloud as needed.) There is a lot to be excited about...
+
+**Speaker:**
+
+Max Yermakhanov, <a href="https://twitter.com/yermax" target="_blank">@yermax</a>

--- a/content/events/2016-toronto/proposals/dotfiles.CI.md
+++ b/content/events/2016-toronto/proposals/dotfiles.CI.md
@@ -1,0 +1,20 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "Will Weaver"
+
++++
+
+### dotfiles.CI
+
+**Abstract:**
+
+Do you have Continuous Integration, or DevOps on your resume or LinkedIn? Do you have years of maintaining a solid deployment pipeline and nothing to show prospective employers on your Github profile. For many companies seeing is believing. In this talk I'll show you how I built tests and a CI pipeline around my dotfiles for prospective clients.
+
+**Speaker:**
+
+Will Weaver, <a href="https://twitter.com/buildingbananas" target="_blank">@buildingbananas</a>
+
+As a DevOps Consultant and Philosopher, <a href="http://www.buildingbananas.com">Will Weaver</a> helps others learn to love change. Will works with teams to implement and realize the benefits of practices like continuous integration, delivery, and deployment. As an avid practitioner of pair development, he demonstrates and educates others on practices that manage the risk of change.

--- a/content/events/2016-toronto/proposals/keynote.md
+++ b/content/events/2016-toronto/proposals/keynote.md
@@ -1,0 +1,30 @@
++++
+City = "Toronto"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+type = "event"
+title = "John Willis"
+
++++
+
+### Coming Soon
+
+**Abstract:**
+
+Coming soon.
+
+**Speaker:**
+
+John Willis, <a href="https://twitter.com/botchagalupe" target="_blank">@botchagalupe</a> 
+
+John Willis has worked in the IT management industry for more than 35 years.
+
+Currently he is an Evangelist at Docker Inc.
+
+Prior to Docker Willis was the VP of Solutions for Socketplane (sold to Docker) and Enstratius (sold to Dell).
+
+Prior to to Socketplane and Enstratius Willis was the VP of Training & Services at Opscode where he formalized the training, evangelism, and professional services functions at the firm.
+
+Willis also founded Gulf Breeze Software, an award winning IBM business partner, which specializes in deploying Tivoli technology for the enterprise.
+
+Willis has authored six IBM Redbooks for IBM on enterprise systems management and was the founder and chief architect at Chain Bridge Systems.


### PR DESCRIPTION
The new site is now in sync with the live site.