### PR TITLE
devopsdays 2016 AMS - Fix minor typos

### DIFF
--- a/content/events/2016-amsterdam/program.md
+++ b/content/events/2016-amsterdam/program.md
@@ -552,7 +552,7 @@ tags = ["amsterdam","amsterdam-2016"]
   </div>
   <div class = "col-md-1"></div>
   <div class = "col-md-3 box-darkgreen">
-    <strong><u>Security Talk Track:</u></strong><br /><a href="/events/2016-amsterdam/program/melanie-rieback" style="color:#62BBD9">Melanie Rieback (Radically Open Security)<br />Pentesting ChatOps</a>
+    <strong>Security Talk Track:</strong><br /><a href="/events/2016-amsterdam/program/melanie-rieback" style="color:#62BBD9">Melanie Rieback (Radically Open Security)<br />Pentesting ChatOps</a>
   </div>
   <div class = "col-md-1"></div>
 </div><!-- end timeslot row-->

--- a/content/events/2016-amsterdam/welcome.md
+++ b/content/events/2016-amsterdam/welcome.md
@@ -111,4 +111,4 @@ This year, we are hosting the fourth edition of devopsdays Amsterdam. We are loo
 
 <!-- add your city twitter name here without the @ sign -->
 
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter devopsams >}}

--- a/content/events/2016-amsterdam/workshops/andrew-farley.md
+++ b/content/events/2016-amsterdam/workshops/andrew-farley.md
@@ -50,7 +50,7 @@ To participate in this workshop and to maximize what you can get out of this wor
 In this workshop I will provide…
 </p>
 
-<p><
+<p>
 • Slides at the start of the chat<br />
 • Demo/Sample API endpoints and code to be used by some of the workshop<br />
 • Various sample codebases and/or tools in various git repositories to be used in the workshop<br />

--- a/content/events/2016-amsterdam/workshops/dave-van-herpen.md
+++ b/content/events/2016-amsterdam/workshops/dave-van-herpen.md
@@ -27,7 +27,7 @@ High-performance teams are NOT the teams with the newest tools or the coolest pi
 </p>
 
 <p>
- This highly interactive workshop will give you real practical instruments, tips & tricks (all based on scientific & practical evidence and experience) how to help truly create a high-performance environment in your organization."
+ This highly interactive workshop will give you real practical instruments, tips & tricks (all based on scientific & practical evidence and experience) how to help truly create a high-performance environment in your organization.
 </p>
 
 <p><strong>About the speakers</strong>

--- a/content/events/2016-amsterdam/workshops/philipp-krenn.md
+++ b/content/events/2016-amsterdam/workshops/philipp-krenn.md
@@ -24,7 +24,7 @@ aliases = ["/events/2016-amsterdam/program/philipp-krenn/"]
 </p>
 
 <p>
- This workshop gives you an overview of the four technologies, how they are working together, and how they can solve your problems. And of course attendees are setting up the full stack on their laptop to try it out for themselves!"
+ This workshop gives you an overview of the four technologies, how they are working together, and how they can solve your problems. And of course attendees are setting up the full stack on their laptop to try it out for themselves!
 </p>
 
 

--- a/content/events/2016-amsterdam/workshops/remi-bergsma.md
+++ b/content/events/2016-amsterdam/workshops/remi-bergsma.md
@@ -2,7 +2,7 @@
 City = "Amsterdam"
 Year = "2016"
 date = "2016-03-06T21:28:07-06:00"
-title = "Cloudstack / Cosmic Cloud"
+title = "Build your own Cloud in record time with Cosmic"
 type = "talk"
 aliases = ["/events/2016-amsterdam/program/remi-bergsma/"]
 

--- a/data/events/2016-amsterdam.yml
+++ b/data/events/2016-amsterdam.yml
@@ -16,7 +16,7 @@ coordinates: "52.376862, 4.922078" # The coordinates of your city. Get Latitude 
 location: "Pakhuis de Zwijger - Amsterdam" # Defaults to city, but you can make it the venue name.
 
 # Team members
-team: ["Harm Boertien", "Thomas Krag", "Kerim Satirli", "Arjan Wolfs", "Wilco Noordermeer", "Arjan Eriks", "Gérard de Vos", "Yvo van Doorn", "Marjana Shammi", "Mine Heck", "Daniel Paulus", "Mark Heistek"]
+team: ["Harm Boertien", "Thomas Krag", "Kerim Satirli", "Arjen Wolfs", "Wilco Noordermeer", "Arjan Eriks", "Gérard de Vos", "Yvo van Doorn", "Marjana Shammi", "Mine Heck", "Daniel Paulus", "Mark Heistek"]
 
 # Emails
 organizer_email: "organizers-amsterdam-2016@devopsdays.org" # Put your organizer email address here


### PR DESCRIPTION
## Major
* Fix twitter link in new `welcome.md`

### Minor
* Remove underline in Security Talk on Melanie's talk. 
* Fix page title for Remi's talk
* Fix Arjan -> Arjen
* Remove trailing `"` from two pages
* Remove extra `<` 
