### PR TITLE
Multiple speakers

### DIFF
--- a/themes/devopsdays-responsive/layouts/talk/single.html
+++ b/themes/devopsdays-responsive/layouts/talk/single.html
@@ -21,7 +21,7 @@
    - mattstratton
  */}}
  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) $city_slug }}
-   {{ if in $.LinkTitle $fname }}
+   {{ if in ($.LinkTitle | urlize) $fname }}
 <hr>
 <div class="row">
     <div class="col-md-3">

--- a/themes/devopsdays-responsive/layouts/talk/single.html
+++ b/themes/devopsdays-responsive/layouts/talk/single.html
@@ -21,7 +21,7 @@
    - mattstratton
  */}}
  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) $city_slug }}
-   {{ if eq $fname ($.LinkTitle | urlize) }}
+   {{ if in $.LinkTitle $fname }}
 <hr>
 <div class="row">
     <div class="col-md-3">


### PR DESCRIPTION
How this works (based on discussion in https://github.com/devopsdays/devopsdays-web/issues/708):

Previously, it was checking to see if the speaker-name filename of the speaker data file matched the urlized "Speaker Name" in the title frontmatter of the talk file - nothing was using linkdata.

Now, it's checking to see if the speaker-name filename of the speaker data file is _in_ the linkdata (which may be the urlized "Speaker Name" in the frontmatter of the talk file, but can also be a collection of as many speaker names as is desired), and all their bios will show up.

Example:

filename:
content/events/2016-city/program/name-one-name-two.md

frontmatter:
title = "Name One & Name Two"
linktitle = "name-one, name-two"
aliases = ["/events/2016-newyork/program/name-one/", "/events/2016-newyork/program/name-two/"]
