### PR TITLE
Fix head template to allow custom titles

### DIFF
--- a/themes/devopsdays-responsive/layouts/partials/head.html
+++ b/themes/devopsdays-responsive/layouts/partials/head.html
@@ -11,10 +11,8 @@
 {{ if eq $url "/" }}
     {{ .Site.Title }}
 {{ else }}
-    {{ if .Params.heading }}
-      {{ .Params.heading }}
-    {{ else }}
-      {{ .Title }}
+    {{ if .Params.heading }} {{ .Params.heading }}
+    {{ else }} {{ .Title }}
     {{ end }}
 {{ end }}
 </title>

--- a/themes/devopsdays-responsive/layouts/partials/head.html
+++ b/themes/devopsdays-responsive/layouts/partials/head.html
@@ -11,7 +11,11 @@
 {{ if eq $url "/" }}
     {{ .Site.Title }}
 {{ else }}
-    {{ if .Params.Heading }} {{ .Params.Heading }} {{ else }} {{ .Title }} {{ end }}
+    {{ if .Params.heading }}
+      {{ .Params.heading }}
+    {{ else }}
+      {{ .Title }}
+    {{ end }}
 {{ end }}
 </title>
 <link rel="canonical" href="{{ .Permalink }}">


### PR DESCRIPTION
The logic to override, or to specify a custom title, per page was already set in the template.

However the Params was improperly used as all Params have to be lower case (per: https://gohugo.io/templates/variables/#page-params). In this case it was `.Params.Heading` instead of `.Params.heading`.

I've added two spaces to it for readability. To anyone that now comes across head.html they'll see that it can either be set by Params.heading or .Title; both can be set in side of the md files in content/

This, to me, fixes #259 as it provides non-breaking change (no one is using "heading" in content in their .md file) to those that want to set custom titles. 