### PR TITLE
PDX: Add dates to the day numbers

### DIFF
--- a/content/events/2016-portland/program.md
+++ b/content/events/2016-portland/program.md
@@ -19,7 +19,7 @@ type = "event"
   </div>
 </div>
 
-## Day 1
+## Day 1 (2016-08-09)
 
 *Keynote*: Kelsey Hightower
 
@@ -36,7 +36,7 @@ type = "event"
 
 *Closing Talk*: What we’re learning about burnout and how a DevOps culture can help (Ken Mugrage)
 
-## Day 2
+## Day 2 (2016-08-10)
 
 *Keynote*: Everything is Terrible: Three Perspectives on Building, Configuring, and Securing Software (Chris Barker, Adrien Thebo, Cody Herriges)
 


### PR DESCRIPTION
I was linked straight to the schedule page and wanted to know what days the talks were on. This information was previously only available on the "welcome" page.