### PR TITLE
Fixes display issue

### DIFF
--- a/content/events/2016-kansascity/welcome.md
+++ b/content/events/2016-kansascity/welcome.md
@@ -1,6 +1,6 @@
 +++
 date = "2016-05-07T09:30:25-05:00"
-title = "devopsdays Kansas City 2016"
+title = "Welcome"
 type = "event"
 aliases = ["/events/2016-kansascity"]
 


### PR DESCRIPTION
Heads up to @barkerd427 - there's an open issue about this (https://github.com/devopsdays/devopsdays-web/issues/259) but for now, you don't want it to look like this (Kansas City twice in one line):

![screen shot 2016-05-10 at 10 12 53 am](https://cloud.githubusercontent.com/assets/2104453/15151712/fe86f346-1697-11e6-9f5c-5f3f90fbb71a.png)
