### PR TITLE
Speakers can have special characters in names.

### DIFF
--- a/utilities/add_speakers.sh
+++ b/utilities/add_speakers.sh
@@ -62,6 +62,7 @@ cp examples/speakers/speaker-full-name.jpg ../static/events/$event_slug/speakers
 cp examples/speakers/speaker-full-name.md ../content/events/$event_slug/program/$speaker_slug.md
 
 sed -i '' "s/SPEAKERNAME/$speakername/" ../content/events/$event_slug/program/$speaker_slug.md
+sed -i '' "s/SPEAKERSLUG/$speaker_slug/" ../content/events/$event_slug/program/$speaker_slug.md
 sed -i '' "s/TITLE/$title/" ../content/events/$event_slug/program/$speaker_slug.md
 sed -i '' "s/ABSTRACT/$abstract/" ../content/events/$event_slug/program/$speaker_slug.md
 

--- a/utilities/examples/speakers/speaker-full-name.md
+++ b/utilities/examples/speakers/speaker-full-name.md
@@ -1,5 +1,6 @@
 +++
 date = "2000-01-01T01:01:01-06:00"
+linktitle = "SPEAKERSLUG"
 title = "SPEAKERNAME"
 type = "talk"
 


### PR DESCRIPTION
Adding `linktitle` per https://gohugo.io/templates/variables/ instead of only having `title`, because of the possibility of special characters in the title. This is set and working correctly for http://www.devopsdays.org/events/2016-chicago/program/abejide-ayodele/.