### PR TITLE
Update footer links/icons

### DIFF
--- a/themes/devopsdays-responsive/layouts/partials/footer.html
+++ b/themes/devopsdays-responsive/layouts/partials/footer.html
@@ -2,8 +2,8 @@
     <div class="footer">
       <div>
           <a class = "social-links" href="{{ .Site.Params.Twitter }}"><i class="fa fa-twitter-square fa-2x"></i></a>
-          <a class = "social-links"  href="http://groups.google.com/group/devopsdays"><i class="fa fa-envelope fa-2x"></i></a>
-          <a class = "social-links" href="http://www.linkedin.com/groups?home=&gid=2445279"><i class="fa fa-linkedin fa-2x"></i></a>
+          <a class = "social-links"  href="/contact"><i class="fa fa-envelope fa-2x"></i></a>
+          <a class = "social-links" href="/index.xml"><i class="fa fa-rss fa-2x"></i></a>
       </div>
     </div>
     {{ partial "footer_scripts" . }}

--- a/themes/devopsdays-responsive/layouts/partials/footer.html
+++ b/themes/devopsdays-responsive/layouts/partials/footer.html
@@ -3,7 +3,7 @@
       <div>
           <a class = "social-links" href="{{ .Site.Params.Twitter }}"><i class="fa fa-twitter-square fa-2x"></i></a>
           <a class = "social-links"  href="/contact"><i class="fa fa-envelope fa-2x"></i></a>
-          <a class = "social-links" href="/index.xml"><i class="fa fa-rss fa-2x"></i></a>
+          <a class = "social-links" href="/blog/index.xml"><i class="fa fa-rss fa-2x"></i></a>
       </div>
     </div>
     {{ partial "footer_scripts" . }}


### PR DESCRIPTION
DO NOT MERGE until #877 is resolved.

1. Change email envelope icon to point to “Contact” page instead of Google Group
2. Remove LinkedIn group link/icon
3. Add RSS icon pointing to feed

Fixes #859