### PR TITLE
Change from twitter search to twitter list widget

### DIFF
--- a/themes/devopsdays-legacy/layouts/partials/twitterfeed.html
+++ b/themes/devopsdays-legacy/layouts/partials/twitterfeed.html
@@ -1,4 +1,4 @@
 <div style="height:340px">
-<a class="twitter-timeline" href="https://twitter.com/search?q=devopsdays+OR+devopsday+OR+%23devopsday+OR+%23devopsdays" data-widget-id="345935942680469504">Tweets about "devopsdays OR devopsday OR #devopsday OR #devopsdays"</a>
+<a class="twitter-timeline" data-chrome="noheader nofooter"  data-tweet-limit=3 data-dnt="true" href="https://twitter.com/devopsdaysmsp/lists/devopsdays" data-widget-id="720829916510466048">Tweets from devopsdays events</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 </div>


### PR DESCRIPTION
This changes from the old, spam-filled search, into a twitter widget based on a whitelisted list of accounts.

This is causing weird overlap with the blue footer, which will need to be resolved.