### PR TITLE
add borders and force dimensions for logos

### DIFF
--- a/themes/devopsdays-legacy/layouts/partials/event_footer.html
+++ b/themes/devopsdays-legacy/layouts/partials/event_footer.html
@@ -14,7 +14,7 @@
   {{ range where $sponsors "level" .id }}
     {{ $s :=  (index $.Site.Data.sponsors .id) }}
     {{ if isset $.Site.Data.sponsors .id }}
-      <a href = "{{ $s.url }}"><img alt = "{{ .id }}" src = "/img/sponsors/{{ .id }}.png" class="img-responsive company-logo" width = "95px"></a>
+      <a href = "{{ $s.url }}"><img alt = "{{ .id }}" src = "/img/sponsors/{{ .id }}.png" class="img-responsive company-logo" height="100px" width="100px"></a>
     {{ end }}
   {{ end }}
   <div class = "sponsor-cta">

--- a/themes/devopsdays-legacy/static/css/style.css
+++ b/themes/devopsdays-legacy/static/css/style.css
@@ -71,7 +71,9 @@
 
 .company-logo {
   float: left;
-  padding: 5px !important;
+  padding: 2px !important;
+  border: 1px solid #18b;
+  margin: 2px;
 }
 
 .sponsor-cta {


### PR DESCRIPTION
Following up on the discussion in #88 this adds CSS borders and specifies the dimensions for the sponsor logos (legacy theme).

`r?` @mattstratton 