### PR TITLE
Adjust sponsor level for Workiva

### DIFF
--- a/data/events/2016-amsterdam.yml
+++ b/data/events/2016-amsterdam.yml
@@ -52,14 +52,14 @@ sponsors:
     level: silver
   - id: redhat
     level: silver
-  - id: workiva
-    level: silver
   # bronze
   - id: beslist
     level: bronze
   - id: devoteam
     level: bronze
   - id: indigo
+    level: bronze
+  - id: workiva
     level: bronze
   # BBQ
   - id: chef


### PR DESCRIPTION
Sponsor is bronze, not silver. 