### PR TITLE
devopsdays 2016 AMS - Closing the event

### DIFF
--- a/content/events/2016-amsterdam/welcome.md
+++ b/content/events/2016-amsterdam/welcome.md
@@ -23,8 +23,11 @@ tags = ["amsterdam","amsterdam-2016"]
 
 <div style="text-align:center;">
 <h3>
-This year, we are hosting the fourth edition of devopsdays Amsterdam. We are looking forward to welcoming 300+ attendees, speakers and trainers for three days of interesting sessions in the end of June 2016.
+Thank you for attending devopsdays Amsterdam 2016! We will see you in June of 2017!
 </h3>
+<h2>
+Please watch this space for links to photos and videos to the event!
+</h2>
 </div>
 
 <div class = "row">
@@ -45,14 +48,14 @@ This year, we are hosting the fourth edition of devopsdays Amsterdam. We are loo
   </div>
 </div>
 
-<div class = "row">
+<!-- <div class = "row">
   <div class = "col-md-2">
     <strong>Register</strong>
   </div>
   <div class = "col-md-8">
     {{< event_link page="registration" text="Register to attend the conference!" >}}
   </div>
-</div>
+</div> -->
 
 <!-- <div class = "row">
   <div class = "col-md-2">

--- a/data/events/2016-amsterdam.yml
+++ b/data/events/2016-amsterdam.yml
@@ -1,10 +1,10 @@
 name: "2016-amsterdam" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
-year: "2016" # The year of the event. Make sure it is in quotes.
+year: 2016 # The year of the event. Make sure it is in quotes.
 city: "Amsterdam" # The city name of the event. Capitalize it.
 friendly: "2016-amsterdam" # Four digit year and the city name in lower-case. Don't forget the dash!
 
 # Datus and status
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
+status: "past" # Options are "past" or "current". Use "current" for upcoming.
 startdate: 2016-06-29  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2016-07-01  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 cfp_date_start: 2016-01-15 # start accepting talk proposals.
@@ -118,7 +118,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
 #  - name: propose
   - name: speakers
   - name: location
-  - name: registration
+#  - name: registration
   - name: sponsor
   - name: contact
   - name: conduct


### PR DESCRIPTION
## Major
* Updated `status` to past
* Updated `year` to not be in quotes (to show up in past events)
* Hid registration link in navigation & on site
* Changed text thanking attendees