### PR TITLE
Allowing multiple-word cities to work with speakers/talks

### DIFF
--- a/themes/devopsdays-responsive/layouts/speakers/single.html
+++ b/themes/devopsdays-responsive/layouts/speakers/single.html
@@ -11,7 +11,7 @@
 
  <!-- speaker page code begin -->
 
-  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (lower $e.city) }}
+  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (replace $e.city " " "" | lower) }}
 <div class="row">
     <div class="col-md-3">
         <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="img-responsive" width = "250px">

--- a/themes/devopsdays-responsive/layouts/talk/single.html
+++ b/themes/devopsdays-responsive/layouts/talk/single.html
@@ -19,7 +19,7 @@
    .Site.Data.events $e.year (printf "%s" (lower $e.city))
    - mattstratton
  */}}
- {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (lower $e.city) }}
+ {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (replace $e.city " " "" | lower) }}
    {{ if eq $fname ($.LinkTitle | urlize) }}
 <hr>
 <div class="row">


### PR DESCRIPTION
Still doesn't handle special characters. Should fix via event slug. But at least this band-aids the current badness with slightly less badness.

Specifically, this allows speaker data to show up on speaker pages and talk pages if the city has a multi-word name. It doesn't introduce regression for single-word names as far as my checks show.