### PR TITLE
[2016-BNA] Removing CFP for event

### DIFF
--- a/content/events/2016-nashville/propose.md
+++ b/content/events/2016-nashville/propose.md
@@ -9,6 +9,8 @@ type = "event"
   {{< cfp_dates >}}
 
 <hr>
+Our CFP has now ended. Thank you to all those who submitted!
+<hr>
 There are three ways to propose a session:
 <ol>
   <li><strong><em>A proposal for a talk/panel</em></strong> during the conference part : these are 30 minute slots that will have the full attention of all attendees, as everybody will be in that one room.</li>


### PR DESCRIPTION
This PR adds a note to the Propose page for 2016-BNA that the CFP has ended.