### PR TITLE
clarify Matt's web team role

### DIFF
--- a/layouts/shortcodes/list_core.html
+++ b/layouts/shortcodes/list_core.html
@@ -1,5 +1,5 @@
 <em>Active</em><br>
-Bridget Kromhout (lead), Kris Buytaert, Jennifer Davis, Bernd Erk, Dan Maher, Matt Stratton, John Willis<br>
+Bridget Kromhout (lead), Kris Buytaert, Jennifer Davis, Bernd Erk, Dan Maher, Matt Stratton (web team lead), John Willis<br>
 <br>
 <em>Historic</em><br>
 Patrick Debois (founder), Damon Edwards, Anthony Goddard, Lindsay Holmwood, Gildas Le Nadan, Stephen Nelson-Smith, Andrew Clay Shafer, Julian Simpson, Christian Trabold, John Vincent, James Wickett


### PR DESCRIPTION
Clarify that @mattstratton leads the devopsdays.org web team.