### PR TITLE
Add subject capability to email shortcodes

### DIFF
--- a/content/events/2016-chicago/contact.md
+++ b/content/events/2016-chicago/contact.md
@@ -5,7 +5,7 @@ type = "event"
 
 +++
 
-If you'd like to contact us by email: {{< email_organizers >}}
+If you'd like to contact us by email: {{< email_organizers subject="DevOpsDays Chicago">}}
 
 **Our local team**
 

--- a/layouts/shortcodes/email_organizers.html
+++ b/layouts/shortcodes/email_organizers.html
@@ -1,4 +1,4 @@
 {{ $path := split .Page.Source.File.Path "/" }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
-<a href='mailto:{{ $e.organizer_email }}'>{{ $e.organizer_email }}</a>
+<a href='mailto:{{ $e.organizer_email }}?subject={{ .Get "subject"}}'>{{ $e.organizer_email }}</a>

--- a/layouts/shortcodes/email_proposals.html
+++ b/layouts/shortcodes/email_proposals.html
@@ -2,4 +2,4 @@
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 
-<a href='mailto:{{ $e.proposal_email }}'>{{ $e.proposal_email }}</a>
+<a href='mailto:{{ $e.proposal_email }}?subject={{ .Get "subject"}}'>{{ $e.proposal_email }}</a>


### PR DESCRIPTION
The `email_proposals` and `email_organizers` shortcodes now take an optional parameter of “subject”, which will be the subject of the email.

See the Contact page for 2016-Chicago for an example.

Fixeds #262 