### PR TITLE
Fix string in hugo version in build

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -2,7 +2,7 @@ box: debian
 build:
   steps:
     - arjen/hugo-build:
-        version: 0.15
+        version: "0.15"
         theme: devopsdays-responsive
         flags: --buildDrafts=false
 


### PR DESCRIPTION
So it seems that the way I was calling/defining the version of Hugo in the build config was being ignored, so it was building to latest. This is making the site use hugo 0.16 in production, which causes some errors. This should fix that.