### PR TITLE
Rework the past and future bottom footers

### DIFF
--- a/themes/devopsdays-legacy/layouts/index.html
+++ b/themes/devopsdays-legacy/layouts/index.html
@@ -11,23 +11,12 @@
      {{ partial "upcoming_headline.html" . }}
      {{ partial "map.html" .}}
   </div>
-  <div class="span-8 last">
-      {{ partial "twitterfeed.html" . }}
-  </div>
 
-  <div style="padding-top:18px;" class="span-18">
-    <h1>Past</h1>
-  </div>
-  <div style="padding-top:18px;" class="span-5 last">
-    <h1>Future</h1>
-  </div>
+    <div class="span-8 last twitter-sidebar">
+        {{ partial "twitterfeed.html" . }}
+    </div>
 
-  <div class="span-18">
     {{ partial "past.html" . }}
-  </div>
-  <div class="span-5 last">
     {{ partial "future.html" . }}
-  </div>
-</div>
 
 {{ partial "footer.html" . }}

--- a/themes/devopsdays-legacy/layouts/partials/footer.html
+++ b/themes/devopsdays-legacy/layouts/partials/footer.html
@@ -1,3 +1,4 @@
+</div>
 {{ partial "footer_scripts" . }}
 
 </body>

--- a/themes/devopsdays-legacy/layouts/partials/future.html
+++ b/themes/devopsdays-legacy/layouts/partials/future.html
@@ -1,23 +1,28 @@
-<div style="height:550px;" id="quicklinks">
-  <table>
-    <tr>
-      <td>
-        <strong>2016</strong><br/>
-        <a href="/events/2016-vancouver/">Vancouver - Apr 15 & 16</a><br/>
-        <a href="/events/2016-london/">London - Apr 19 & 20</a><br/>
-        <a href="/events/2016-denver/">Denver - Apr 21 & 22</a><br/>
-        <a href="/events/2016-atlanta/">Atlanta - Apr</a><br/>
-        <a href="/events/2016-kiel/">Kiel - May 12 & 13</a><br/>
-        <a href="/events/2016-seattle/">Seattle - May 12 & 13</a><br/>
-        <a href="/events/2016-toronto/">Toronto - May 26 & 27</a><br/>
-        <a href="/events/2016-washington-dc/">Washington, DC - Jun 8 & 9</a><br/>
-        <a href="/events/2016-minneapolis/">Minneapolis - Jul 20 & 21</a><br/>
-        <a href="/events/2016-edinburgh/">Edinburgh - Jul</a><br/>
-        <a href="/events/2016-saltlakecity/">Salt Lake City</a><br/>
-        <a href="/events/2016-philadelphia/">Philadelphia</a><br/>
-        <a href="/events/2016-portland/">Portland - Aug 9 & 10</a><br/>
-        <a href="/events/2016-istanbul/">Istanbul</a><br/>
-      </td>
-    </tr>
-  </table>
-</div>
+<div class="span-6 last">
+    <div style=" padding-top:18px;" class="span-5 last">
+        <h1>Future</h1>
+    </div>
+
+    <div class="span-6 last">
+        <div style="height:700px;" id="quicklinks">
+            <table>
+                <tr>
+                    <div style="display:table-cell; vertical-align:top">
+                        <div style="margin:1px;">
+                            <strong>2016</strong> <!--lazy hardcoding! -->
+                            <br/>
+
+                            {{ range $.Site.Data.events }}
+                              {{ if eq .status "current" }}
+                                <a href="/events/{{ .friendly}}">{{ .city }}: {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2" .enddate }}</a>
+                                <br />
+                              {{ end }}
+                            {{ end }}
+                        </div>
+                    </div>
+
+                </tr>
+            </table>
+        </div>
+    </div>
+  </div>

--- a/themes/devopsdays-legacy/layouts/partials/past.html
+++ b/themes/devopsdays-legacy/layouts/partials/past.html
@@ -1,4 +1,3 @@
-<div style="height:550px;" id="quicklinks">
 <!-- The following blocks of comments explains how this list is generated with Hugo.
 If you read this post generation, it will make no sense. see pre generated sources -->
 
@@ -17,21 +16,37 @@ Chomping .year has the nice effect of turning an int into string. -->
   {{ end }}
 {{ end }}
 
-<!-- Now scan through all the years that were marked as active in order to print the headline -->
-{{ range ($.Scratch.GetSortedMapValues "active_years") }}
-<div style="display:table-cell; vertical-align:top">
-  <div style="margin:2px;">
-    <strong>{{ . }}</strong><br/>
+<div class="span-17 ">
+    <div style=" padding-top:18px;" class="span-7 last">
+        <h1>Past </h1>
+    </div>
 
-<!-- Finally, scan throug the scratch with the ID of that year and print all the events sorted by startdate
-Chomping here in order to convert int to string -->
-      {{ range ($.Scratch.GetSortedMapValues (chomp .)) }}
-        {{ $city := (index $.Site.Data.events . "city") }}
-        {{ $friendly := (index $.Site.Data.events . "friendly") }}
-        <a href="/events/{{ $friendly }}/">{{ $city }}</a><br/>
-      {{ end }}
+    <div class="span-17 ">
+        <div style="height:700px;" id="quicklinks">
+            <table>
+                <tr>
+                    <!-- Now scan through all the years that were marked as active in order to print the headline -->
+                    {{ range ($.Scratch.GetSortedMapValues "active_years") }}
+                    <div style="display:table-cell; vertical-align:top">
+                        <div style="margin:1px;">
+                            <strong>{{ . }}</strong>
+                            <br/>
 
+                            <!-- Finally, scan throug the scratch with the ID of that year and print all the events sorted by startdate
+                      Chomping here in order to convert int to string -->
+                            {{ range ($.Scratch.GetSortedMapValues (chomp .)) }}
+                              {{ $city := (index $.Site.Data.events . "city") }}
+                              {{ $year := (index $.Site.Data.events . "year") }}
+                              {{ $friendly := (index $.Site.Data.events . "friendly") }}
+                              <a href="/events/{{ $friendly }}/">{{ $city }} {{ $year }}</a>
+                              <br/>
+                            {{ end }}
+                        </div>
+                    </div>
+                    {{ end }}
+
+                </tr>
+            </table>
+        </div>
+    </div>
   </div>
-</div>
-{{ end }}
-</div>

--- a/themes/devopsdays-legacy/static/css/style.css
+++ b/themes/devopsdays-legacy/static/css/style.css
@@ -77,3 +77,6 @@
 .sponsor-cta {
   clear: both;
 }
+.twitter-sidebar {
+  overflow: hidden;
+}


### PR DESCRIPTION
Please note two bugs this introduces that will need to be fixed later:

1. The "past" footer is still data-driven. This means that we need to migrate the past events to the new format. Or we hard-code them into the template and have to manually move events after they occur. As this entire UX in the footer is being revamped, I think we will do the latter. This is tracked in #146

2. The year "2016" is hard-coded into the headline on the "future.html" partial for now :) This is tracked in #147