### PR TITLE
SIN-16 welcome: Fix redirect to welcome page

### DIFF
--- a/content/events/2016-singapore/welcome.md
+++ b/content/events/2016-singapore/welcome.md
@@ -4,7 +4,7 @@ Year ="2016"
 date = "2016-03-06T21:15:25-06:00"
 title = "welcome"
 type = "event"
-aliases = ["/events/2016-Singapore"]
+aliases = ["/events/2016-singapore"]
 
 
 +++


### PR DESCRIPTION
The upper case 'S' letter prevented the redirect to take effect.

Now the redirect from `2016-singapore/` to `2016-singapore/welcome`
works as expected.