### PR TITLE
fix for stretchy logos

### DIFF
--- a/layouts/shortcodes/event_logo.html
+++ b/layouts/shortcodes/event_logo.html
@@ -2,4 +2,4 @@
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 
-<img alt="DevOpsDays {{ $e.city }} {{ $e.year }}" src="/events/{{ $event_slug }}/logo.png" style="width: 90%; margin:5%;"/>
+<img alt="DevOpsDays {{ $e.city }} {{ $e.year }}" src="/events/{{ $event_slug }}/logo.png" style="max-width: 90%; margin:5%;"/>


### PR DESCRIPTION
Changed the CSS style on the logo from `width: 90%` to `max-width`, so that smaller logos are not upscaled.