### PR TITLE
Updated map zoom and labels

### DIFF
--- a/themes/devopsdays-responsive/layouts/partials/map.html
+++ b/themes/devopsdays-responsive/layouts/partials/map.html
@@ -28,9 +28,6 @@ function initialize() {
       {{ end }}
     ];
 
-    // Display multiple markers on a map
-    // var infoWindow = new google.maps.InfoWindow(), marker, i;
-
     // Loop through our array of markers & place each one on the map
     for( i = 0; i < markers.length; i++ ) {
         var position = new google.maps.LatLng(markers[i][1], markers[i][2]);
@@ -38,11 +35,18 @@ function initialize() {
         marker = new MarkerWithLabel({
             position: position,
             map: map,
-            labelContent: markers[i][0] + "<br>" + markers[i][3],
-            labelAnchor: new google.maps.Point(25, 50),
-            labelClass: "labels",
-            labelStyle: { opacity: 1 }
         });
+
+        marker.info = new google.maps.InfoWindow({
+            content: markers[i][0] + "<br>" + markers[i][3]
+        });
+
+        google.maps.event.addListener(marker, 'click', function() {
+            infoWindow = this.info
+            infoWindow.open(map, this);
+            google.maps.event.addListener(map, "drag", function() {infoWindow.close();});
+        });
+
         // cityLink = markers[i][4]
         // This isn't working right now btw
         // google.maps.event.addListener(marker, "click", function (e) { location.href=cityLink});
@@ -50,7 +54,45 @@ function initialize() {
         // refocus
         map.fitBounds(bounds);
     }
+
+    // Try HTML5 geolocation
+    if(navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(function(position) {
+        var pos = new google.maps.LatLng(position.coords.latitude,
+                                         position.coords.longitude);
+
+        map.setCenter(pos);
+        smoothZoom(map, 6, map.getZoom());
+      }, function() {
+        handleNoGeolocation(true);
+      });
+    } else {
+      // Browser doesn't support Geolocation
+      handleNoGeolocation(false);
+    }
 }
+
+function handleLocationError(browserHasGeolocation, infoWindow, pos) {
+  infoWindow.setPosition(pos);
+  infoWindow.setContent(browserHasGeolocation ?
+                        'Error: The Geolocation service failed.' :
+                        'Error: Your browser doesn\'t support geolocation.');
+}
+
+// the smooth zoom function
+function smoothZoom (map, max, cnt) {
+    if (cnt >= max) {
+        return;
+    }
+    else {
+        z = google.maps.event.addListener(map, 'zoom_changed', function(event){
+            google.maps.event.removeListener(z);
+            smoothZoom(map, max, cnt + 1);
+        });
+        setTimeout(function(){map.setZoom(cnt)}, 60);
+    }
+}
+
 </script>
 
 <script type="text/javascript" language="javascript">
@@ -60,7 +102,7 @@ function initialize() {
       };
 </script>
 
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?key=AIzaSyC1bvNK9qFJGEhoWNbQuojmJJ1Tg0DoOew&sensor=false"></script>
+<script type="text/javascript" src="http://maps.google.com/maps/api/js?key=AIzaSyC1bvNK9qFJGEhoWNbQuojmJJ1Tg0DoOew&sensor=false&callback=initialize"></script>
 <script type="text/javascript" src="/js/googlemaps_label.js"></script>
 <!-- <script type="text/javascript" src="/js/googlemaps_content.js"></script> -->
 <div class="embed-responsive embed-responsive-16by9">


### PR DESCRIPTION
This closes #82 by adding support for localizing the map. I have currently set the zoom at 6, but we can play with that if it isn't optimal. If location information isn't available, then the default zoom is applied.

I also removed the labels and added info windows instead. They're still slightly buggy in that the "disappear on drag" functionality only works on the last window to appear. I've done this in the past, but it may require additional restructuring. I'll log an issue if this PR is merged.