### PR TITLE
Moving Kiel and Seattle to past

### DIFF
--- a/content/events/2016-kiel/welcome.md
+++ b/content/events/2016-kiel/welcome.md
@@ -12,7 +12,7 @@ aliases = ["/events/2016-kiel"]
 
 <h1>DevOpsDays is coming to Kiel!</h1>
 
-## {{< event_start >}} - {{< event_end >}}
+## Thursday, May 12, 2016 - Friday, May 13, 2016
 
 
 

--- a/data/events/2016-kiel.yml
+++ b/data/events/2016-kiel.yml
@@ -3,7 +3,7 @@ year: 2016
 city: "Kiel"
 friendly: "2016-kiel"
 status: "past"
-startdate: 2016-05-12
+startdate: 2016-05-11
 enddate: 2016-05-13
 coordinates: "54.3233, 10.1228"
 

--- a/data/events/2016-kiel.yml
+++ b/data/events/2016-kiel.yml
@@ -1,8 +1,8 @@
 name: "2016-kiel"
-year: "2016"
+year: 2016
 city: "Kiel"
 friendly: "2016-kiel"
-status: "current"
+status: "past"
 startdate: 2016-05-12
 enddate: 2016-05-13
 coordinates: "54.3233, 10.1228"

--- a/data/events/2016-seattle.yml
+++ b/data/events/2016-seattle.yml
@@ -1,8 +1,8 @@
 name: 2016-seattle # The name of the event. Four digit year with the city name in lower-case, with no spaces.
-year: "2016" # The year of the event. Make sure it is in quotes.
+year: 2016 # The year of the event. Make sure it is in quotes.
 city: "Seattle" # The city name of the event. Capitalize it.
 friendly: "2016-seattle" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "current" # Options are "past" or "current".
+status: "past" # Options are "past" or "current".
 startdate: 2016-05-12
 enddate: 2016-05-13
 cfp_date_start: 2016-02-01


### PR DESCRIPTION
Note for https://github.com/devopsdays/devopsdays-web/issues/33 - right now it's not possible to have two events with the same start date show up in the "past" footer. Only the alphabetically-last one shows up.

I worked around this by changing Kiel's start date to a day earlier. This is terri-bad, but gives the display we want. That commit should be reverted when this is fixed.