### PR TITLE
Remove year from the past events.

### DIFF
--- a/themes/devopsdays-legacy/layouts/partials/past.html
+++ b/themes/devopsdays-legacy/layouts/partials/past.html
@@ -36,9 +36,8 @@ Chomping .year has the nice effect of turning an int into string. -->
                       Chomping here in order to convert int to string -->
                             {{ range ($.Scratch.GetSortedMapValues (chomp .)) }}
                               {{ $city := (index $.Site.Data.events . "city") }}
-                              {{ $year := (index $.Site.Data.events . "year") }}
                               {{ $friendly := (index $.Site.Data.events . "friendly") }}
-                              <a href="/events/{{ $friendly }}/">{{ $city }} {{ $year }}</a>
+                              <a href="/events/{{ $friendly }}/">{{ $city }}</a>
                               <br/>
                             {{ end }}
                         </div>


### PR DESCRIPTION
The year in the past events looks terrible and makes it wrap a lot. Presumably we could replace it if we need it in a re-design, but for now it would be nice for it to not be cluttering a space we're working in.