### PR TITLE
[DC 2016] Closing out DC 2016

### DIFF
--- a/content/events/2016-washington-dc/location.md
+++ b/content/events/2016-washington-dc/location.md
@@ -5,7 +5,7 @@ type = "event"
 
 +++
 
-DevOpsDays DC 2016 will be held at [The United States Patent and Trademark
+DevOpsDays DC 2016 was held at [The United States Patent and Trademark
 Office](http://www.uspto.gov/)'s Madison Auditorium at 600 Dulany Street,
 Alexandria, Virginia, just outside the District (but inside the Beltway!) Please
 see [USPTO's directions

--- a/content/events/2016-washington-dc/sponsor.md
+++ b/content/events/2016-washington-dc/sponsor.md
@@ -5,8 +5,7 @@ type = "event"
 
 +++
 
-We greatly value sponsors for this open event.  **All of our current Sponsorship
-options have sold out**.  Would you like to [sponsor DevOpsDays
+**DevOpsDays DC 2016 has ended.** Would you like to [sponsor DevOpsDays
 Baltimore](http://www.devopsdays.org/events/2016-baltimore/sponsor/)?
 
 <style>
@@ -87,14 +86,6 @@ Baltimore](http://www.devopsdays.org/events/2016-baltimore/sponsor/)?
 </tbody>
 </table>
 
-**All of our current Sponsorship options have sold out**.
-
-Although we no longer have sponsorships available, there will be another
-DevOpsDays in the area later this Summer.  Checkout the [sponsorship
-opportunities for DevOpsDays
-Baltimore](http://www.devopsdays.org/events/2016-baltimore/sponsor/).
-
-
 ### Silver - SOLD OUT
 
 * 2 included tickets
@@ -117,7 +108,7 @@ Baltimore](http://www.devopsdays.org/events/2016-baltimore/sponsor/).
 
 We greatly value sponsors for this open event.
 
-Although we no longer have sponsorships available, there will be another
+Although DevOpsDays DC 2016 has ended, there will be another
 DevOpsDays in the area later this Summer.  Checkout the [sponsorship
 opportunities for DevOpsDays
 Baltimore](http://www.devopsdays.org/events/2016-baltimore/sponsor/).

--- a/content/events/2016-washington-dc/welcome.md
+++ b/content/events/2016-washington-dc/welcome.md
@@ -15,10 +15,10 @@ aliases = ["/events/2016-washington-dc"]
 ### A house divided against itself cannot stand.
 
 **_Change is in session!_**
-DevOpsDays DC will be held **June 8 and 9, 2016** at the {{< event_link page="location"
+DevOpsDays DC was held **June 8 and 9, 2016** at the {{< event_link page="location"
 text="US Patent and Trademark Office" >}} in Alexandria, Virginia.
 
-## Watch The Live Stream
+## Review The Video
 
 <iframe id="ls_embed_1465391059"
 src="//livestream.com/accounts/4828334/events/5290229/player?width=560&height=315&autoPlay=false&mute=false"
@@ -27,18 +27,6 @@ width="560" height="315" frameborder="0" scrolling="no"></iframe>
 Courtesy of our Platinum and Venue Sponsor, the [US Patent and Trademark
 Office](http://www.uspto.gov/). Archived video is available via
 [Livestream.com](http://livestream.com/uspto/Devops2016).
-
-## Registration and ticket sales
-
-[Tickets are on sale now](https://devopsdaysdc2016.busyconf.com/bookings/new)
-for both Government and private sector employees ($100 each).  Please [register
-early](https://devopsdaysdc2016.busyconf.com/bookings/new).  Some ticket types
-have already **sold out**.
-
-## Schedule
-
-The keynote and ignite sessions have been announced and are now [available on
-the schedule](http://devopsdaysdc2016.busyconf.com/schedule).
 
 ## Why Attend?
 
@@ -53,23 +41,6 @@ shop with DevOps practitioners, _DevOpsDays is for you._
 
 DevOpsDays are a mix of keynote sessions and [open
 spaces](http://en.wikipedia.org/wiki/Open_Space_Technology).
-
-## Local Hotels
-
-There are a number of hotels near the US Patent and Trademark Office.  Some
-options include:
-
-* [The Westin Alexandria](http://www.westinalexandria.com/) - official hotel of
-DevOpsDays DC.
-* [Residence Inn Alexandria Old Town/Duke Street](http://www.marriott.com/hotels/travel/wasdk-residence-inn-alexandria-old-town-duke-street/)
-* [Hilton Alexandria Old Town](http://www3.hilton.com/en/hotels/virginia/hilton-alexandria-old-town-DCAOTHF/index.html)
-* [Wyndham Old Town Alexandria](https://www.extraholidays.com/washington-dc/wyndham-old-town-alexandria.aspx)
-
-## Sponsorship
-
-DevOpsDays is a self-organizing conference for DevOps practitioners that depends
-on your sponsorships to happen.  We no longer have sponsorship opportunities
-available.
 
 ## About Washington, DC
 

--- a/data/events/2016-washington-dc.yml
+++ b/data/events/2016-washington-dc.yml
@@ -1,8 +1,8 @@
 name: 2016-washington-dc # The name of the event. Four digit year with the city name in lower-case, with no spaces.
-year: "2016" # The year of the event. Make sure it is in quotes.
+year: 2016
 city: "Washington, DC" # The city name of the event. Capitalize it.
 friendly: "2016-washington-dc" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "current" # Options are "past" or "current".
+status: "past" # Options are "past" or "current".
 startdate: 2016-06-08 # The start date of your event, in YYYY-MM-DD format. Leave blank if you don't have a date yet.
 enddate: 2016-06-09 # The end date of your event, in YYYY-MM-DD format. Leave blank if you don't have a date yet.
 cfp_date_start: 2016-04-01


### PR DESCRIPTION
This advice in content/data/2016-washington-dc.yml appears to be
incorrect with regard to the quotes:

    year: "2016" # The year of the event. Make sure it is in quotes.

With quotes there, the event does not appear in the "past" partial.
Without quotes, it does. Thus I've removed the quotes, but feel free to
tell me how to fix this another way if that breaks anything.