### PR TITLE
remove base href tag

### DIFF
--- a/themes/devopsdays-responsive/layouts/partials/head.html
+++ b/themes/devopsdays-responsive/layouts/partials/head.html
@@ -5,7 +5,7 @@
 {{ partial "meta.html" . }}
 {{ partial "head/seo.html" . }}
 {{ .Hugo.Generator }}
-<base href="{{ .Site.BaseURL }}">
+<!-- <base href="{{ .Site.BaseURL }}"> -->
 <title>
 {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}
 {{ if eq $url "/" }}


### PR DESCRIPTION
This shouldn’t break anything. But if it does, it’s just commented out in `themes/devopsdays-responsive/partials/head.html`

fixes #969