### PR TITLE
Max sponsors

### DIFF
--- a/themes/devopsdays-responsive/layouts/partials/sponsors.html
+++ b/themes/devopsdays-responsive/layouts/partials/sponsors.html
@@ -4,33 +4,34 @@
 
 <div class="col-md-4">
   {{ if $e.sponsors }}
-    {{ $sponsors := $e.sponsors }}
-    {{ range $e.sponsor_levels }}
-    <div class = "row">
-      <div class = "md-col-12">
-        <h2>{{ .label }} Sponsors</h2>
-      {{ range where $sponsors "level" .id }}
-        {{ $s :=  (index $.Site.Data.sponsors .id) }}
-        {{ if isset $.Site.Data.sponsors .id }}
-          <a href = "{{ $s.url }}"><img alt = "{{ .id }}" src = "/img/sponsors/{{ .id }}.png" class="img-responsive company-logo" height="100px" width="100px"></a>
-        {{ end }}
-      {{ end }}
-    </div>
-      {{ if eq $e.status "current" }}
-        {{ if eq $e.sponsors_accepted "no" }}
-        {{ else }}
-        <div class = "row">
-          <div class = "col-xs-12 sponsor-cta">
-          <a href = "/events/{{ $e.name }}/sponsor">Become a {{ .label }} Sponsor!</a>
-          </div>
-        </div>
-        {{ end }}
-      {{ else }}
-        <div class = "sponsor-cta">
-        </div>
-      {{ end }}
-  </div>
+    {{ range $index, $level := $e.sponsor_levels }}
+      {{ $.Scratch.Set $level.id 0 }}
+      <div class = "row">
 
+        <div class = "md-col-12">
+          <h2>{{ $level.label }} Sponsors</h2>
+          {{ range where $e.sponsors "level" $level.id }}
+            {{ $s := (index $.Site.Data.sponsors .id) }}
+            {{ if isset $.Site.Data.sponsors .id }}
+              {{ $.Scratch.Add $level.id 1 }}
+              <a href = "{{ $s.url }}"><img alt = "{{ .id }}" src = "/img/sponsors/{{ .id }}.png" class="img-responsive company-logo" height="100px" width="100px"></a>
+            {{ end }}
+          {{ end }}
+        </div>
+
+        {{ if eq $e.status "current" }}
+          {{ if ne $e.sponsors_accepted "no" }}
+            {{ if or (not $level.max) (lt ($.Scratch.Get $level.id) $level.max) }}
+              <div class = "row">
+                <div class = "col-xs-12 sponsor-cta">
+                  <a href = "/events/{{ $e.name }}/sponsor">Become a {{ .label }} Sponsor!</a>
+                </div>
+              </div>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+
+      </div>
     {{ end }}
   {{ end }}
 </div>

--- a/yyyy-city.yml
+++ b/yyyy-city.yml
@@ -50,13 +50,16 @@ sponsors:
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.
-# You may optionally include a "max" attribute to limit the number of sponsors per level.
+# You may optionally include a "max" attribute to limit the number of sponsors per level. For
+# unlimitted sponsors, omit the max attribute or set it to 0. If you want to prevent all
+# sponsorship for a specific level, it is best to remove the level.
 sponsor_levels:
   - id: gold
     label: Gold
-    #max: 10
+    max: 10
   - id: silver
     label: Silver
+    max: 0 # This is the same as omitting the max limit.
   - id: bronze
     label: Bronze
   - id: community

--- a/yyyy-city.yml
+++ b/yyyy-city.yml
@@ -48,9 +48,13 @@ sponsors:
     level: community
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
-sponsor_levels: # In this section, list the level of sponsorships and the label to use.
+
+# In this section, list the level of sponsorships and the label to use.
+# You may optionally include a "max" attribute to limit the number of sponsors per level.
+sponsor_levels:
   - id: gold
     label: Gold
+    #max: 10
   - id: silver
     label: Silver
   - id: bronze


### PR DESCRIPTION
Got around to addressing the need to control the sponsor level CTA per issue #93 

Basically using $.Scratch to setup a counter, so we can count how many sponsors get iterated per level, then comparing it to the level "max" property (if it exists or is non-zero)