### PR TITLE
Moving embedded tweets to @devopsdays.

### DIFF
--- a/themes/devopsdays-responsive/layouts/index.html
+++ b/themes/devopsdays-responsive/layouts/index.html
@@ -7,9 +7,9 @@
     {{ partial "map.html" .}}
   </div>
   <div class="col-md-4">
-    <a href="https://twitter.com/devopsdaysmsp/lists/devopsdays"><h4>Tweets from devopsdays events</h4></a>
+    <a href="https://twitter.com/devopsdays/lists/devopsdays"><h4>Tweets from devopsdays events</h4></a>
     <div>
-    <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/devopsdaysmsp/lists/devopsdays" data-widget-id="720829916510466048" data-chrome="noheader" height="440"></a>
+    <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/devopsdays/lists/devopsdays" data-chrome="noheader" height="440"></a>
 
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     </div>


### PR DESCRIPTION
Moving embedded tweets to @devopsdays.

* No longer requires data-widget-id
* Now can be maintained by all core organizers