### PR TITLE
Add string function to work around hugo 0.16 bug

### DIFF
--- a/themes/devopsdays-responsive/layouts/partials/past.html
+++ b/themes/devopsdays-responsive/layouts/partials/past.html
@@ -10,8 +10,8 @@ Chomping .year has the nice effect of turning an int into string. -->
   {{ $r_year := . }}
   {{ range $.Site.Data.events }}
     {{ if and (eq .year $r_year) (eq .status "past")  }}
-      {{ $.Scratch.SetInMap "active_years" (string (chomp .year)) (string (chomp .year)) }}
-      {{ $.Scratch.SetInMap (string (chomp .year)) .startdate (.name) }}
+      {{ $.Scratch.SetInMap "active_years" (print (chomp .year)) (print (chomp .year)) }}
+      {{ $.Scratch.SetInMap (print (chomp .year)) .startdate (.name) }}
     {{ end }}
   {{ end }}
 {{ end }}
@@ -29,7 +29,7 @@ Chomping .year has the nice effect of turning an int into string. -->
       <br/>
         <!-- Finally, scan throug the scratch with the ID of that year and print all the events sorted by startdate
   Chomping here in order to convert int to string -->
-        {{ range ($.Scratch.GetSortedMapValues (string (chomp .))) }}
+        {{ range ($.Scratch.GetSortedMapValues (print (chomp .))) }}
           {{ $city := (index $.Site.Data.events . "city") }}
           {{ $friendly := (index $.Site.Data.events . "friendly") }}
           <a href="/events/{{ $friendly }}/">{{ $city }}</a>

--- a/themes/devopsdays-responsive/layouts/partials/past.html
+++ b/themes/devopsdays-responsive/layouts/partials/past.html
@@ -10,8 +10,8 @@ Chomping .year has the nice effect of turning an int into string. -->
   {{ $r_year := . }}
   {{ range $.Site.Data.events }}
     {{ if and (eq .year $r_year) (eq .status "past")  }}
-      {{ $.Scratch.SetInMap "active_years" (chomp .year) (chomp .year) }}
-      {{ $.Scratch.SetInMap (chomp .year) .startdate (.name) }}
+      {{ $.Scratch.SetInMap "active_years" (string (chomp .year)) (string (chomp .year)) }}
+      {{ $.Scratch.SetInMap (string (chomp .year)) .startdate (.name) }}
     {{ end }}
   {{ end }}
 {{ end }}
@@ -29,7 +29,7 @@ Chomping .year has the nice effect of turning an int into string. -->
       <br/>
         <!-- Finally, scan throug the scratch with the ID of that year and print all the events sorted by startdate
   Chomping here in order to convert int to string -->
-        {{ range ($.Scratch.GetSortedMapValues (chomp .)) }}
+        {{ range ($.Scratch.GetSortedMapValues (string (chomp .))) }}
           {{ $city := (index $.Site.Data.events . "city") }}
           {{ $friendly := (index $.Site.Data.events . "friendly") }}
           <a href="/events/{{ $friendly }}/">{{ $city }}</a>

--- a/themes/devopsdays-responsive/layouts/speakers/single.html
+++ b/themes/devopsdays-responsive/layouts/speakers/single.html
@@ -11,7 +11,7 @@
 
  <!-- speaker page code begin -->
 
-  {{ range $fname, $s := index .Site.Data.speakers (string (chomp $e.year)) (lower $e.city) }}
+  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (lower $e.city) }}
 <div class="row">
     <div class="col-md-3">
         <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="img-responsive" width = "250px">

--- a/themes/devopsdays-responsive/layouts/speakers/single.html
+++ b/themes/devopsdays-responsive/layouts/speakers/single.html
@@ -11,7 +11,7 @@
 
  <!-- speaker page code begin -->
 
-  {{ range $fname, $s := index .Site.Data.speakers (chomp $e.year) (lower $e.city) }}
+  {{ range $fname, $s := index .Site.Data.speakers (string (chomp $e.year)) (lower $e.city) }}
 <div class="row">
     <div class="col-md-3">
         <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="img-responsive" width = "250px">

--- a/themes/devopsdays-responsive/layouts/talk/single.html
+++ b/themes/devopsdays-responsive/layouts/talk/single.html
@@ -19,7 +19,7 @@
    .Site.Data.events $e.year (printf "%s" (lower $e.city))
    - mattstratton
  */}}
- {{ range $fname, $s := index .Site.Data.speakers (string (chomp $e.year)) (lower $e.city) }}
+ {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (lower $e.city) }}
    {{ if eq $fname ($.Title | urlize) }}
 <hr>
 <div class="row">

--- a/themes/devopsdays-responsive/layouts/talk/single.html
+++ b/themes/devopsdays-responsive/layouts/talk/single.html
@@ -19,7 +19,7 @@
    .Site.Data.events $e.year (printf "%s" (lower $e.city))
    - mattstratton
  */}}
- {{ range $fname, $s := index .Site.Data.speakers (chomp $e.year) (lower $e.city) }}
+ {{ range $fname, $s := index .Site.Data.speakers (string (chomp $e.year)) (lower $e.city) }}
    {{ if eq $fname ($.Title | urlize) }}
 <hr>
 <div class="row">


### PR DESCRIPTION
The chomp function doesn't work quite as expected in 0.16. Per https://discuss.gohugo.io/t/errors-with-type-template-html-should-be-string-with-hugo-0-16-0/3470/4?u=mattstratton, i have wrapped the chomp stuff and it seems to work fine now under 0.16.

This handles the defect mentioned in #543 