### PR TITLE
Adds link to future & past events where expected.

### DIFF
--- a/themes/devopsdays-responsive/layouts/index.html
+++ b/themes/devopsdays-responsive/layouts/index.html
@@ -14,6 +14,10 @@
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     </div>
   </div>
+  <div class="col-md-4 last">
+    <br>
+    <a href="/events">Future (including unscheduled) & Past Events</a>
+  </div>
 </div>
 
 {{ partial "footer.html" . }}


### PR DESCRIPTION
![screen shot 2016-06-04 at 10 35 11 am](https://cloud.githubusercontent.com/assets/2104453/15800468/5b053fd6-2a40-11e6-8189-3190e3f7a139.png)

I found myself accidentally scrolling to the lower right a lot and then wondering where the sorted-by-date, not-all-even-on-map event list was. This is the minimum viable "fix that". /cc @kmugrage @mattstratton 