### PR TITLE
Set google maps url to SSL version

### DIFF
--- a/themes/devopsdays-responsive/layouts/partials/map.html
+++ b/themes/devopsdays-responsive/layouts/partials/map.html
@@ -60,7 +60,7 @@ function initialize() {
       };
 </script>
 
-<script type="text/javascript" src="https://maps.google.com/maps/api/js?key=AIzaSyC1bvNK9qFJGEhoWNbQuojmJJ1Tg0DoOew&sensor=false"></script>
+<script type="text/javascript" src="https://maps-api-ssl.google.com/maps/api/js?key=AIzaSyC1bvNK9qFJGEhoWNbQuojmJJ1Tg0DoOew"></script>
 <script type="text/javascript" src="/js/googlemaps_label.js"></script>
 <!-- <script type="text/javascript" src="/js/googlemaps_content.js"></script> -->
 <div class="embed-responsive embed-responsive-16by9">


### PR DESCRIPTION
This still doesn’t fix the mixed-mode error, but it’s the way Google says to do it.