### PR TITLE
Add displayname functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then in a new window:
 A more permanent fix is to add the following to `/etc/sysctl.conf` (run `touch /etc/sysctl.conf` first if the file doesn't exist; it likely does not):
 
 ```
-kern.maxfiles=20480 
+kern.maxfiles=20480
 kern.maxfilesperproc=24576
 ```
 ...and reboot!
@@ -62,6 +62,18 @@ The easiest way to create a new event is with the [make_new_event.sh](https://gi
 
 Once you have created a logo graphic, you will want to add it to the following directory (creating the directory if necessary) `/static/events/yyyy-city/logo.png`. The file MUST be called `logo.png`.
 
+### Special characters in city names
+
+If your city has either spaces, or accented characters, you will want to add the optional parameter `displayname` to your `yyyy-city.yml`. The `name` and `city` parameters need to be named with "URL-friendly" (i.e., ASCII, no spaces), but `displayname` can have whatever you want in it.
+
+For example, for Zürich, your event directory would be `2016-zurich`, and the data file would have the following elements:
+```
+name: "2015-zurich"
+year: 2015
+city: "Zurich"
+displayname: "Zürich"
+```
+
 ## Adding sponsors
 
 Sponsors each need a file in the data directory, as such: `data/sponsors/chef.yml`. Please make sure to use the year for the sponsor (just so that the old events don't end up with newer sponsor logos, etc - but don't make one just for your city). If there is an existing sponsor and you can use it, you do not need to create the data file (or the image). If your information is different, please create a new file, such as `data/sponsors/chefchicago.yml`.  (Note: there is an experimental feature for an "override" of the sponsor data; more on this feature as it is developed)
@@ -81,7 +93,7 @@ All logos will be constrained, via markup, to 100px square; combined with the im
 The program is driven by the program.md file in your event (copied from the [sample program.md](https://raw.githubusercontent.com/devopsdays/devopsdays-web/master/content/events/sample-event/program.md). To generate a data-driven program, look at the Minneapolis 2016 [speakers data files](https://github.com/devopsdays/devopsdays-web/tree/master/data/speakers/2016/minneapolis) and [program directory](https://github.com/devopsdays/devopsdays-web/tree/master/content/events/2016-minneapolis/program).
 
 ### Speaker Images
-The headshots for your speaker images should be exactly 500px wide (they display at 250px wide, but upload them at 500px wide in order to make them look good on retina displays). 
+The headshots for your speaker images should be exactly 500px wide (they display at 250px wide, but upload them at 500px wide in order to make them look good on retina displays). They must be in JPG format and named with the `.jpg` extension.
 
 ## Binary files
 
@@ -95,7 +107,7 @@ Generally speaking, you should avoid storing any files other than logos or small
 If you are going to be making changes to the overall functionality of the site, please keep the following in mind:
 
 ### Changes to content should be separate from overall functionality
-"Content" means anything inside the `/content/...`, `/data/...`, or `/static/...` directories. 
+"Content" means anything inside the `/content/...`, `/data/...`, or `/static/...` directories.
 
 Changes to content should be submitted as a separate PR from changes to site functionality. It would be additionally delightful if you label PR's for site functionality (such as `bug` or `enhancement`), but that's not required.
 

--- a/data/events/2016-chicago.yml
+++ b/data/events/2016-chicago.yml
@@ -1,6 +1,7 @@
 name: 2016-chicago
 year: "2016"
 city: "Chicago"
+displayname: "Windy City"
 friendly: "2016-chicago"
 status: "current"
 startdate: 2016-08-30
@@ -154,4 +155,3 @@ speakers:
 speaker_levels:
   - id: talk
     label: Talk
-

--- a/data/events/2016-chicago.yml
+++ b/data/events/2016-chicago.yml
@@ -1,7 +1,6 @@
 name: 2016-chicago
 year: "2016"
 city: "Chicago"
-displayname: "Windy City"
 friendly: "2016-chicago"
 status: "current"
 startdate: 2016-08-30

--- a/themes/devopsdays-responsive/layouts/partials/event_header.html
+++ b/themes/devopsdays-responsive/layouts/partials/event_header.html
@@ -10,12 +10,20 @@
 {{ $path := split $.Source.File.Path "/" }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
+{{ $citydisplay := "hello"}}
+{{ if $e.displayname }}
+  I have a display. It is {{ $e.displayname }}.
+  {{ $citydisplay := "MY CITY NAME"}}
+{{ else }}
+  I don't have a display
+  {{ $citydisplay := $e.city }}
+{{ end }}
 
 {{/* end site data query */}}
 
 <div class="row">
   <div class="col-md-8">
-    <h1>{{ $e.city }} {{ $e.year }} - {{ title .Title }}</h1>
+    <h1>{{ $citydisplay }} {{ $e.year }} - {{ title .Title }}</h1>
     <!-- Main navigation -->
     <div class = "event-navigation">
       <h3 class="event-navigation">

--- a/themes/devopsdays-responsive/layouts/partials/event_header.html
+++ b/themes/devopsdays-responsive/layouts/partials/event_header.html
@@ -10,20 +10,18 @@
 {{ $path := split $.Source.File.Path "/" }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
-{{ $citydisplay := "hello"}}
+{{ $citydisplay := $e.displayname }}
 {{ if $e.displayname }}
-  I have a display. It is {{ $e.displayname }}.
-  {{ $citydisplay := "MY CITY NAME"}}
+  {{ $.Scratch.Add "citydisplay" $e.displayname }}
 {{ else }}
-  I don't have a display
-  {{ $citydisplay := $e.city }}
+  {{ $.Scratch.Add "citydisplay" $e.city }}
 {{ end }}
 
 {{/* end site data query */}}
 
 <div class="row">
   <div class="col-md-8">
-    <h1>{{ $citydisplay }} {{ $e.year }} - {{ title .Title }}</h1>
+    <h1>{{ $.Scratch.Get "citydisplay" }} {{ $e.year }} - {{ title .Title }}</h1>
     <!-- Main navigation -->
     <div class = "event-navigation">
       <h3 class="event-navigation">

--- a/themes/devopsdays-responsive/layouts/partials/future.html
+++ b/themes/devopsdays-responsive/layouts/partials/future.html
@@ -26,7 +26,11 @@ through these lists to generate our event info.
                             {{ range sort $.Site.Data.events "startdate" }}
                               {{ if  and ( eq .status "current") ( .startdate ) }}
                               <a href = "/events/{{ .name }}/welcome">
-                                {{ .city }}
+                                {{ if .displayname }}
+                                  {{ .displayname }}
+                                {{ else }}
+                                  {{ .city }}
+                                {{ end }}
                                 {{ dateFormat "Jan 2" .startdate }}
                                 -
                                 {{ dateFormat "Jan 2" .enddate }}
@@ -38,7 +42,11 @@ through these lists to generate our event info.
                             {{ range sort $.Site.Data.events "startdate" }}
                               {{ if  and ( eq .status "current") ( not .startdate ) }}
                               <a href = "/events/{{ .name }}/welcome">
-                                {{ .city }}
+                                {{ if .displayname }}
+                                  {{ .displayname }}
+                                {{ else }}
+                                  {{ .city }}
+                                {{ end }}
                               </a><br />
                               {{ end }}
                             {{ end }}

--- a/themes/devopsdays-responsive/layouts/partials/past.html
+++ b/themes/devopsdays-responsive/layouts/partials/past.html
@@ -30,9 +30,13 @@ Chomping .year has the nice effect of turning an int into string. -->
         <!-- Finally, scan throug the scratch with the ID of that year and print all the events sorted by startdate
   Chomping here in order to convert int to string -->
         {{ range ($.Scratch.GetSortedMapValues (print (chomp .))) }}
-          {{ $city := (index $.Site.Data.events . "city") }}
-          {{ $friendly := (index $.Site.Data.events . "friendly") }}
-          <a href="/events/{{ $friendly }}/">{{ $city }}</a>
+          {{ if index $.Site.Data.events . "displayname" }}
+            {{ $.Scratch.Set "citydisplay" (index $.Site.Data.events . "displayname") }}
+          {{ else }}
+            {{ $.Scratch.Set "citydisplay" (index $.Site.Data.events . "city") }}
+          {{ end }}
+          {{ $friendly := (index $.Site.Data.events . "name") }}
+          <a href="/events/{{ $friendly }}/">{{ $.Scratch.Get "citydisplay" }}</a>
           <br/>
         {{ end }}
       </div>

--- a/themes/devopsdays-responsive/layouts/partials/upcoming_headline.html
+++ b/themes/devopsdays-responsive/layouts/partials/upcoming_headline.html
@@ -5,7 +5,11 @@
       {{ $.Scratch.Add "events" "<a href = '/events/" }}
       {{ $.Scratch.Add "events" .name }}
       {{ $.Scratch.Add "events" "/welcome' class = 'upcoming-headline'>" }}
-      {{ $.Scratch.Add "events" .city }}
+      {{ if .displayname }}
+        {{ $.Scratch.Add "events" .displayname }}
+      {{ else }}
+        {{ $.Scratch.Add "events" .city }}
+      {{ end }}
       {{ $.Scratch.Add "events" "</a> - " }}
     {{ end }}
   {{ end }}


### PR DESCRIPTION
This PR adds support for the (optional) `displayname` parameter in the event data file. If the `displayname` is set, this is what will be shown when the event is referenced (on the navigation menus, as well as on the main headers for the event page).

You should use the `displayname` parameter if your city has non-URL friendly characters, such as accented characters or spaces (i.e., "Zürich" or "Salt Lake City"). The name parameter should be set as `2016-zurich` or `2016-salt-lake-city` for example. Please also make sure that the "city" parameter is set with non-accented or space characters in this case as well.