### PR TITLE
Fix event header to re-implement offsite links. Fixes #76 (again)

### DIFF
--- a/data/events/2016-chicago.yml
+++ b/data/events/2016-chicago.yml
@@ -18,6 +18,7 @@ nav_elements:
   - name: location
   - name: program
   - name: propose
+    url: http://cfp.devopsdayschi.org
   - name: conduct
   - name: sponsor
 

--- a/themes/devopsdays-legacy/layouts/partials/event_header.html
+++ b/themes/devopsdays-legacy/layouts/partials/event_header.html
@@ -20,8 +20,18 @@
       <!-- Main navigation -->
       <div class="submenu">
         <h3>
-        {{ range $navigation := $e.navigationelements}}
-          <a href="/events/{{ $event_slug }}/{{ $navigation}}">{{ $navigation }}</a>&nbsp;
-        {{ end }}
+          {{ if $e.nav_elements }}
+            {{ range $e.nav_elements }}
+              {{ if .url }}
+                <a href="{{ .url}}">{{ .name }}</a>&nbsp;
+              {{ else }}
+                <a href="/events/{{ $event_slug }}/{{ .name }}">{{ .name }}</a>&nbsp;
+              {{ end }}
+           {{ end }}
+           {{ else }}
+            {{ range $navigation := $e.navigationelements}}
+              <a href="/events/{{ $event_slug }}/{{ $navigation}}">{{ $navigation }}</a>&nbsp;
+            {{ end }}
+           {{ end }}
         </h3>
       </div>


### PR DESCRIPTION
When I refactored out the event_header partial, I didn't bring over the offsite link capability. This commit fixes this. The commit that broke it was dfc9062. This was identified in #76 by @davidasnider.