### PR TITLE
remove duplicate header

### DIFF
--- a/themes/devopsdays-legacy/layouts/_default/single.html
+++ b/themes/devopsdays-legacy/layouts/_default/single.html
@@ -14,13 +14,6 @@
       {{ partial "twitterfeed.html" . }}
   </div>
 
-  <div style="padding-top:18px;" class="span-18">
-    <h1>Past</h1>
-  </div>
-  <div style="padding-top:18px;" class="span-5 last">
-    <h1>Future</h1>
-  </div>
-
   <div class="span-18">
     {{ partial "past.html" . }}
   </div>


### PR DESCRIPTION
The Past and Future are showing up twice because they are in the past / future partials as well as the _default layout - for #207 