### PR TITLE
[2016-BNA] Adding github/chef sponsors

### DIFF
--- a/data/events/2016-nashville.yml
+++ b/data/events/2016-nashville.yml
@@ -35,6 +35,10 @@ sponsors: # List all of your sponsors here along with what level of sponsorship 
     level: gold
   - id: raventools
     level: silver
+  - id: github
+    level: gold
+  - id: chef
+    level: silver
 sponsor_levels: # In this section, list the level of sponsorships and the label to use.
   - id: gold
     label: Gold


### PR DESCRIPTION
This PR adds the GitHub and Chef sponsors to 2016-Nashville event.

/cc @jcockhren @cwage @elizabrock @nickalausw