### PR TITLE
Removing link to closed proposals.

### DIFF
--- a/content/events/2016-philadelphia/welcome.md
+++ b/content/events/2016-philadelphia/welcome.md
@@ -35,15 +35,6 @@ aliases = ["/events/2016-philadelphia"]
 
 <div class = "row">
   <div class = "col-md-2">
-    <strong>Propose</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="propose" text="Propose a talk!" >}}
-  </div>
-</div>
-
-<div class = "row">
-  <div class = "col-md-2">
     <strong>Register</strong>
   </div>
   <div class = "col-md-8">


### PR DESCRIPTION
Much like https://github.com/devopsdays/devopsdays-web/pull/780, this removes a misleading link (as proposals are closed). CCing @peterjshan for approval.