### PR TITLE
Fix talk page

### DIFF
--- a/content/events/2016-london/program/test-user.md
+++ b/content/events/2016-london/program/test-user.md
@@ -1,0 +1,11 @@
++++
+City = "London"
+Year = "2016"
+date = "2016-03-06T21:28:07-06:00"
+title = "Test User"
+type = "talk"
+
++++
+
+This is a test.
+

--- a/data/speakers/2016/london/test-user.yml
+++ b/data/speakers/2016/london/test-user.yml
@@ -1,0 +1,3 @@
+name: "Test User"
+twitter: "testuser"
+bio: "This is a test."

--- a/themes/devopsdays-legacy/layouts/talk/single.html
+++ b/themes/devopsdays-legacy/layouts/talk/single.html
@@ -17,7 +17,7 @@
    .Site.Data.events $e.year (printf "%s" (lower $e.city))
    - mattstratton
  */}}
- {{ range $fname, $s := index .Site.Data.speakers $e.year (lower $e.city) }}
+ {{ range $fname, $s := index .Site.Data.speakers (chomp $e.year) (lower $e.city) }}
    {{ if eq $fname ($.Title | urlize) }}
      <h2>Speaker</h2>
      <h3>{{ $s.name }}</h3>


### PR DESCRIPTION
There's an issue right now where "past" events need their year set as a non-string, but "current" events need it as a string. This raises hell on the template for a talk. This fixes that.