### PR TITLE
devopsdays 2016 AMS - Set page titles

### DIFF
--- a/content/events/2016-amsterdam/conduct.md
+++ b/content/events/2016-amsterdam/conduct.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:17:08-06:00"
+heading = "devopsdays Amsterdam - Code of Conduct"
 title = "Code of Conduct"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]

--- a/content/events/2016-amsterdam/contact.md
+++ b/content/events/2016-amsterdam/contact.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:16:08-06:00"
+heading = "devopsdays Amsterdam - Contact"
 title = "Contact"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]

--- a/content/events/2016-amsterdam/location.md
+++ b/content/events/2016-amsterdam/location.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:17:00-06:00"
+heading = "devopsdays Amsterdam - Event Location"
 title = "Event Location"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]

--- a/content/events/2016-amsterdam/program.md
+++ b/content/events/2016-amsterdam/program.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:28:07-06:00"
+heading = "devopsdays Amsterdam - Program"
 title = "Program"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]

--- a/content/events/2016-amsterdam/proposals.md
+++ b/content/events/2016-amsterdam/proposals.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:28:14-06:00"
+heading = "devopsdays Amsterdam - Proposals"
 title = "Proposals"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]

--- a/content/events/2016-amsterdam/propose.md
+++ b/content/events/2016-amsterdam/propose.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T22:47:24-06:00"
+heading = "devopsdays Amsterdam - Call for Papers"
 title = "Propose"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]

--- a/content/events/2016-amsterdam/registration.md
+++ b/content/events/2016-amsterdam/registration.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:28:23-06:00"
+heading = "devopsdays Amsterdam - Registration"
 title = "Registration"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]

--- a/content/events/2016-amsterdam/speakers.md
+++ b/content/events/2016-amsterdam/speakers.md
@@ -1,5 +1,6 @@
 +++
 date = "2016-03-06T21:17:14-06:00"
+heading = "devopsdays Amsterdam - Speakers"
 title = "speakers"
 type = "speakers"
 

--- a/content/events/2016-amsterdam/sponsor.md
+++ b/content/events/2016-amsterdam/sponsor.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:17:14-06:00"
+heading = "devopsdays Amsterdam - Sponsors"
 title = "Sponsor Information"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]

--- a/content/events/2016-amsterdam/workshops.md
+++ b/content/events/2016-amsterdam/workshops.md
@@ -2,6 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:28:07-06:00"
+heading = "devopsdays Amsterdam - Workshops"
 title = "Workshops"
 type = "event"
 tags = ["amsterdam","amsterdam-2016"]


### PR DESCRIPTION
## Major
* All pages but welcome (see #536) now use `heading` option. 