### PR TITLE
Support adding more info for organizers

### DIFF
--- a/data/events/2016-portland.yml
+++ b/data/events/2016-portland.yml
@@ -19,7 +19,31 @@ nav_elements:
   - name: sponsor
   - name: contact
   - name: conduct
-team: ["Bill Weiss", "Alice Goldfuss", "Alistair Drong", "Daniel Dreier", "Jason Yee", "Joe Nuspi", "Michelle Carroll", "Rich Burroughs", "Spencer Krum"]
+team_members:
+  - name: "Bill Weiss"
+    twitter: "billweiss"
+    employer: "Puppet"
+  - name: "Alice Goldfuss"
+    twitter: "alicegoldfuss"
+    employer: "New Relic"
+  - name: "Alastair Drong"
+  - name: "Daniel Dreier"
+    twitter: "daniel_dreier"
+    employer: "Puppet"
+  - name: "Jason Yee"
+    twitter: "@gitbisect"
+  - name: "Joe Nuspl"
+    twitter: "joenuspl"
+    employer: "Workday"
+  - name: "Michelle Carroll"
+    twitter: "miiiiiche"
+    employer: "Elastic"
+  - name: "Rich Burroughs"
+    twitter: "richburroughs"
+    employer: "Yesmail"
+  - name: "Spencer Krum"
+    twitter: "nibalizer"
+    employer: "IBM"
 organizer_email: "organizers-portland-2016@devopsdays.org" # Put your organizer email address here
 proposal_email: "proposals-portland-2016@devopsdays.org" # Put your proposal email address here
 sponsors: # List all of your sponsors here along with what level of sponsorship they have.

--- a/layouts/shortcodes/list_organizers.html
+++ b/layouts/shortcodes/list_organizers.html
@@ -1,8 +1,24 @@
 {{ $path := split .Page.Source.File.Path "/" }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
+
 <ul>
-  {{ range $event_organizers := $e.team }}
-    <li>{{ $event_organizers }}</li>
+  {{ if $e.team_members }}
+    {{ range $e.team_members }}
+      <li>
+        {{ .name }}
+        {{ if .twitter }}
+          {{ $twitter := replace .twitter "@" "" }}
+          - <a href="http://twitter.com/{{ $twitter }}">@{{ $twitter }}</a>
+        {{ end }}
+        {{ if .employer }}
+          - <em>{{ .employer }}</em>
+        {{ end}}
+      </li>
+    {{ end }}
+  {{ else }}
+    {{ range $event_organizers := $e.team }}
+      <li>{{ $event_organizers }}</li>
+    {{ end }}
   {{ end }}
 </ul>

--- a/yyyy-city.yml
+++ b/yyyy-city.yml
@@ -21,6 +21,12 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: conduct
   - name: sponsor
 team: ["John Doe", "Jane Smith", "Sally Fields"]
+team_members:
+  - name: "John Doe"
+  - name: "Jane Smith"
+    twitter: "devopsdays"
+  - name: "Sally Fields"
+    employer: "Acme Anvil Co."
 organizer_email: "organizers-city-year@devopsdays.org" # Put your organizer email address here
 proposal_email: "proposals-city-year@devopsdays.org" # Put your proposal email address here
 sponsors: # List all of your sponsors here along with what level of sponsorship they have.


### PR DESCRIPTION
- New YAML key for "team_members".
- Supports name (required), twitter (optional, with or without @),
  and employer (optional).
- Maintains compatibility with simpler "team" list method.

See issue #75