### PR TITLE
Ignore a script that updates the ulimit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ $RECYCLE.BIN/
 *.lnk
 node_modules
 _mdwriter.cson
+
+# A script to update the ulimt for OS X
+increase_ulimit.sh


### PR DESCRIPTION
I always have to copy-n-paste out ulimit fixes out of the README

I've added a local bash script that will do this for me but not sure if
everyone wants this in the repo.

Here's what the script contains, I'm happy to add it if there's
interest:

```
#!/bin/bash
sysctl -w kern.maxfiles=65536
sysctl -w kern.maxfilesperproc=65536
ulimit -n 65536 65536
```

Signed-off-by: Nathen Harvey <nharvey@chef.io>