### PR TITLE
devopsdays 2016 AMS - Fix Registration Page

### DIFF
--- a/content/events/2016-amsterdam/registration.md
+++ b/content/events/2016-amsterdam/registration.md
@@ -7,8 +7,6 @@ type = "event"
 tags = ["amsterdam","amsterdam-2016"]
 +++
 
-<div style="width:100%; text-align:left;">
-
-<div style="width:100%; text-align:left;" >
+<div class="span-15 last">
   <iframe src="http://www.eventbrite.com/tickets-external?eid=22133654356&ref=etckt"" frameborder="0" height="1000" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe>
 </div>


### PR DESCRIPTION
### Major
* Registration page had a double (unclosed) `<div>` that was causing havoc. 