### PR TITLE
Updating core team

### DIFF
--- a/content/page/contact.md
+++ b/content/page/contact.md
@@ -7,26 +7,12 @@ Title = "Contact devopsdays"
 
 +++
 
-The devopsdays global core team helps local organizers host their own devopsdays events worldwide. The core team consists of the following people:
+Organization is decentralized. Local events handle their own sponsorships, registration, and all other organization. For questions about a specific event you see listed on the site, contact the local organizers for that event; their email is on their contact page.
 
-- Patrick Debois
-- John Willis
-- Damon Edwards
-- Kris Buytaert
-- John Vincent
-- Andrew Shafer
-- Lindsay Holmwood
-- Stephen Nelson-Smith
-- Christian Trabold
-- James Wickett
-- Anthony Goddard
-- Bernd Erk (January 2015-present)
-- Bridget Kromhout (January - 2015-present)
-- Jennifer Davis (November 2015-present)
+The devopsdays global core team guides local organizers in hosting their own devopsdays events worldwide.
 
-Organization is decentralized, so each individual event handles their own sponsorships, registration, and so forth. For questions about a specific event you see listed on the site, please contact the organizers for that event.
+**Core Organizers**
 
-If you have other questions (such as inquiries about hosting your own event or about potential future events you don't see on the site), the core organizers are happy to hear from you:
+{{< list_core >}}
 
-- Email: [info@devopsdays.org](mailto:info@devopsdays.org)
-- Twitter: [@devopsdays](https://twitter.com/devopsdays)
+If you have questions about hosting your own event or about potential future events you don't see listed, [email the core organizers](mailto:info@devopsdays.org). The core organizers cannot answer questions about sponsorships or registration for individual cities.

--- a/layouts/shortcodes/list_core.html
+++ b/layouts/shortcodes/list_core.html
@@ -1,16 +1,4 @@
-<ul>
-<li>Patrick Debois</li>
-<li>John Willis</li>
-<li>Damon Edwards</li>
-<li>Kris Buytaert</li>
-<li>John Vincent</li>
-<li>Andrew Shafer</li>
-<li>Lindsay Holmwood</li>
-<li>Stephen Nelson-Smith</li>
-<li>Christian Trabold</li>
-<li>James Wickett</li>
-<li>Anthony Goddard</li>
-<li>Bernd Erk (January 2015-present)</li>
-<li>Bridget Kromhout (January 2015-present)</li>
-<li>Jennifer Davis (November 2015-present)</li>
-</ul>
+<em>Active</em><br>
+Bridget Kromhout (lead), Kris Buytaert, Jennifer Davis, Bernd Erk, Dan Maher, Matt Stratton, John Willis<br>
+<em>Historic</em><br>
+Patrick Debois (founder), Damon Edwards, Anthony Goddard, Lindsay Holmwood, Gildas Le Nadan, Stephen Nelson-Smith, Andrew Clay Shafer, Julian Simpson, Christian Trabold, John Vincent, James Wickett


### PR DESCRIPTION
Per discussion with the core team, redefining roles and add @mattstratton plus @phrawzty.