### PR TITLE
Don't display Twitter "@" when handle isn't set

### DIFF
--- a/themes/devopsdays-responsive/layouts/speakers/single.html
+++ b/themes/devopsdays-responsive/layouts/speakers/single.html
@@ -18,9 +18,9 @@
     </div>
     <div class= "col-md-8">
        <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
-       <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a>
-     <br><br>
-     {{ $s.bio | markdownify }}
+       {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
+       <br>
+       {{ $s.bio | markdownify }}
 <hr>
     </div>
 </div>

--- a/themes/devopsdays-responsive/layouts/speakers/single.html
+++ b/themes/devopsdays-responsive/layouts/speakers/single.html
@@ -19,7 +19,7 @@
     <div class= "col-md-8">
        <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
        {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
-       <br>
+     <br>
      {{ $s.bio | markdownify }}
 <hr>
     </div>

--- a/themes/devopsdays-responsive/layouts/speakers/single.html
+++ b/themes/devopsdays-responsive/layouts/speakers/single.html
@@ -20,7 +20,7 @@
        <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
        {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
        <br>
-       {{ $s.bio | markdownify }}
+     {{ $s.bio | markdownify }}
 <hr>
     </div>
 </div>

--- a/themes/devopsdays-responsive/layouts/talk/single.html
+++ b/themes/devopsdays-responsive/layouts/talk/single.html
@@ -28,8 +28,8 @@
     </div>
     <div class= "col-md-8">
        <h3>{{ $s.name }}</h3>
-       <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a>
-     <br><br>
+       {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
+     <br>
      {{ $s.bio | markdownify }}
     </div>
 </div>


### PR DESCRIPTION
Add a hugo parameter check prior to displaying twitter handle. By default if the parameter is not set (0 byte content) it pass the if statement. (ref: https://gohugo.io/templates/go-templates/#conditionals)

This fixed #366 
