### PR TITLE
Moves sponsors to bottom

### DIFF
--- a/content/events/2016-amsterdam/program.md
+++ b/content/events/2016-amsterdam/program.md
@@ -14,116 +14,116 @@ tags = ["amsterdam","amsterdam-2016"]
 
 
 <center><b><h2>Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>30 June - Thursday</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-09:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-09:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
 <a href="/events/2016-amsterdam/program/erica-baker">Erica Baker (Slack) - Diversity in Technology</a> (Opening keynote)
     <br />
 </div>
-<div class="span-2">09:45-10:00</div><div class="span-4 box last">
+<div class="span-2">09:45-10:00</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">10:00-10:30</div><div class="span-4 box last">
+<div class="span-2">10:00-10:30</div><div class="span-8 box last">
 <a href="/events/2016-amsterdam/program/daniel-van-gils">Daniël van Gils (Cloud66) - How the hell do I run my microservices in production, and will it scale?</a>
     <br />
 
 </div>
-<div class="span-2">10:30-10:45</div><div class="span-4 box last">
+<div class="span-2">10:30-10:45</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:45-11:15</div><div class="span-4 box last">
+<div class="span-2">10:45-11:15</div><div class="span-8 box last">
 <a href="/events/2016-amsterdam/program/warner-more">Warner More (CoverMyMeds) - DevOps has Always Been About Security</a>
     <br />
 </div>
 
-<div class="span-2">11:15-11:30</div><div class="span-4 box last">
+<div class="span-2">11:15-11:30</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:30-12:00</div><div class="span-4 box last">
+<div class="span-2">11:30-12:00</div><div class="span-8 box last">
 <a href="/events/2016-amsterdam/program/avishai-ish-shalom">Avishai Ish-Shalom (Fewbytes) - The Mathematics of Reliability</a>
     <br />
 </div>
 
-<div class="span-2">12:00-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">12:00-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:00-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #1</div>
 
-<div class="span-2">14:45-15:00</div><div class="span-4 box last"><strong>Break</strong> <br /> </div>
+<div class="span-2">14:45-15:00</div><div class="span-8 box last"><strong>Break</strong> <br /> </div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #2</div>
 
-<div class="span-2">15:45-16:30</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #3</div>
+<div class="span-2">15:45-16:30</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #3</div>
 
-<div class="span-2">16:30-16:45</div><div class="span-4 box last"><strong></strong>Closing</div>
+<div class="span-2">16:30-16:45</div><div class="span-8 box last"><strong></strong>Closing</div>
 
-<div class="span-2">17:00-18:00</div><div class="span-4 box last"><strong>Sponsor happy hour (Sponsored by Red Hat)</strong><br /></div>
+<div class="span-2">17:00-18:00</div><div class="span-8 box last"><strong>Sponsor happy hour (Sponsored by Red Hat)</strong><br /></div>
 
-<div class="span-2">18:00-20:00</div><div class="span-4 box last"><strong>BBQ & Band (Sponsored by Chef)</strong><br /></div>
+<div class="span-2">18:00-20:00</div><div class="span-8 box last"><strong>BBQ & Band (Sponsored by Chef)</strong><br /></div>
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>1 July - Friday</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
 <a href="/events/2016-amsterdam/program/ken-mugrage">Ken Mugrage (Thoughtworks) - What we’re learning about burnout and how a DevOps culture can help</a>
     <br />
 </div>
-<div class="span-2">09:45-10:00</div><div class="span-4 box last">
+<div class="span-2">09:45-10:00</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">10:00-10:30</div><div class="span-4 box last">
+<div class="span-2">10:00-10:30</div><div class="span-8 box last">
 <a href="/events/2016-amsterdam/program/victoria-jeffrey">Victoria Jeffrey (Chef) - Preparing for the Day After Tomorrow - Test-Driven Infrastructure</a>
     <br />
 
 </div>
-<div class="span-2">10:30-10:45</div><div class="span-4 box last">
+<div class="span-2">10:30-10:45</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:45-11:15</div><div class="span-4 box last">
+<div class="span-2">10:45-11:15</div><div class="span-8 box last">
 <a href="/events/2016-amsterdam/program/jeffrey-snover">Jeffrey Snover (Microsoft) - Rearchitecting Windows Server for DevOps</a>
     <br />
 </div>
 
-<div class="span-2">11:15-11:30</div><div class="span-4 box last">
+<div class="span-2">11:15-11:30</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:30-12:00</div><div class="span-4 box last">
+<div class="span-2">11:30-12:00</div><div class="span-8 box last">
 <a href="/events/2016-amsterdam/program/harim-weites">Harim Weites (Wehkamp) - One engineer, four environments, no termination protection.</a>
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Sponsor Raffle & Open Space Opening</div>
+<div class="span-2">13:00-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Sponsor Raffle & Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #1</div>
 
-<div class="span-2">14:45-15:00</div><div class="span-4 box last"><strong>Break</strong> <br /> </div>
+<div class="span-2">14:45-15:00</div><div class="span-8 box last"><strong>Break</strong> <br /> </div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #2</div>
 
-<div class="span-2">15:45-16:30</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #3</div>
+<div class="span-2">15:45-16:30</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #3</div>
 
-<div class="span-2">16:30-16:45</div><div class="span-4 box last"><strong></strong>Closing</div>
+<div class="span-2">16:30-16:45</div><div class="span-8 box last"><strong></strong>Closing</div>
 
 
 

--- a/content/events/2016-atlanta/program.md
+++ b/content/events/2016-atlanta/program.md
@@ -13,15 +13,15 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Tuesday, April 26th, 2016</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
   <strong>Opening Keynote</strong>
   <br/>
   <a style="text-decoration:none;" href="/events/2016-atlanta/proposals/Putting%20the%20Service%20in%20Microservices/"><strong>Putting the Service in Microservices</strong></a>
@@ -30,33 +30,33 @@ type = "event"
     <br />
 
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <a style="text-decoration:none;" href="/events/2016-atlanta/proposals/Developing%20and%20Operating%20an%20Enterprise%20Application%20as%20a%2012Factor%20App%20using%20Docker%20and%20Amazon%20Web%20Services"><strong>Developing and Operating an Enterprise Application as a 12Factor App using Docker and Amazon Web Services</strong></a>
     <br />
     <em>by</em>  <a href="https://www.linkedin.com/in/bloodysock">Kartik Pandya</a>
     <br/>
     </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-atlanta/proposals/Frameworks%20for%20Feedback"><strong>Frameworks for Feedback</strong></a>
   <br />
   <em>by</em>  <a href="https://twitter.com/rmillerwebster">Rebecca Miller-Webster</a>
   <br/>
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
 
 
-  <div class="span-2">11:20-11:50</div><div class="span-4 box last">
+  <div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <strong>Closing Keynote</strong>
     <br/>
 <a style="text-decoration:none;" href="/events/2016-atlanta/proposals/burnout"><strong>Burnout</strong></a>
@@ -64,9 +64,9 @@ type = "event"
     <em>by</em>  <a href="https://twitter.com/botchagalupe">John Willis</a>
     <br/>
   </div>
-<div class="span-2">11:50-1:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-1:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">1:00-1:30</div><div class="span-4 box last">
+<div class="span-2">1:00-1:30</div><div class="span-8 box last">
 <strong>Ignites</strong>
 <br />
 <br/>
@@ -101,17 +101,17 @@ type = "event"
 <br/>
       </div>
 
-<div class="span-2">1:30-2:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> <a href="/pages/open-space-format">Open Space Opening</a></div>
+<div class="span-2">1:30-2:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> <a href="/pages/open-space-format">Open Space Opening</a></div>
 
-<div class="span-2">2:00-2:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">2:00-2:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">3:00-3:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">3:00-3:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">4:00-4:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">4:00-4:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">4:45-5:00</div><div class="span-4 box last"><strong></strong>Close Day &amp; Logistics</div>
+<div class="span-2">4:45-5:00</div><div class="span-8 box last"><strong></strong>Close Day &amp; Logistics</div>
 
-<div class="span-2">5:15</div><div class="span-4 box last"><strong>Evening Event</strong>
+<div class="span-2">5:15</div><div class="span-8 box last"><strong>Evening Event</strong>
   <br />
   <a href="https://www.pindrop.com/">Pindrop</a> After Party at <a href="http://www.gordonbiersch.com/locations/midtown?action=view">Gordon Biersch</a><br/>
   Food, Drinks, Board Games, &amp; Music by <br/> <a href="http://scottlowsongs.com/">Scott Low &amp; the Southern Bouillon</a>
@@ -122,57 +122,57 @@ type = "event"
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Wednesday, April 27th, 2016</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
 
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-atlanta/proposals/The%20Unrealized%20Role%20of%20Monitoring%20and%20Alerting"><strong>The Unrealized Role of Monitoring &amp; Alerting</strong></a>
   <br />
   <em>by</em>  <a href="https://twitter.com/jasonhand">Jason hand</a>
   <br/>
 </div>
 
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-atlanta/proposals/From%200%20to%20Hero%20CareerBuilder%20DevOps%20Deployment%20Pipeline"><strong>From Zero to Hero: CareerBuilder's DevOps Deployment Pipeline </strong></a>
   <br />
   <em>by</em>  <a href="https://www.linkedin.com/in/jeff-bragdon-8636363">Jeff Bragdon</a> and <a href='https://www.linkedin.com/in/aouzounov' >Anton Ouzounov</a>
   <br/>
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <a style="text-decoration:none;" href="/events/2016-atlanta/proposals/The%20test%20automation%20journey%20a%20labor%20of%20love%20and%20where%20are%20we%20now"><strong>The test automation journey; a labor of love and where are we now?</strong></a>
     <br />
     <em>by</em>  <a href="https://www.linkedin.com/in/webwolf">Lee Blackburn</a>, Chue Her, &amp; <a href="https://www.linkedin.com/in/adrian-kosciak-7977911a">Adrian Kosciak</a>
     <br/>
     </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
   <a href="/events/2016-atlanta/proposals/Dont%20hit%20it%20with%20a%20pretty%20stick%20LeanUX%20Methods%20for%20Agile%20Teams">Don’t hit it with a pretty stick: LeanUX Methods for Agile Teams</a>
   <br />
   <em>by</em>  <a href="https://twitter.com/vcagwin">Virginia Cagwin</a>
   <br/>
   </div>
 
-<div class="span-2">11:50-1:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-1:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">1:00-1:30</div><div class="span-4 box last">
+<div class="span-2">1:00-1:30</div><div class="span-8 box last">
   <strong>Ignites</strong>
   <br />
   <br/>
@@ -207,15 +207,15 @@ type = "event"
 
 </div>
 
-<div class="span-2">1:30-2:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> <a href="/pages/open-space-format">Open Space Opening</a></div>
+<div class="span-2">1:30-2:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> <a href="/pages/open-space-format">Open Space Opening</a></div>
 
-<div class="span-2">2:00-2:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">2:00-2:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">3:00-3:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">3:00-3:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">4:00-4:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">4:00-4:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">5:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">5:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-austin/program.md
+++ b/content/events/2016-austin/program.md
@@ -14,110 +14,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-boise/program.md
+++ b/content/events/2016-boise/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-capetown/program.md
+++ b/content/events/2016-capetown/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-chicago/program.md
+++ b/content/events/2016-chicago/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-dallas/program.md
+++ b/content/events/2016-dallas/program.md
@@ -14,110 +14,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-denver/program.md
+++ b/content/events/2016-denver/program.md
@@ -14,110 +14,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-detroit/program.md
+++ b/content/events/2016-detroit/program.md
@@ -14,110 +14,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-ghent/program.md
+++ b/content/events/2016-ghent/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-istanbul/program.md
+++ b/content/events/2016-istanbul/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:15-09:15</div><div class="span-4 box last">Registration & Breakfast</div>
-<div class="span-2">09:15-9:30</div><div class="span-4 box last"><strong></strong>Opening Bell Ceremony</div>
-<div class="span-2">09:30-10:00</div><div class="span-4 box last">Opening Welcome</div>
-<div class="span-2">10:00-10:45</div><div class="span-4 box last">
+<div class="span-2">08:15-09:15</div><div class="span-8 box last">Registration & Breakfast</div>
+<div class="span-2">09:15-9:30</div><div class="span-8 box last"><strong></strong>Opening Bell Ceremony</div>
+<div class="span-2">09:30-10:00</div><div class="span-8 box last">Opening Welcome</div>
+<div class="span-2">10:00-10:45</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/waxzce">Quentin Adam</a> -
   <a href="/events/2016-istanbul/proposals/the-future-of-infrastructures">It automation & devops, what is the future of infrastructures?</a>
     <br />
 </div>
-<div class="span-2">10:45-11:30</div><div class="span-4 box last">
+<div class="span-2">10:45-11:30</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/waxzce">Iago López Galeiras</a> -
   <a href="/events/2016-istanbul/proposals/rkt-whats-coming-next">rkt, what's coming next</a>
     <br />
 </div>
-<div class="span-2">11:30-11:45</div><div class="span-4 box last">
+<div class="span-2">11:30-11:45</div><div class="span-8 box last">
   Coffee Break
 </div>
-<div class="span-2">11:45-12:30</div><div class="span-4 box last">
+<div class="span-2">11:45-12:30</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/helmoltz">Stefano Rago</a> -
   <a href="/events/2016-istanbul/proposals/a-developers-journey-into-building-automated-tests-for-it-from-the-ground-up">A developer's journey into building automated tests for IT from the ground up</a>
     <br />
 </div>
-<div class="span-2">12:30-13:00</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">12:30-13:00</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:00-14:15</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">13:00-14:15</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
 
-<div class="span-2">14:15-15:00</div><div class="span-4 box last">
+<div class="span-2">14:15-15:00</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/AlainHelaili">Alain Hélaïli</a> -
   <a href="/events/2016-istanbul/proposals/continuous-delivery-at-github-with-hubot">Continuous delivery at GitHub - How do we deploy to production 50 times a day</a>
     <br />
 </div>
 
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
-<div class="span-2">15:45-16:00</div><div class="span-4 box last">
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">15:45-16:00</div><div class="span-8 box last">
   Coffee Break
 </div>
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">16:45-17:30</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">16:45-17:30</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">17:30</div><div class="span-4 box last"><strong></strong>Close Day</div>
+<div class="span-2">17:30</div><div class="span-8 box last"><strong></strong>Close Day</div>
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">09:30-10:00</div><div class="span-4 box last"> Registration & Breakfast</div>
-<div class="span-2">10:00-10:45</div><div class="span-4 box last">
+<div class="span-2">09:30-10:00</div><div class="span-8 box last"> Registration & Breakfast</div>
+<div class="span-2">10:00-10:45</div><div class="span-8 box last">
   Simon Poulton -
   <a href="/events/2016-istanbul/proposals/how-an-organization-can-successfully-adopt-devops-principals">Continuous Delivery & DevOps CoE: How an organization can successfully adopt DevOps principals</a>
     <br />
 </div>
-<div class="span-2">10:45-11:30</div><div class="span-4 box last">
+<div class="span-2">10:45-11:30</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/serhat_dirik">Serhat Dirik</a> -
   <a href="/events/2016-istanbul/proposals/boost-your-devops-adaptation-with-openshift-paas">Boost your DevOps adaptation with OpenShift PaaS</a>
     <br />
 </div>
-<div class="span-2">11:30-11:45</div><div class="span-4 box last">
+<div class="span-2">11:30-11:45</div><div class="span-8 box last">
   Coffee Break
 </div>
 
-<div class="span-2">11:45-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">11:45-11:10</div><div class="span-8 box last" style="height:100px;">
   <a target="_blank" href="https://twitter.com/kayraotaner">Kayra Otaner</a> -
   <a href="/events/2016-istanbul/proposals/utilizing-devops-dynamics-for-security-orchestration-and-situational-awareness">Utilizing DevOps dynamics
 for Security Orchestration and Situational Awareness</a>
     <br />
 </div>
 
-<div class="span-2">12:30-13:00</div><div class="span-4 box last"><strong>Ignites</strong> <br /></div>
+<div class="span-2">12:30-13:00</div><div class="span-8 box last"><strong>Ignites</strong> <br /></div>
 
-<div class="span-2">13:00-14:15</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">13:00-14:15</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">14:15-15:00</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">14:15-15:00</div><div class="span-8 box last" style="height:100px;">
   <a target="_blank" href="https://twitter.com/julsimon">Julien Simon</a> -
   <a href="/events/2016-istanbul/proposals/building-a-serverless-data-pipeline-with-aws">Building a serverless data pipeline with AWS</a>
     <br />
 </div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">15:00-15:45</div><div class="span-8 box last" style="height:100px;">
   <a target="_blank" href="https://twitter.com/chrisvantuin">Chris Van Tuin</a> -
   <a href="/events/2016-istanbul/proposals/a-security-state-of-mind-continuous-security-for-containers-in-devops">A Security State of Mind: Continuous Security for Containers in DevOps</a>
     <br />
 </div>
 
-<div class="span-2">15:45-16:00</div><div class="span-4 box last">
+<div class="span-2">15:45-16:00</div><div class="span-8 box last">
   Coffee Break
 </div>
 
-<div class="span-2">16:00-17:00</div><div class="span-4 box last"><strong>Workshops</strong></div>
+<div class="span-2">16:00-17:00</div><div class="span-8 box last"><strong>Workshops</strong></div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-kansascity/program.md
+++ b/content/events/2016-kansascity/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-kiel/program.md
+++ b/content/events/2016-kiel/program.md
@@ -14,136 +14,136 @@ type = "event"
 <hr />
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Thursday May,12th 2016</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:30</div><div class="span-4 box last"><p><strong>Opening Welcome</strong></p><p>Dr. Ulf Kämpfer, Mayor of the City of Kiel<br>Werner Kässens (KiWi)<br>Dr. Inge Schröder (Wissenschaftszentrum)<br>Moderation:<br> Sabine Bernecker-Bendixen</p></div>
-<div class="span-2">09:30-10:10</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:30</div><div class="span-8 box last"><p><strong>Opening Welcome</strong></p><p>Dr. Ulf Kämpfer, Mayor of the City of Kiel<br>Werner Kässens (KiWi)<br>Dr. Inge Schröder (Wissenschaftszentrum)<br>Moderation:<br> Sabine Bernecker-Bendixen</p></div>
+<div class="span-2">09:30-10:10</div><div class="span-8 box last">
     <p><strong>Oliver Siebenmarck</strong></p><p><a href = "/events/2016-kiel/program/#desc1">From 0 to DevOps - Coping with Continuous Delivery to the Cloud</a></p>
 </div>
-<div class="span-2">10:15-10:55</div><div class="span-4 box last">
+<div class="span-2">10:15-10:55</div><div class="span-8 box last">
   <p><strong>Jan-Joost Bouwman</strong></p><p><a href = "/events/2016-kiel/program/#desc2">ITIL and DevOps can be friends</a></p>
 </div>
-<div class="span-2">10:55-11:20</div><div class="span-4 box last">
+<div class="span-2">10:55-11:20</div><div class="span-8 box last">
     <strong>Coffee Break</strong>
 </div>
-<div class="span-2">11:20-12:00</div><div class="span-4 box last">
+<div class="span-2">11:20-12:00</div><div class="span-8 box last">
   <p><strong>Wayne Ariola</strong></p><p><a href = "/events/2016-kiel/program/#desc3">Continous Testing for DevOps: Evolving Beyond Automation</a></p>
 </div>
 
-<div class="span-2">12:00-13:00</div><div class="span-4 box last">
+<div class="span-2">12:00-13:00</div><div class="span-8 box last">
     <strong>Lunch</strong>
 </div>
 
-<div class="span-2">13:00-13:40</div><div class="span-4 box last">
+<div class="span-2">13:00-13:40</div><div class="span-8 box last">
   <p><strong>Rafael Ördög</strong></p><p><a href = "/events/2016-kiel/program/#desc4">Learning to fall</a></p>
 </div>
 
-<div class="span-2">13:45-14:25</div><div class="span-4 box last">
+<div class="span-2">13:45-14:25</div><div class="span-8 box last">
     <p><strong>Marta Paciorkowska</strong></p><p><a href = "/events/2016-kiel/program/#desc17">DevOps and sharing</a></p>
 </div>
 
-<div class="span-2">14:25-14:35</div><div class="span-4 box last"><strong>Sponsor pitches</strong>
+<div class="span-2">14:25-14:35</div><div class="span-8 box last"><strong>Sponsor pitches</strong>
 </div>
 
-<div class="span-2">14:35-15:00</div><div class="span-4 box last"><strong>Ignites</strong><br />
+<div class="span-2">14:35-15:00</div><div class="span-8 box last"><strong>Ignites</strong><br />
 <a href = "/events/2016-kiel/program/#desc7">Keep it simple, Stupid</a><br />
 <i>Moritz Rogalli</i><br />
 <a href = "/events/2016-kiel/program/#desc14">The (Un)Surprising Truth About DevOps Culture</a><br />
 <i>Manuel Pais</i><br /><br />
 </div>
 
-<div class="span-2">15:00-15:30</div><div class="span-4 box last"><strong>Preparing Open Spaces</strong></div>
+<div class="span-2">15:00-15:30</div><div class="span-8 box last"><strong>Preparing Open Spaces</strong></div>
 
-<div class="span-2">15:30-16:00</div><div class="span-4 box last">
+<div class="span-2">15:30-16:00</div><div class="span-8 box last">
 <strong>Coffee Break</strong>
 </div>
 
-<div class="span-2">16:00-16:30</div><div class="span-4 box last"><strong>Open Space</strong> (3-4 groups) <br /> Open Space #1</div>
+<div class="span-2">16:00-16:30</div><div class="span-8 box last"><strong>Open Space</strong> (3-4 groups) <br /> Open Space #1</div>
 
-<div class="span-2">16:35-17:05</div><div class="span-4 box last"><strong>Open Space</strong> (3-4 groups) <br /> Open Space #2</div>
+<div class="span-2">16:35-17:05</div><div class="span-8 box last"><strong>Open Space</strong> (3-4 groups) <br /> Open Space #2</div>
 
-<div class="span-2">17:10-17:40</div><div class="span-4 box last"><strong>Open Space</strong> (3-4 groups) <br /> Open Space #3</div>
+<div class="span-2">17:10-17:40</div><div class="span-8 box last"><strong>Open Space</strong> (3-4 groups) <br /> Open Space #3</div>
 
-<div class="span-2">17:40-18:30</div><div class="span-4 box last"><strong>Happy Hour</strong></div>
+<div class="span-2">17:40-18:30</div><div class="span-8 box last"><strong>Happy Hour</strong></div>
 
-<div class="span-2">18:30-19:30</div><div class="span-4 box last"><strong>Free time</strong></div>
+<div class="span-2">18:30-19:30</div><div class="span-8 box last"><strong>Free time</strong></div>
 
-<div class="span-2">19:30-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:30-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Friday May,13th 2016</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong>Opening 2nd Day</strong><br>Moderation:<br> Sabine Bernecker-Bendixen</div>
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong>Opening 2nd Day</strong><br>Moderation:<br> Sabine Bernecker-Bendixen</div>
 
-<div class="span-2">09:15-09:55</div><div class="span-4 box last">
+<div class="span-2">09:15-09:55</div><div class="span-8 box last">
     <p><strong>Bianca Heinemann</strong></p><p><a href = "/events/2016-kiel/program/#desc8">The Challenges of Adopting DevOps</a></p>
 </div>
-<div class="span-2">10:00-10:40</div><div class="span-4 box last">
+<div class="span-2">10:00-10:40</div><div class="span-8 box last">
   <p><strong>Baruch Sadogursky</strong></p><p><a href = "/events/2016-kiel/program/#desc9">Docker Container Lifecyle: Problem or Opportunity?</a></p>
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <strong>Coffee Break</strong>
 </div>
 
-<div class="span-2">11:10-11:50</div><div class="span-4 box last">
+<div class="span-2">11:10-11:50</div><div class="span-8 box last">
   <p><strong>Philipp Krenn</strong></p><p><a href = "/events/2016-kiel/program/#desc8">Collect all the things with Beats</a></p>
 </div>
 
-<div class="span-2">11:50-12:00</div><div class="span-4 box last">
+<div class="span-2">11:50-12:00</div><div class="span-8 box last">
   <strong>Sponsor Pitches</strong>
 </div>
 
-<div class="span-2">12:00-13:00</div><div class="span-4 box last">
+<div class="span-2">12:00-13:00</div><div class="span-8 box last">
   <strong>Lunch</strong>
 </div>
 
-<div class="span-2">13:00-13:40</div><div class="span-4 box last">
+<div class="span-2">13:00-13:40</div><div class="span-8 box last">
     <p><strong>Jorge Salamero Sanz</strong></p><p><p><a href = "/events/2016-kiel/program/#desc6">War Games - flight training for DevOps</a></p>
 </div>
 
-<div class="span-2">13:45-14:25</div><div class="span-4 box last">
+<div class="span-2">13:45-14:25</div><div class="span-8 box last">
 <p><strong>Felix Willnecker/André van Hoorn</strong></p><p><a href = "/events/2016-kiel/program/#desc11">Rethinking Performance Engineering in the DevOps World</a></p>
 </div>
 
-<div class="span-2">14:25-15:00</div><div class="span-4 box last">
+<div class="span-2">14:25-15:00</div><div class="span-8 box last">
     <strong>Coffee Break</strong>
 </div>
 
-<div class="span-2">15:00-15:40</div><div class="span-4 box last">
+<div class="span-2">15:00-15:40</div><div class="span-8 box last">
 <p><strong>Bernd Erk</strong></p><p><a href = "/events/2016-kiel/program/#desc12">Working in and with Open Source Communities</a></p>
 </div>
 
-<div class="span-2">15:40-16:10</div><div class="span-4 box last"><strong>Ignites</strong><br /><a href = "/events/2016-kiel/program/#desc14">Scalable & clean build environments with Jenkins and Docker</a><br />
+<div class="span-2">15:40-16:10</div><div class="span-8 box last"><strong>Ignites</strong><br /><a href = "/events/2016-kiel/program/#desc14">Scalable & clean build environments with Jenkins and Docker</a><br />
 <i>Stefan Kahlhöfer</i><br /><br />
 <a href = "/events/2016-kiel/program/#desc18">Praise the "overwrite" - Why boring approaches are awesome!</a><br />
 <i>Florian Sellmayr</i>
 </div>
 
-<div class="span-2">16:10-16:30</div><div class="span-4 box last"><strong>Preparing Open Spaces</strong></div>
+<div class="span-2">16:10-16:30</div><div class="span-8 box last"><strong>Preparing Open Spaces</strong></div>
 
-<div class="span-2">16:35-17:05</div><div class="span-4 box last"><strong>Open Space</strong> (3-4 groups) <br /> Open Space #4</div>
+<div class="span-2">16:35-17:05</div><div class="span-8 box last"><strong>Open Space</strong> (3-4 groups) <br /> Open Space #4</div>
 
-<div class="span-2">17:10-17:45</div><div class="span-4 box last"><strong>Get together with AMA Panel</strong><br /><br />
+<div class="span-2">17:10-17:45</div><div class="span-8 box last"><strong>Get together with AMA Panel</strong><br /><br />
 Moderation:<br />
 Maik Wojcieszak<br />
 Sabine Bernecker-Bendixen
 </div>
 
-<div class="span-2">17:45</div><div class="span-4 box last"><strong>Close Day & Farewell</strong></div>
+<div class="span-2">17:45</div><div class="span-8 box last"><strong>Close Day & Farewell</strong></div>
 
 </div>
 <div style="clear:both"></div>

--- a/content/events/2016-london/program.md
+++ b/content/events/2016-london/program.md
@@ -10,88 +10,88 @@ type = "event"
 
 <h2>The Schedule</h2>
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00</div><div class="span-4 box last"><strong></strong>Welcome<br/>Owen Gardner and Markos Rendell</div>
-<div class="span-2">09:15</div><div class="span-4 box last"><a href="http://bridgetkromhout.com/speaking/2016/devopsdays-london/">Cloudy With a Chance of DevOps </a><br/><a href="https://twitter.com/bridgetkromhout">Bridget Kromhout</a>
+<div class="span-2">08:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00</div><div class="span-8 box last"><strong></strong>Welcome<br/>Owen Gardner and Markos Rendell</div>
+<div class="span-2">09:15</div><div class="span-8 box last"><a href="http://bridgetkromhout.com/speaking/2016/devopsdays-london/">Cloudy With a Chance of DevOps </a><br/><a href="https://twitter.com/bridgetkromhout">Bridget Kromhout</a>
 </div>
-<div class="span-2">09:35</div><div class="span-4 box last">
+<div class="span-2">09:35</div><div class="span-8 box last">
 <a href="/events/2016-london/program/joanne-molesky">We are great at DevOps but the Enterprise is failing</a><br/><a href="https://twitter.com/jemolesky">Joanne Molesky</a>
 </div>
-<div class="span-2">10:15</div><div class="span-4 box last">
+<div class="span-2">10:15</div><div class="span-8 box last">
 <a href="/events/2016-london/program/kris-saxton">Bi-Model IT and other SnakeOil</a><br /><a href="https://twitter.com/KrisSaxton">Kris Saxton</a>
 </div>
-<div class="span-2">10:45</div><div class="span-4 box last">
+<div class="span-2">10:45</div><div class="span-8 box last">
   Break
 </div>
-<div class="span-2">11:10</div><div class="span-4 box last">
+<div class="span-2">11:10</div><div class="span-8 box last">
 <a href="/events/2016-london/program/casey-west/">Minimum Viable Platform</a><br /><a href="https://twitter.com/caseywest">Casey West</a>
 </div>
 
-<div class="span-2">11:50</div><div class="span-4 box last">
+<div class="span-2">11:50</div><div class="span-8 box last">
 <a href="/events/2016-london/program/thiago-almeida">DevOps inside Microsoft engineering: lessons learned</a><br/><a href="https://twitter.com/nzthiago">Thiago Almeida</a>
 </div>
 
-<div class="span-2">12:20</div><div class="span-4 box last">
+<div class="span-2">12:20</div><div class="span-8 box last">
 Ignites<br />
 <a href="/events/2016-london/program/claire-agutter">Claire Agutter</a><br/>
 <a href="/events/2016-london/program/benjamin-wootton">Benjamin Wootton</a><br/>
 <a href="/events/2016-london/program/john-clapham">John Clapham</a><br/>
 </div>
 
-<div class="span-2">12:50</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">12:50</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">14:00</div><div class="span-4 box last">Open Spaces (<a href="https://docs.google.com/spreadsheets/d/14lBKI3OqOkqdu0RgfaQtzTfG6txP18PeI90hsI-kbdA/edit?usp=sharing">Live Schedule</a>)
+<div class="span-2">14:00</div><div class="span-8 box last">Open Spaces (<a href="https://docs.google.com/spreadsheets/d/14lBKI3OqOkqdu0RgfaQtzTfG6txP18PeI90hsI-kbdA/edit?usp=sharing">Live Schedule</a>)
   <br />
 </div>
 
-<div class="span-2">16:30</div><div class="span-4 box last">
+<div class="span-2">16:30</div><div class="span-8 box last">
 <a href="/events/2016-london/program/justin-cormack">Let's talk about Security</a><br /><a href="https://twitter.com/justincormack">Justin Cormack</a></div>
 
-<div class="span-2">17:00</div><div class="span-4 box last">Closing<br /></div>
+<div class="span-2">17:00</div><div class="span-8 box last">Closing<br /></div>
 
-<div class="span-2">17:20</div><div class="span-4 box last">Drinks Reception<br /></div>
+<div class="span-2">17:20</div><div class="span-8 box last">Drinks Reception<br /></div>
 
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00</div><div class="span-4 box last"><strong></strong>Welcome<br/>Owen Gardner and Markos Rendell</div>
-<div class="span-2">09:15</div><div class="span-4 box last"><a href="https://github.com/kramos/devopsdays-webby/blob/master/site/content/events/2016-london/program/slides/KrisBuytaertDOD2016.odp">Reflecting on 6.5 years of #devopsdays</a><br/><a href="https://twitter.com/KrisBuytaert">Kris Buytaert</a>
+<div class="span-2">08:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00</div><div class="span-8 box last"><strong></strong>Welcome<br/>Owen Gardner and Markos Rendell</div>
+<div class="span-2">09:15</div><div class="span-8 box last"><a href="https://github.com/kramos/devopsdays-webby/blob/master/site/content/events/2016-london/program/slides/KrisBuytaertDOD2016.odp">Reflecting on 6.5 years of #devopsdays</a><br/><a href="https://twitter.com/KrisBuytaert">Kris Buytaert</a>
     <br />
 </div>
-<div class="span-2">09:35</div><div class="span-4 box last">
+<div class="span-2">09:35</div><div class="span-8 box last">
 <a href="/events/2016-london/program/gene-kim">The impact on DevOps becoming mainstream</a><br/><a href="https://twitter.com/RealGeneKim">Gene Kim</a>
 </div>
-<div class="span-2">10:15</div><div class="span-4 box last">
+<div class="span-2">10:15</div><div class="span-8 box last">
 <a href="https://vimeo.com/165184758">Panel</a><br /><br/><br/>
 </div>
-<div class="span-2">10:45</div><div class="span-4 box last">
+<div class="span-2">10:45</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">11:10</div><div class="span-4 box last" >
+<div class="span-2">11:10</div><div class="span-8 box last" >
 <a href="/events/2016-london/program/gareth-rushgrove">Rate of Change, (Un)opinionated Platforms and Devops Coevolution</a><br /><a href="https://twitter.com/garethr">Gareth Rushgrove</a>
 </div>
 
-<div class="span-2">11:50</div><div class="span-4 box last">
+<div class="span-2">11:50</div><div class="span-8 box last">
 <a href="/events/2016-london/program/jeromy-carriere">Enterprise Ops Rising</a><br/><a href="https://twitter.com/sjcarriere">Jeromy Carriere</a>
 </div>
 
-<div class="span-2">12:20</div><div class="span-4 box last">
+<div class="span-2">12:20</div><div class="span-8 box last">
 Ignites <br />
 <a href="/events/2016-london/program/philippe-guenet">Philippe Guenet</a><br/>
 <a href="/events/2016-london/program/andi-mann">Andi Mann</a><br/>
@@ -99,15 +99,15 @@ Ignites <br />
 <a href="/events/2016-london/program/simon-vans-colina">Simon Vans Colina</a><br/>
 </div>
 
-<div class="span-2">12:50</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">12:50</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">14:00</div><div class="span-4 box last">Open Spaces <br />
+<div class="span-2">14:00</div><div class="span-8 box last">Open Spaces <br />
 
 </div>
 
-<div class="span-2">16:30</div><div class="span-4 box last">Closing <br /> </div>
+<div class="span-2">16:30</div><div class="span-8 box last">Closing <br /> </div>
 
-<div class="span-2">17:00</div><div class="span-4 box last">End</div>
+<div class="span-2">17:00</div><div class="span-8 box last">End</div>
 
 </div>
 

--- a/content/events/2016-losangeles-1day/program.md
+++ b/content/events/2016-losangeles-1day/program.md
@@ -12,22 +12,22 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">10:00-10:45</div><div class="span-4 box last">Make DevOps Great Again - Andrew Clay Shafer</div>
-<div class="span-2">10:45-11:15</div><div class="span-4 box last">Getting Started with TDI - Carlos Meza</div>
-<div class="span-2">11:15-11:45</div><div class="span-4 box last">Haute Performance: Cracking the Flash Sale - Joel Salas</div>
-<div class="span-2">11:45-12:15</div><div class="span-4 box last">Open Source tools for distributed systems administration - Elizabeth K. Joseph</div>
-<div class="span-2">12:15-13:45</div><div class="span-4 box last">Lunch Break</div>
-<div class="span-2">13:45-14:15</div><div class="span-4 box last">Config Management Sucks - Justin Garrison</div>
-<div class="span-2">14:15-15:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
-<div class="span-2">15:00-16:30</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
-<div class="span-2">15:30-16:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
-<div class="span-2">16:00-16:30</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
-<div class="span-2">16:30-17:00</div><div class="span-4 box last"><strong></strong>Closing Circle</div>
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Expo Hall Reception</strong><br /></div>
+<div class="span-2">10:00-10:45</div><div class="span-8 box last">Make DevOps Great Again - Andrew Clay Shafer</div>
+<div class="span-2">10:45-11:15</div><div class="span-8 box last">Getting Started with TDI - Carlos Meza</div>
+<div class="span-2">11:15-11:45</div><div class="span-8 box last">Haute Performance: Cracking the Flash Sale - Joel Salas</div>
+<div class="span-2">11:45-12:15</div><div class="span-8 box last">Open Source tools for distributed systems administration - Elizabeth K. Joseph</div>
+<div class="span-2">12:15-13:45</div><div class="span-8 box last">Lunch Break</div>
+<div class="span-2">13:45-14:15</div><div class="span-8 box last">Config Management Sucks - Justin Garrison</div>
+<div class="span-2">14:15-15:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">15:00-16:30</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">15:30-16:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">16:00-16:30</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:30-17:00</div><div class="span-8 box last"><strong></strong>Closing Circle</div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Expo Hall Reception</strong><br /></div>
 </div>

--- a/content/events/2016-madison/program.md
+++ b/content/events/2016-madison/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-minneapolis/program.md
+++ b/content/events/2016-minneapolis/program.md
@@ -8,122 +8,122 @@ type = "event"
 +++
 
 <hr>
-<div class="span-14 last ">With talks in the morning and attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions in the afternoon, we have two full days of content! </div>
+<div class="span-22 last ">With talks in the morning and attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions in the afternoon, we have two full days of content! </div>
 </center>
 <hr />
 
 
 <center><b><h2>Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Wednesday July 20</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
 <a href="/events/2016-minneapolis/program/nicole-forsgren">Nicole Forsgren (Chef) - The Data on DevOps: Making the Case for Awesome</a> (Opening keynote)
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
 <a href="/events/2016-minneapolis/program/megan-carney">Megan Carney (Yelp) - How Security Can Win Friends and Influence People</a>
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
 <a href="/events/2016-minneapolis/program/jamie-riedesel">Jamie Riedesel (HelloSign) - Intentional Design of Your Monitoring System</a>
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
 <a href="/events/2016-minneapolis/program/jeff-smith">Jeff Smith (GrubHub) - DevOps: What’s Buried in the Fine Print</a>
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:00-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #1</div>
 
-<div class="span-2">14:45-15:00</div><div class="span-4 box last"><strong>Break</strong> <br /> </div>
+<div class="span-2">14:45-15:00</div><div class="span-8 box last"><strong>Break</strong> <br /> </div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #2</div>
 
-<div class="span-2">15:45-16:30</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #3</div>
+<div class="span-2">15:45-16:30</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #3</div>
 
-<div class="span-2">16:30-16:45</div><div class="span-4 box last"><strong></strong>Closing</div>
+<div class="span-2">16:30-16:45</div><div class="span-8 box last"><strong></strong>Closing</div>
 
-<div class="span-2">17:00-18:00</div><div class="span-4 box last"><strong>Sponsor happy hour</strong><br /></div>
+<div class="span-2">17:00-18:00</div><div class="span-8 box last"><strong>Sponsor happy hour</strong><br /></div>
 
-<div class="span-2">18:00-20:00</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">18:00-20:00</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Thursday July 21</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
 <a href="/events/2016-minneapolis/program/ben-zvan">Ben Zvan (Capella) - What if You Can’t Tear Down All The Silos?</a>
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
 <a href="/events/2016-minneapolis/program/sarah-goff-dupont">Sarah Goff-Dupont (Atlassian) - Marketing: your unexpected devops allies</a>
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
 <a href="/events/2016-minneapolis/program/allan-espinosa">Allan Espinosa (Engineyard) - Autoscaling Containers... with Math</a>
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
 <a href="/events/2016-minneapolis/program/charity-majors">Charity Majors (Hound) - Making good choices with software (and other impossible things)</a> (Closing keynote)
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Sponsor Raffle & Open Space Opening</div>
+<div class="span-2">13:00-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Sponsor Raffle & Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #1</div>
 
-<div class="span-2">14:45-15:00</div><div class="span-4 box last"><strong>Break</strong> <br /> </div>
+<div class="span-2">14:45-15:00</div><div class="span-8 box last"><strong>Break</strong> <br /> </div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #2</div>
 
-<div class="span-2">15:45-16:30</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #3</div>
+<div class="span-2">15:45-16:30</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> Open Space #3</div>
 
-<div class="span-2">16:30-16:45</div><div class="span-4 box last"><strong></strong>Closing</div>
+<div class="span-2">16:30-16:45</div><div class="span-8 box last"><strong></strong>Closing</div>
 
 
 

--- a/content/events/2016-newyork/program.md
+++ b/content/events/2016-newyork/program.md
@@ -16,110 +16,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-newzealand/program.md
+++ b/content/events/2016-newzealand/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-ohio/program.md
+++ b/content/events/2016-ohio/program.md
@@ -15,110 +15,110 @@ draft = true
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-oslo/program.md
+++ b/content/events/2016-oslo/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-oslo/welcome.md
+++ b/content/events/2016-oslo/welcome.md
@@ -69,4 +69,19 @@ aliases = ["/events/2016-oslo"]
 <a class="twitter-timeline" href="https://twitter.com/search?q=devopsdaysoslo+OR+devopsdayoslo+OR+%23devopsdayoslo+OR+%23devopsdaysoslo" data-widget-id="710501757596651520">Tweets about DevOpsDays Oslo</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 </div>
+
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
 <hr>

--- a/content/events/2016-philadelphia/program.md
+++ b/content/events/2016-philadelphia/program.md
@@ -14,110 +14,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-portland/program.md
+++ b/content/events/2016-portland/program.md
@@ -14,110 +14,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-raleigh/program.md
+++ b/content/events/2016-raleigh/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-saltlakecity/program.md
+++ b/content/events/2016-saltlakecity/program.md
@@ -14,110 +14,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-seattle/program.md
+++ b/content/events/2016-seattle/program.md
@@ -11,50 +11,50 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/nicolefv">Nicole Forsgren</a> -
   <a href="/events/2016-seattle/proposals/My_First_Year_at_Chef_Measuring_All_the_Things">My First Year at Chef: Measuring All the Things</a>
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/jemolesky">Joanne Molesky</a> -
   <a href="/events/2016-seattle/proposals/An_unlikely_happy_couple_DevOps_and_IT_Audit">An unlikely happy couple - DevOps and IT Audit?</a>
     <br />
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/paulycomtois">Pauly Comtois</a> -
   <a href="/events/2016-seattle/proposals/Building_an_Enterprise_DevOps_Community">Building an Enterprise DevOps Community</a>
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/benr">Ben Rockwood</a> -
   <a href="/events/2016-seattle/proposals/The_Power_of_A3_Thinking_in_Action">The Power of A3 Thinking in Action</a>
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
   <a href="https://twitter.com/cote">Michael Coté</a> - <a href="/events/2016-seattle/proposals/How_to_survive_and_thrive_in_a_big_company">How to survive and thrive in a big company</a>
   <br /><br />
   <a href="https://twitter.com/EverydayKanban">Julia Wester</a> - <a href="/events/2016-seattle/proposals/Combat_Chaos_Driven_Delivery_by_thinking_like_an_OS">Combat Chaos-Driven Delivery by thinking like an OS</a>
@@ -64,65 +64,65 @@ type = "event"
   <a href="https://twitter.com/jjasghar">JJ Asghar</a> - <a href="/events/2016-seattle/proposals/Being_an_introvert_at_a_conference_is_not_as_hellish_as_you_think">Being an introvert at a conference is not as hellish as you think</a>
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space Opening</strong> <br /> Introduction and session nominations</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space Opening</strong> <br /> Introduction and session nominations</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>DevOpsDays Seattle Opening Day Party @ Moz <br /> <a target='_blank' href="http://www.meetup.com/Chef-Meetup/events/229825263/?rv=ea1">RSVP Here</a></strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>DevOpsDays Seattle Opening Day Party @ Moz <br /> <a target='_blank' href="http://www.meetup.com/Chef-Meetup/events/229825263/?rv=ea1">RSVP Here</a></strong><br /></div>
 
 
 </div>
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/ladyhock">Courtney Kissler</a> -
   <a href="/events/2016-seattle/proposals/Living_in_a_Hybrid_World">Living in a Hybrid World</a>
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/jasonhand">Jason Hand</a> -
   <a href="/events/2016-seattle/proposals/Understanding_Cognitive_Bias_Found_In_Judgement_and_Choice">Understanding Cognitive Bias Found In Judgement & Choice</a>
     <br />
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
   <a target="_blank" href="https://twitter.com/brendandburns">Brendan Burns</a> -
   <a href="/events/2016-seattle/proposals/How_Container_Clusters_like_Kubernetes_change_operations">How Container Clusters, like Kubernetes, change operations</a>
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
   <a target="_blank" href="https://twitter.com/bignimble">Michael Kauffman</a> -
   <a href="/events/2016-seattle/proposals/Past_The_Hype_A_Better_Way_To_Think_About_Big_Data">Past The Hype: A Better Way To Think About Big Data</a>
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
   <a href="https://twitter.com/chadeb">Chad Buffett</a> - <a href="/events/2016-seattle/proposals/DevOps_at_Expedia_Local_Expert">DevOps at Expedia Local Expert</a>
   <br /><br />
   <a href="https://twitter.com/dominicad">Dominica DeGrandis</a> - <a href="/events/2016-seattle/proposals/Why_Weekends_Matter">Why Weekends Matter</a>
@@ -132,15 +132,15 @@ type = "event"
   <a href="https://twitter.com/OguzPastirmaci">Oguz Pastirmaci</a> - <a href="/events/2016-seattle/proposals/Moving_from_SysAdmin_to_DevOps">Everything you always wanted to know about moving from a regular sysadmin role to a DevOps role (but were afraid to ask)</a>
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space Opening</strong> <br /> Introduction and session nominations</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space Opening</strong> <br /> Introduction and session nominations</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout discussions</strong> <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 </div>

--- a/content/events/2016-siliconvalley/program.md
+++ b/content/events/2016-siliconvalley/program.md
@@ -10,4 +10,4 @@ type = "event"
 
 
 <center><b><h2>The Schedule (TBD)</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">

--- a/content/events/2016-singapore/program.md
+++ b/content/events/2016-singapore/program.md
@@ -14,110 +14,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-toronto/program.md
+++ b/content/events/2016-toronto/program.md
@@ -23,38 +23,38 @@ type = "event"
 <hr />
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1 - Thursday, May 26th</h4>
 </div>
 
-<div class="span-2">09:00-10:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-10:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
 
-<div class="span-2">10:00-10:15</div><div class="span-4 box last">Opening Welcome</div>
+<div class="span-2">10:00-10:15</div><div class="span-8 box last">Opening Welcome</div>
 
-<div class="span-2">10:15-10:45</div><div class="span-4 box last">
+<div class="span-2">10:15-10:45</div><div class="span-8 box last">
     <a href="/events/2016-toronto/proposals/keynote/">Devops Enterprise State of the Union</a><br />
     <em>John Willis</em>, <a href="https://twitter.com/botchagalupe" target="_blank">@botchagalupe</a>
     Keynote<br />
 </div>
 
-<div class="span-2">10:50-11:20</div><div class="span-4 box last">
+<div class="span-2">10:50-11:20</div><div class="span-8 box last">
     <a href="/events/2016-toronto/proposals/How%20Brazil's%20government%20kept%20us%20up%20at%20night/">How Brazil's government kept us up at night</a><br />
     <em>Hany Fahim</em>, <a href="https://twitter.com/iHandroid" target="_blank">@iHandroid</a><br />
     <br />
 </div>
 
-<div class="span-2">11:20-11:30</div><div class="span-4 box last">Break</div>
+<div class="span-2">11:20-11:30</div><div class="span-8 box last">Break</div>
 
-<div class="span-2">11:30-12:00</div><div class="span-4 box last">
+<div class="span-2">11:30-12:00</div><div class="span-8 box last">
     <a href="/events/2016-toronto/proposals/From%20Commit%20To%20Production%20And%20Beyond%20-%20The%20Continuous%20Delivery%20Pipeline/">From Commit To Production And Beyond - The Continuous Delivery Pipeline</a><br />
     <em>Arthur Maltson</em>, <a href="https://twitter.com/amaltson" target="_blank">@amaltson</a>
 </div>
 
-<div class="span-2">12:00-13:00</div><div class="span-4 box last">Lunch</div>
+<div class="span-2">12:00-13:00</div><div class="span-8 box last">Lunch</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last">
+<div class="span-2">13:00-13:30</div><div class="span-8 box last">
     Ignites<br />
     <a href="/events/2016-toronto/proposals/Being%20an%20introvert%20and%20at%20a%20conference%20not%20as%20hellish%20as%20you%20think%20it%20is/">Being an introvert and at a conference, not as hellish as you think it is</a><br />
     <em>JJ Asghar</em>, <a href="https://twitter.com/jjasghar" target="_blank">@jjasghar</a><br /><br />
@@ -69,52 +69,52 @@ type = "event"
     <em>Jason Shaw</em>, <a href="https://twitter.com/jasonious" target="_blank">@jasonious</a>
 </div>
 
-<div class="span-2">13:35-14:05</div><div class="span-4 box last">
+<div class="span-2">13:35-14:05</div><div class="span-8 box last">
     <a href="/events/2016-toronto/proposals/Containers%20will%20not%20fix%20your%20broken%20culture%20(and%20other%20hard%20truths)/">Containers will not fix your broken culture (and other hard truths)</a><br />
     <em>Bridget Kromhout</em>, <a href="https://twitter.com/bridgetkromhout" target="_blank">@bridgetkromhout</a>
 </div>
 
 
-<div class="span-2">14:05-14:40</div><div class="span-4 box last"><strong><a href="/pages/open-space-format">Open Space Opening</a></strong></div>
+<div class="span-2">14:05-14:40</div><div class="span-8 box last"><strong><a href="/pages/open-space-format">Open Space Opening</a></strong></div>
 
-<div class="span-2">14:40-15:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #1</div>
+<div class="span-2">14:40-15:25</div><div class="span-8 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #1</div>
 
-<div class="span-2">15:25-15:40</div><div class="span-4 box last">Break</div>
+<div class="span-2">15:25-15:40</div><div class="span-8 box last">Break</div>
 
-<div class="span-2">15:40-16:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #2</div>
+<div class="span-2">15:40-16:25</div><div class="span-8 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #2</div>
 
-<div class="span-2">16:25-16:40</div><div class="span-4 box last">Break</div>
+<div class="span-2">16:25-16:40</div><div class="span-8 box last">Break</div>
 
-<div class="span-2">16:40-17:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #3</div>
+<div class="span-2">16:40-17:25</div><div class="span-8 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #3</div>
 
-<div class="span-2">17:45-20:30</div><div class="span-4 box last"><strong>Happy Hour - details to come</strong></div>
+<div class="span-2">17:45-20:30</div><div class="span-8 box last"><strong>Happy Hour - details to come</strong></div>
 
 
 </div>
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2 - Friday, May 27th</h4>
 </div>
 
-<div class="span-2">09:00-10:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-10:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
 
-<div class="span-2">10:00-10:15</div><div class="span-4 box last">Opening Welcome</div>
+<div class="span-2">10:00-10:15</div><div class="span-8 box last">Opening Welcome</div>
 
-<div class="span-2">10:15-10:45</div><div class="span-4 box last">
+<div class="span-2">10:15-10:45</div><div class="span-8 box last">
     <a href="/events/2016-toronto/proposals/Scaling%20out%20Continuous%20Delivery/">Scaling out Continuous Delivery</a><br />
     <em>John Arthorne</em>, <a href="https://twitter.com/jarthorne" target="_blank">@jarthorne</a>
 </div>
 
-<div class="span-2">10:50-11:20</div><div class="span-4 box last">
+<div class="span-2">10:50-11:20</div><div class="span-8 box last">
     <a href="/events/2016-toronto/proposals/Why%20We%20Threw%205%20Months%20of%20Work%20in%20the%20Trash%20or%20How%20we%20Failed%20at%20adopting%20DevOps/">Why We Threw 5 Months of Work in the Trash; or How we Failed at adopting DevOps</a><br />
     <em>Sina Jahan</em>
 </div>
 
-<div class="span-2">11:20-11:30</div><div class="span-4 box last">Break</div>
+<div class="span-2">11:20-11:30</div><div class="span-8 box last">Break</div>
 
-<div class="span-2">11:30-12:00</div><div class="span-4 box last">
+<div class="span-2">11:30-12:00</div><div class="span-8 box last">
     <a href="/events/2016-toronto/proposals/Agile%20databases/">Agile databases</a><br />
     <em>Jeff Zohrab</em><br />
     <br />
@@ -124,9 +124,9 @@ type = "event"
     <br />
 </div>
 
-<div class="span-2">12:00-13:00</div><div class="span-4 box last">Lunch</div>
+<div class="span-2">12:00-13:00</div><div class="span-8 box last">Lunch</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last">
+<div class="span-2">13:00-13:30</div><div class="span-8 box last">
     Ignites<br />
 
     <a href="/events/2016-toronto/proposals/Supporting%20Developers%20Through%20DevOps/">Supporting Developers Through DevOps</a><br />
@@ -146,23 +146,23 @@ type = "event"
     <br />
 </div>
 
-<div class="span-2">13:35-14:05</div><div class="span-4 box last">
+<div class="span-2">13:35-14:05</div><div class="span-8 box last">
     <a href="/events/2016-toronto/proposals/Waterboy%20-%20our%20robot%20coworker/">Waterboy - our robot coworker</a><br />
     <em>Sean Walberg</em>, <a href="https://twitter.com/seanwalberg" target="_blank">@seanwalberg</a>
 </div>
 
-<div class="span-2">14:05-14:40</div><div class="span-4 box last"><strong><a href="/pages/open-space-format">Open Space Opening</a></strong></div>
+<div class="span-2">14:05-14:40</div><div class="span-8 box last"><strong><a href="/pages/open-space-format">Open Space Opening</a></strong></div>
 
-<div class="span-2">14:40-15:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #1</div>
+<div class="span-2">14:40-15:25</div><div class="span-8 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #1</div>
 
-<div class="span-2">15:25-15:40</div><div class="span-4 box last">Break</div>
+<div class="span-2">15:25-15:40</div><div class="span-8 box last">Break</div>
 
-<div class="span-2">15:40-16:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #2</div>
+<div class="span-2">15:40-16:25</div><div class="span-8 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #2</div>
 
-<div class="span-2">16:25-16:40</div><div class="span-4 box last">Break</div>
+<div class="span-2">16:25-16:40</div><div class="span-8 box last">Break</div>
 
-<div class="span-2">16:40-17:25</div><div class="span-4 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #3</div>
+<div class="span-2">16:40-17:25</div><div class="span-8 box last"><strong>Attendee-suggested breakout discussions</strong><br /> Open Space #3</div>
 
-<div class="span-2">17:30-17:45</div><div class="span-4 box last"><strong>Closing Day & Farewell</strong></div>
+<div class="span-2">17:30-17:45</div><div class="span-8 box last"><strong>Closing Day & Farewell</strong></div>
 
 </div>

--- a/content/events/2016-vancouver/program.md
+++ b/content/events/2016-vancouver/program.md
@@ -15,15 +15,15 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/Capacity_Planning_at_Demonware/"><strong>Capacity Planning at Demonware</strong></a>
   <br />
   Dmytro Dyachuk
@@ -35,21 +35,21 @@ type = "event"
   Capacity Planning engineer, Demonware
   <br />
 </div>
-<div class="span-2">09:45-10:15</div><div class="span-4 box last">
+<div class="span-2">09:45-10:15</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/What_do_the_recent_CVEs_tell_us_about_Container_Security_compliance/"><strong>What do the recent CVEs tell us about Container Security compliance?</strong></a>
   <br />
   Diógenes Rettori, <a href='https://twitter.com/@rettori'>@rettori</a>
   <br />
   Product Manager, Redhat OpenShift
 </div>
-<div class="span-2">10:15-10:20</div><div class="span-4 box last">
+<div class="span-2">10:15-10:20</div><div class="span-8 box last">
   Message from Gold Sponsors
 </div>
-<div class="span-2">10:20-10:30</div><div class="span-4 box last">
+<div class="span-2">10:20-10:30</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:30-11:00</div><div class="span-4 box last">
+<div class="span-2">10:30-11:00</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/Empathy_is_a_Core_Engineering_Skill/"><strong>Empathy is a core engineering skill</strong></a>
   <br />
   Matthew Smillie
@@ -57,13 +57,13 @@ type = "event"
   Software Engineer, Joyent
 </div>
 
-<div class="span-2">11:00-11:30</div><div class="span-4 box last">
+<div class="span-2">11:00-11:30</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/Gender_in_organizations_From_fixing_the_women_to_liberating_the_men/"><strong>Gender in organizations: From fixing the women to liberating the men</strong></a>
   <br />
   Dr. Jennifer Berdahl
 </div>
 
-<div class="span-2">11:30-12:00</div><div class="span-4 box last"><strong>Ignites</strong> <br /><br />
+<div class="span-2">11:30-12:00</div><div class="span-8 box last"><strong>Ignites</strong> <br /><br />
   <ol>
     <li><a href="/events/2016-vancouver/proposals/Data_Pipelines_for_the_Lazy/">Data Pipelines for the Lazy</a> - Kyle Young, <a href='https://twitter.com/@ksgyoung'>@ksgyoung</a><br />Systems Engineer, Mobify</li>
     <li><a href="/events/2016-vancouver/proposals/Improve_the_impact_of_DevOps–driven_application_delivery_with_machine_data_insights/">Improve the impact of DevOps–driven application delivery with machine data insights</a> - Stela Udovicic, <a href='https://twitter.com/@stela_udo'>@stela_udo</a><br />Senior Product Marketing Manager, Splunk</li>
@@ -74,54 +74,54 @@ type = "event"
   </ol>
 </div>
 
-<div class="span-2">12:00-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">12:00-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-14:15</div><div class="span-4 box last">Open Space Opening</div>
+<div class="span-2">13:00-14:15</div><div class="span-8 box last">Open Space Opening</div>
 
-<div class="span-2">14:15-15:15</div><div class="span-4 box last">Open Space #1</div>
+<div class="span-2">14:15-15:15</div><div class="span-8 box last">Open Space #1</div>
 
-<div class="span-2">15:15-16:15</div><div class="span-4 box last">Open Space #2</div>
+<div class="span-2">15:15-16:15</div><div class="span-8 box last">Open Space #2</div>
 
-<div class="span-2">16:15-17:15</div><div class="span-4 box last">Open Space #3</div>
+<div class="span-2">16:15-17:15</div><div class="span-8 box last">Open Space #3</div>
 
-<div class="span-2">17:15-17:45</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">17:15-17:45</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">18:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">18:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/Scaling_out_Continuous_Delivery/"><strong>Scaling out Continuous Delivery</strong></a>
   <br />
   John Arthorne
   <br />
   Production Engineering, Shopify
 </div>
-<div class="span-2">09:45-10:15</div><div class="span-4 box last">
+<div class="span-2">09:45-10:15</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/The_Cognitive_Neuroscience_of_Empathy_Youre_a_DevOps_Natural/"><strong>The Cognitive Neuroscience of Empathy: You’re a DevOps Natural</strong></a>
   <br />
   Dave Mangot, <a href='https://twitter.com/@davemangot'>@davemangot</a>
   <br />
   Director of Operations, Papertrail and Librato
 </div>
-<div class="span-2">10:15-10:20</div><div class="span-4 box last">
+<div class="span-2">10:15-10:20</div><div class="span-8 box last">
   Message from Gold Sponsors
 </div>
-<div class="span-2">10:20-10:30</div><div class="span-4 box last">
+<div class="span-2">10:20-10:30</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:30-11:00</div><div class="span-4 box last">
+<div class="span-2">10:30-11:00</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/System_Testing_with_pytest_and_docker_py/"><strong>System Testing with pytest and docker-py</strong></a>
   <br />
   Christie Wilson, <a href='https://twitter.com/@bobcatwilson'>@bobcatwilson</a>
@@ -133,7 +133,7 @@ type = "event"
   Software Engineer at Demonware
 </div>
 
-<div class="span-2">11:00-11:30</div><div class="span-4 box last">
+<div class="span-2">11:00-11:30</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/Improved_Resilience_by_Testing_in_Production/"><strong>Improved Resilience by Testing in Production</strong></a>
   <br />
   Kenneth Rose, <a href='https://twitter.com/@klprose'>@klprose</a>
@@ -141,7 +141,7 @@ type = "event"
   Principal Engineer, PagerDuty
 </div>
 
-<div class="span-2">11:30-12:00</div><div class="span-4 box last"><strong>Ignites</strong> <br /> <br />
+<div class="span-2">11:30-12:00</div><div class="span-8 box last"><strong>Ignites</strong> <br /> <br />
   <ol>
     <li><a href="/events/2016-vancouver/proposals/Leveling_Up_Deployment_Infrastructure/">Leveling Up Deployment Infrastructure</a> - Jan Ulrich<br />DevOps team manager and developer, Salesforce Pardot</li>
     <li><a href="/events/2016-vancouver/proposals/Infrastructure_drift_detection_using_Terraform/">Infrastructure drift detection using Terraform</a> - Payam Moghaddam, <a href='https://twitter.com/@payammoghaddam'>@payammoghaddam</a><br />Infrastructure Engineer, ACL</li>
@@ -154,9 +154,9 @@ type = "event"
 
 </div>
 
-<div class="span-2">12:00-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">12:00-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last">
+<div class="span-2">13:00-13:30</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/Making_Single_Page_Applications_SPA_faster/"><strong>Making Single Page Applications (SPA) faster</strong></a>
   <br />
   Boris Livshutz
@@ -168,7 +168,7 @@ type = "event"
   Enterprise Architect, Advanced Solutions and Services, Akamai Technologies
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last">
+<div class="span-2">13:30-14:00</div><div class="span-8 box last">
   <a style="text-decoration:none;" href="/events/2016-vancouver/proposals/Utilizing_DevOps_for_effective_IoT_and_User_Telemetry_correlation-based_Data_Analytics/"><strong>Utilizing DevOps for effective IoT and User Telemetry correlation-based Data Analytics</strong></a>
   <br />
   Hubert Duan
@@ -180,13 +180,13 @@ type = "event"
   Boeing Canada Ltd – AeroInfo Systems
 </div>
 
-<div class="span-2">14:00-15:15</div><div class="span-4 box last">Open Space Opening</div>
+<div class="span-2">14:00-15:15</div><div class="span-8 box last">Open Space Opening</div>
 
-<div class="span-2">15:15-16:15</div><div class="span-4 box last">Open Space #4</div>
+<div class="span-2">15:15-16:15</div><div class="span-8 box last">Open Space #4</div>
 
-<div class="span-2">16:15-17:15</div><div class="span-4 box last">Open Space #5</div>
+<div class="span-2">16:15-17:15</div><div class="span-8 box last">Open Space #5</div>
 
-<div class="span-2">17:15-17:45</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:15-17:45</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/2016-washington-dc/program.md
+++ b/content/events/2016-washington-dc/program.md
@@ -12,110 +12,110 @@ type = "event"
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/content/events/sample-event/program.md
+++ b/content/events/sample-event/program.md
@@ -13,110 +13,110 @@ draft = true
 
 
 <center><b><h2>The Schedule</h2></b></center>
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 1</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last">Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last">Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">16:45-17:00</div><div class="span-4 box last"><strong></strong>Close Day & Logistics</div>
+<div class="span-2">16:45-17:00</div><div class="span-8 box last"><strong></strong>Close Day & Logistics</div>
 
-<div class="span-2">19:00-late</div><div class="span-4 box last"><strong>Evening Event</strong><br /></div>
+<div class="span-2">19:00-late</div><div class="span-8 box last"><strong>Evening Event</strong><br /></div>
 
 
 </div>
 
 
-<div class="span-7 append-bottom border">
+<div class="span-11 append-bottom border">
 
-<div class="span-7 last">
+<div class="span-11 last">
 <h4>Day 2</h4>
 </div>
 
-<div class="span-2">08:00-09:00</div><div class="span-4 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
-<div class="span-2">09:00-9:15</div><div class="span-4 box last"><strong></strong>Opening Welcome</div>
-<div class="span-2">09:15-09:45</div><div class="span-4 box last">
+<div class="span-2">08:00-09:00</div><div class="span-8 box last"> Registration, Breakfast, and Sponsor Booths Open</div>
+<div class="span-2">09:00-9:15</div><div class="span-8 box last"><strong></strong>Opening Welcome</div>
+<div class="span-2">09:15-09:45</div><div class="span-8 box last">
     <br />
 </div>
-<div class="span-2">09:45-09:55</div><div class="span-4 box last">
+<div class="span-2">09:45-09:55</div><div class="span-8 box last">
   Sponsors
 </div>
-<div class="span-2">09:55-10:25</div><div class="span-4 box last">
+<div class="span-2">09:55-10:25</div><div class="span-8 box last">
     <br />
 
 </div>
-<div class="span-2">10:25-10:40</div><div class="span-4 box last">
+<div class="span-2">10:25-10:40</div><div class="span-8 box last">
   Break
 </div>
 
-<div class="span-2">10:40-11:10</div><div class="span-4 box last" style="height:100px;">
+<div class="span-2">10:40-11:10</div><div class="span-8 box last" style="height:100px;">
     <br />
 </div>
 
-<div class="span-2">11:10-11:20</div><div class="span-4 box last">
+<div class="span-2">11:10-11:20</div><div class="span-8 box last">
   Sponsors
 </div>
 
-<div class="span-2">11:20-11:50</div><div class="span-4 box last">
+<div class="span-2">11:20-11:50</div><div class="span-8 box last">
     <br />
 </div>
 
-<div class="span-2">11:50-13:00</div><div class="span-4 append-bottom last">Lunch (catered)</div>
+<div class="span-2">11:50-13:00</div><div class="span-8 append-bottom last">Lunch (catered)</div>
 
-<div class="span-2">13:00-13:30</div><div class="span-4 box last"><strong>Ignites</strong> <br />
+<div class="span-2">13:00-13:30</div><div class="span-8 box last"><strong>Ignites</strong> <br />
 
 </div>
 
-<div class="span-2">13:30-14:00</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
+<div class="span-2">13:30-14:00</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space Opening</div>
 
-<div class="span-2">14:00-14:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
+<div class="span-2">14:00-14:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #1</div>
 
-<div class="span-2">15:00-15:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
+<div class="span-2">15:00-15:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #2</div>
 
-<div class="span-2">16:00-16:45</div><div class="span-4 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
+<div class="span-2">16:00-16:45</div><div class="span-8 box last"><strong>Open Space</strong> (Open Space) <br /> Open Space #3</div>
 
-<div class="span-2">17:00</div><div class="span-4 box last"><strong></strong>Close Day & Farewell</div>
+<div class="span-2">17:00</div><div class="span-8 box last"><strong></strong>Close Day & Farewell</div>
 
 
 

--- a/themes/devopsdays-legacy/layouts/partials/event_footer.html
+++ b/themes/devopsdays-legacy/layouts/partials/event_footer.html
@@ -4,9 +4,8 @@
 
 </div>
 
+<p>
 
-
-<div class="col-md-4">
 <!-- sponsor code begin -->
 {{ if $e.sponsors }}
   {{ $sponsors := $e.sponsors }}
@@ -21,11 +20,12 @@
     {{ if eq $e.status "current" }}
       {{ if eq $e.sponsors_accepted "no" }}
         <div class = "sponsor-cta">
-          <br>
+          <br><br><hr><br>
         </div>
       {{ else }}
         <div class = "sponsor-cta">
         <a href = "/events/{{ $e.name }}/sponsor">Become a {{ .label }} Sponsor!</a>
+          <br><br><hr><br>
         </div>
       {{ end }}
     {{ else }}
@@ -39,5 +39,4 @@
 </div>
 </div>
 
-</div>
 {{ partial "footer.html" . }}

--- a/themes/devopsdays-legacy/layouts/partials/event_header.html
+++ b/themes/devopsdays-legacy/layouts/partials/event_header.html
@@ -15,7 +15,7 @@
 
 <div class = "container-fluid">
   <div class="row">
-		<div class="col-md-8">
+		<div class="col-md-12">
       <h1> {{ $e.city }} {{ $e.year }} - {{ title .Title }} </h1>
       <!-- Main navigation -->
       <div class="submenu">

--- a/themes/devopsdays-legacy/static/css/style.css
+++ b/themes/devopsdays-legacy/static/css/style.css
@@ -71,9 +71,8 @@
 
 .company-logo {
   float: left;
-  padding: 2px !important;
-  border: 1px solid #18b;
-  margin: 2px;
+  padding: 4px !important;
+  margin: 4px;
 }
 
 .sponsor-cta {


### PR DESCRIPTION
I think @mattstratton is right in https://github.com/devopsdays/devopsdays-web/issues/295 and we should approach the re-design in a considered fashion. When I started looking at what it would take to move the sponsors to the bottom, though, it was so trivial that I figured I'd throw a PR together for consideration.

I ran through all pages on all 2016 events to make sure this change wouldn't make them unusable. There are a few cosmetic issues caused by how non-responsive the site is in general, but https://github.com/devopsdays/devopsdays-web/commit/a1709011e286bf547ed7267a51d29ad3163b700b fixes the only major issue.

Because moving sponsors to the bottom means there is a lot more space for them, I went with what I thought was more aesthetically pleasing of no borders (https://github.com/devopsdays/devopsdays-web/commit/d6b82c510a980b62d0fa7e40a92f3a6f971fdc5d). Here's what that looks like in practice:


![screen shot 2016-05-14 at 5 03 32 pm](https://cloud.githubusercontent.com/assets/2104453/15270924/edcce328-19f6-11e6-988e-d421d03933d3.png)

There are improvements we could make in the future (perhaps centering all this) that should definitely wait for a redesign.

I also widened the 2016 programs as seen in these before & after screencaps. While it could be argued that should wait for the redesign, it looked really weird without the sponsor sidebar since it didn't move to fill the space.

Before:
![screen shot 2016-05-14 at 5 12 49 pm](https://cloud.githubusercontent.com/assets/2104453/15270930/2b1d60a4-19f7-11e6-8bff-9ce6e3e84896.png)

After:
![screen shot 2016-05-14 at 5 13 12 pm](https://cloud.githubusercontent.com/assets/2104453/15270933/30e26e9e-19f7-11e6-987d-e6fff3bcf5fa.png)

Let the bikeshedding commence. :) (Do not merge without @mattstratton's 👍 .)