### PR TITLE
devopsdays 2016 AMS - Move prospectus into a S3 bucket

### DIFF
--- a/content/events/2016-amsterdam/program/will-button.md
+++ b/content/events/2016-amsterdam/program/will-button.md
@@ -11,29 +11,30 @@ aliases = ["/events/2016-amsterdam/program/willbutton/"]
 <div class="span-15  ">
   <div class="span-15  last ">
   <p><strong>Title:</strong>
-  Taking Out the Garbage: Finding Memory Leaks in Node.js
+  An ElasticSearch Cluster Named George Armstrong Custer
 </p>
 
 <p><strong>Description:</strong></p>
 
-<p>To be Provided</p>
+<p>
+This is the epic tale of an elasticsearch cluster named "Custer", named after the US Calvary Commander.</p>
 
 <p>
-No one likes taking out the garbage. It’s gross. It’s smelly. It’s probably not even yours, but it must be done. Memory management in Node.js is no different. In this talk, seasoned DevOps advocate Will Button teaches you how to master garbage collection in Node.js. Memory management is often overlooked in Node.js applications. Common performance and scaling issues can be traced directly to memory leaks, resulting in a frustrating, poorly performing application. Failure to isolate and resolve these memory leaks means that you spend time, money and resources over-provisioning your environment. You will learn</p>
+ It didn't start out with a name, it started out as our logstash cluster, but after experiencing how easy it was to search and find logs using logstash, our developers took it upon themselves to see what else it could be used for. This was our Battle of Little Big Horn.</p>
 
-<p>
- • Enabling garbage collection statistics<br />
- • Recognizing the different types of garbage collection used by V8<br />
- • Understanding the metrics from the node.js garbage collector<br />
- • Identifying memory issues in your node.js applications (even before you look for them)<br />
- • Profiling your node.js server to understand your memory utilization<br />
- • Taking heapdump snapshots<br />
- • Structuring your code for better memory diagnosis<br />
- • Best practices for building scalable node.js applications<br />
- • Load testing Node.js applications<br />
+ <p>
+ In this ignite talk, attendees will laugh and learn as I explain: <br />
+ • the origin of our cluster <br />
+ • how it got it's name <br />
+ • Where things went wrong <br />
+ • Steps we took (good and bad) to deal with daily crashes (a.k.a. Little Big Horn) <br />
+ • Lessons learned on using and scaling elasticsearch <br />
+ </p>
+
+ <p>
+ Attendees will leave this short, 5 minute talk with the ability to identify the signs and symptoms of an over-utilized cluster. Specific thresholds that proved invaluable to us, such as JVM heap usage, memory utilization, shard movement, and index latency will be shared. They will also learn the tips and tactics on how to recover once a problem cluster is identified.
 </p>
 
-<p>Developers, DevOps Engineers and Sysadmins of all levels will benefit from the practical, easy-to-use tips and tools presented. While no particular programming skill set or expertise is required, attendees should be familiar with Node.js. By the end of the talk, you will be able to perform memory profiling and diagnose memory leaks on Node.js applications using the free and open source tools demonstrated.
 </p>
 
 

--- a/content/events/2016-amsterdam/sponsor.md
+++ b/content/events/2016-amsterdam/sponsor.md
@@ -196,5 +196,5 @@ Here is a quick overview of the options for this year:
 
 <br>
 
-Please find all information about our sponsorship opportunities for 2016 in our <a href="/events/2016-amsterdam/devopsdays_2016_-_sponsor_prospectus.pdf">sponsor document.</a>
+Please find all information about our sponsorship opportunities for 2016 in our <a href="http://dodams-prospectus.s3-eu-west-1.amazonaws.com/devopsdays_2016_-_sponsor_prospectus.pdf">sponsor document</a>.
 <hr/>


### PR DESCRIPTION
Moves the prospectus out of the github repo (addresses #401).

