### PR TITLE
Better signalling of the TVA id *before* ordering the tickets

### DIFF
--- a/content/events/2016-ghent/welcome.md
+++ b/content/events/2016-ghent/welcome.md
@@ -87,11 +87,6 @@ aliases = ["/events/2016-ghent"]
 <br/>
 <br/>
 
-<div style="width:100%; text-align:left;" ><iframe  src="//eventbrite.co.uk/tickets-external?eid=26322043942&ref=etckt" frameborder="0" height="293" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:10px; padding:5px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #dddddd; text-decoration: none;" target="_blank" href="http://www.eventbrite.co.uk/l/registration-online/">Powered by Eventbrite</a></div></div>
-
-<br/>
-<br/>
-
 <p>The DevOpsDays Belgium team didn't want to wait another 5 years to bring the conference back to Belgium.</p>
 <div>
   <div>
@@ -107,5 +102,8 @@ aliases = ["/events/2016-ghent"]
   </div>
 </div>
 
+<div style="width:100%; text-align:left;" ><iframe  src="//eventbrite.co.uk/tickets-external?eid=26322043942&ref=etckt" frameborder="0" height="293" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:10px; padding:5px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #dddddd; text-decoration: none;" target="_blank" href="http://www.eventbrite.co.uk/l/registration-online/">Powered by Eventbrite</a></div></div>
+
+<br/>
 
 {{< event_twitter devopsdays >}}

--- a/content/events/2016-ghent/welcome.md
+++ b/content/events/2016-ghent/welcome.md
@@ -85,7 +85,6 @@ aliases = ["/events/2016-ghent"]
 </div>
 
 <br/>
-<br/>
 
 <p>The DevOpsDays Belgium team didn't want to wait another 5 years to bring the conference back to Belgium.</p>
 <div>
@@ -101,6 +100,8 @@ aliases = ["/events/2016-ghent"]
     </p>
   </div>
 </div>
+
+<br/>
 
 <div style="width:100%; text-align:left;" ><iframe  src="//eventbrite.co.uk/tickets-external?eid=26322043942&ref=etckt" frameborder="0" height="293" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:10px; padding:5px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #dddddd; text-decoration: none;" target="_blank" href="http://www.eventbrite.co.uk/l/registration-online/">Powered by Eventbrite</a></div></div>
 


### PR DESCRIPTION
I moved the Eventbrite iframe down in the content to make sure everyone reads the note about the TVA id *before* they start booking tickets.