### PR TITLE
allow special/international characters in speaker name

### DIFF
--- a/themes/devopsdays-responsive/layouts/talk/single.html
+++ b/themes/devopsdays-responsive/layouts/talk/single.html
@@ -20,7 +20,7 @@
    - mattstratton
  */}}
  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (lower $e.city) }}
-   {{ if eq $fname ($.Title | urlize) }}
+   {{ if eq $fname ($.LinkTitle | urlize) }}
 <hr>
 <div class="row">
     <div class="col-md-3">


### PR DESCRIPTION
LinkTitle defaults to Title unless linktitle is specified in the md file