### PR TITLE
Add aliases for Baltimore 2016

### DIFF
--- a/content/events/2017-baltimore/conduct.md
+++ b/content/events/2017-baltimore/conduct.md
@@ -2,6 +2,10 @@
 date = "2016-05-20T09:31:15-04:00"
 title = "conduct"
 type = "event"
+aliases = [
+  "/events/2017-baltimore/conduct",
+  "/events/2016-baltimore/conduct"
+]
 
 +++
 

--- a/content/events/2017-baltimore/contact.md
+++ b/content/events/2017-baltimore/contact.md
@@ -2,7 +2,10 @@
 date = "2016-05-20T09:31:15-04:00"
 title = "contact"
 type = "event"
-
+aliases = [
+  "/events/2017-baltimore/contact",
+  "/events/2016-baltimore/contact"
+]
 
 +++
 

--- a/content/events/2017-baltimore/location.md
+++ b/content/events/2017-baltimore/location.md
@@ -2,6 +2,10 @@
 date = "2016-05-20T09:31:15-04:00"
 title = "location"
 type = "event"
+aliases = [
+  "/events/2017-baltimore/location",
+  "/events/2016-baltimore/location"
+]
 
 +++
 

--- a/content/events/2017-baltimore/program.md
+++ b/content/events/2017-baltimore/program.md
@@ -2,6 +2,10 @@
 date = "2016-05-20T09:31:15-04:00"
 title = "program"
 type = "event"
+aliases = [
+  "/events/2017-baltimore/program",
+  "/events/2016-baltimore/program"
+]
 
 +++
 

--- a/content/events/2017-baltimore/sponsor.md
+++ b/content/events/2017-baltimore/sponsor.md
@@ -2,6 +2,10 @@
 date = "2016-05-20T09:31:15-04:00"
 title = "sponsor"
 type = "event"
+aliases = [
+  "/events/2017-baltimore/sponsor",
+  "/events/2016-baltimore/sponsor"
+]
 
 +++
 

--- a/content/events/2017-baltimore/welcome.md
+++ b/content/events/2017-baltimore/welcome.md
@@ -2,7 +2,12 @@
 date = "2016-05-20T09:31:15-04:00"
 title = "welcome"
 type = "event"
-aliases = ["/events/2017-baltimore"]
+aliases = [
+  "/events/2017-baltimore",
+  "/events/2016-baltimore",
+  "/events/2017-baltimore/welcome",
+  "/events/2016-baltimore/welcome"
+]
 
 +++
 


### PR DESCRIPTION
The conference was postponed until 2017.

This change makes all of the old 2016 URLs redirect to the 2017 pages.

For example, /events/2016-baltimore/welcome/ now redirects to /events/2017-baltimore/welcome/.

Signed-off-by: Nathen Harvey <nharvey@chef.io>