### PR TITLE
Add basic structured metadata to event pages for Google

### DIFF
--- a/themes/devopsdays-responsive/layouts/event/single.html
+++ b/themes/devopsdays-responsive/layouts/event/single.html
@@ -5,5 +5,6 @@
 </div> <!-- closes the col-md-8 div from event_header -->
 {{ partial "sponsors.html" . }}
 </div> <!-- closes the row div -->
+{{- partial "event_metadata.html" . -}}
 
 {{ partial "footer.html" . }}

--- a/themes/devopsdays-responsive/layouts/partials/event_metadata.html
+++ b/themes/devopsdays-responsive/layouts/partials/event_metadata.html
@@ -1,0 +1,26 @@
+{{/* site data query copypasta from event/single.html, per mattstratton's note - esigler */}}
+{{ $path := split $.Source.File.Path "/" }}
+{{ $event_slug := index $path 1 }}
+{{ $e :=  (index $.Site.Data.events $event_slug) }}
+{{/* end site data query */}}
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "ExhibitionEvent",
+  "name": "DevOpsDays {{ $e.city }} {{ $e.year }}",
+  "startDate": "{{ $e.startdate }}",
+  "endDate": "{{ $e.enddate }}",
+  "url": {{ .Permalink }},
+  "image": {{ string ( delimit ( slice "/events/" $event_slug "/logo.png") "" ) | absURL }},
+  "location": {
+    "@type": "Place",
+    {{ if eq $e.city $e.location }}
+      "name": "{{ $e.city }}",
+    {{ else }}
+      "name": "{{ $e.location }}, {{ $e.city }}",
+    {{ end }}
+    "address": "{{ $e.coordinates }}"
+  }
+}
+</script>

--- a/themes/devopsdays-responsive/layouts/partials/event_metadata.html
+++ b/themes/devopsdays-responsive/layouts/partials/event_metadata.html
@@ -8,6 +8,11 @@
 {
   "@context": "http://schema.org",
   "@type": "ExhibitionEvent",
+  {{ if and ($e.description) (ne $e.description "") }}
+    "description": "{{ $e.description }}",
+  {{ else }}
+    "description": "The conference that brings development and operations together.",
+  {{ end }}
   "name": "DevOpsDays {{ $e.city }} {{ $e.year }}",
   "startDate": "{{ $e.startdate }}",
   "endDate": "{{ $e.enddate }}",

--- a/utilities/examples/yyyy-city.yml
+++ b/utilities/examples/yyyy-city.yml
@@ -2,6 +2,7 @@ name: "yyyy-city" # The name of the event. Four digit year with the city name in
 year: "YYYY" # The year of the event. Make sure it is in quotes.
 city: "City" # The displayed city name of the event. Capitalize it.
 status: "current" # Options are "past" or "current". Use "current" for upcoming.
+description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.


### PR DESCRIPTION
Howdy!

This change puts in the basics for JSON-LD metadata on an event page, with
a little bit of logic for if the city has been duplicated into the location.
Concatenating the image URL together took far longer than I want to admit.

Are there other types of metadata that y'all would want included?  If the
address was available in the event yaml, that might surface up better in 
search results?

Example output on what would be https://www.devopsdays.org/events/2016-chicago/welcome/:

```
<script type="application/ld+json">
{
  "@context": "http://schema.org",
  "@type": "ExhibitionEvent",
  "name": "DevOpsDays Chicago 2016",
  "startDate": "2016-08-30",
  "endDate": "2016-08-31",
  "url": "https://devopsdays.org/events/2016-chicago/welcome/",
  "image": "https://devopsdays.org/events/2016-chicago/logo.png",
  "location": {
    "@type": "Place",
    "name": "Summit West, Chicago",
    "address": "41.882219, -87.640530"
  }
}
</script>
```

Addresses https://github.com/devopsdays/devopsdays-web/issues/799