### PR TITLE
Revert "Past under construction"

### DIFF
--- a/themes/devopsdays-legacy/layouts/partials/past.html
+++ b/themes/devopsdays-legacy/layouts/partials/past.html
@@ -17,8 +17,8 @@ Chomping .year has the nice effect of turning an int into string. -->
 {{ end }}
 
 <div class="span-17 ">
-    <div style=" padding-top:18px;" class="span-17 last">
-        <h1>Past  - in migration currently</h1>
+    <div style=" padding-top:18px;" class="span-7 last">
+        <h1>Past </h1>
     </div>
 
     <div class="span-17 ">


### PR DESCRIPTION
Reverts devopsdays/devopsdays-web#279

Since the past has been bulk-migrated, although cosmetic issues remain, I don't think we need to say this any longer.