### PR TITLE
Refactor past and future to use date fields

### DIFF
--- a/data/events/2012-newyork.yml
+++ b/data/events/2012-newyork.yml
@@ -1,6 +1,7 @@
 name: "2012-newyork" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
-year: 2012 # The year of the event. Make sure it is in quotes.
+year: 2013 # The year of the event. Make sure it is in quotes.
 city: "New York" # The city name of the event. Capitalize it.
+displayname: "New York (Winter)"
 friendly: "2012-newyork" # Four digit year and the city name in lower-case. Don't forget the dash!
 status: "past" # Options are "past" or "current". Use "current" for upcoming.
 

--- a/data/events/2013-newyork.yml
+++ b/data/events/2013-newyork.yml
@@ -1,6 +1,7 @@
 name: "2013-newyork" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: 2013 # The year of the event. Make sure it is in quotes.
 city: "New York" # The city name of the event. Capitalize it.
+displayname: "New York (Fall)"
 friendly: "2013-newyork" # Four digit year and the city name in lower-case. Don't forget the dash!
 status: "past" # Options are "past" or "current". Use "current" for upcoming.
 
@@ -27,4 +28,3 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: sponsor
   - name: contact
   - name: conduct
-

--- a/data/events/2013-newyork.yml
+++ b/data/events/2013-newyork.yml
@@ -3,7 +3,7 @@ year: 2013 # The year of the event. Make sure it is in quotes.
 city: "New York" # The city name of the event. Capitalize it.
 displayname: "New York (Fall)"
 friendly: "2013-newyork" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "past" # Options are "past" or "current". Use "current" for upcoming.
+status: "past" # Options are "past" or "current". Use "current" for upcoming
 
 # All dates are in unquoted 2013-MM-DD, like this:   variable: 2016-01-05
 startdate: 2013-10-17

--- a/themes/devopsdays-responsive/layouts/partials/future.html
+++ b/themes/devopsdays-responsive/layouts/partials/future.html
@@ -24,16 +24,16 @@ through these lists to generate our event info.
                         <div style="margin:1px;">
                             <strong>2016 - 2017</strong><br/>
                             {{ range sort $.Site.Data.events "startdate" }}
-                              {{ if  and ( eq .status "current") ( .startdate ) }}
+                              {{ if  and ( .startdate ) ( ge (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) ) }}
                               <a href = "/events/{{ .name }}/welcome">
                                 {{ if .displayname }}
                                   {{ .displayname }}
                                 {{ else }}
                                   {{ .city }}
                                 {{ end }}
-                                {{ dateFormat "Jan 2" .startdate }}
+                                {{ dateFormat "Jan 2, 2006" .startdate }}
                                 -
-                                {{ dateFormat "Jan 2" .enddate }}
+                                {{ dateFormat "Jan 2, 2006" .enddate }}
                               </a><br />
                               {{ end }}
                             {{ end }}

--- a/themes/devopsdays-responsive/layouts/partials/past.html
+++ b/themes/devopsdays-responsive/layouts/partials/past.html
@@ -9,9 +9,10 @@ Chomping .year has the nice effect of turning an int into string. -->
 {{ range seq 2009 2020 }}
   {{ $r_year := . }}
   {{ range $.Site.Data.events }}
-    {{ if and (eq .year $r_year) (eq .status "past")  }}
-      {{ $.Scratch.SetInMap "active_years" (print (chomp .year)) (print (chomp .year)) }}
-      {{ $.Scratch.SetInMap (print (chomp .year)) .startdate (.name) }}
+  {{ $my_year := string ((dateFormat "2006" .startdate ))}}
+    {{ if and (eq $my_year (string $r_year)) ( lt (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")))  }}
+      {{ $.Scratch.SetInMap "active_years" (print (chomp $my_year)) (print (chomp $my_year)) }}
+      {{ $.Scratch.SetInMap (print (chomp $my_year)) .startdate (.name) }}
     {{ end }}
   {{ end }}
 {{ end }}

--- a/themes/devopsdays-responsive/layouts/partials/past.html
+++ b/themes/devopsdays-responsive/layouts/partials/past.html
@@ -1,4 +1,4 @@
-<!-- The following blocks of comments explains how this list is generated with Hugo.
+ <!-- The following blocks of comments explains how this list is generated with Hugo.
 If you read this post generation, it will make no sense. see pre generated sources -->
 
 <!-- Scan through a range of years and look in data/events for events during these years.
@@ -25,7 +25,7 @@ Chomping .year has the nice effect of turning an int into string. -->
 <div class = "row">
   <!-- Now scan through all the years that were marked as active in order to print the headline -->
   {{ range ($.Scratch.GetSortedMapValues "active_years") }}
-    <div class = "col-md-3">
+    <div class = "col-md-4">
       <strong>{{ . }}</strong>
       <br/>
         <!-- Finally, scan throug the scratch with the ID of that year and print all the events sorted by startdate


### PR DESCRIPTION
Do not merge this yet - the /events page is displaying oddly,and it’s somehow due to the two New Yorks. If you change the startdate of New York (Winter) to be in 2012, everything lays out properly.

Fixes #882 