### PR TITLE
(GH989) Fix building Hugo website on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: 1.0.{build}
+install:
+#  Install Hugo from chocolatey and display the version number
+- cmd: >-
+    choco install hugo -y
+
+    hugo version
+
+# Change the Path seperator to a Windows version (backslash)    
+- ps: >-
+    $buildRoot = $ENV:APPVEYOR_BUILD_FOLDER
+
+    $content = (Get-Content ($buildRoot + '\config.toml')) -join "`n"
+
+    $content = $content -replace 'PathSeperator = "/"','PathSeperator = "\\"'
+
+    Write-Output "config.toml content changed to:`n----`n$($content)"
+
+    $content | Set-Content ($buildRoot + '\config.toml')
+
+build_script:
+#  Build the devopsdays-web site once
+- cmd: >-
+    hugo --verbose
+
+test: off

--- a/config.toml
+++ b/config.toml
@@ -19,3 +19,7 @@ buildDrafts = false
 	Twitter = "http://www.twitter.com/devopsdays"
 	Linkedin = "http://www.linkedin.com/groups?home=&gid=2445279"
 	Groups = "http://groups.google.com/group/devopsdays"
+
+	# Set to "/" on *nix and Mac, "\\" on Windows
+	# Refer to https://github.com/spf13/hugo/issues/2394 for more information
+	PathSeperator = "/"

--- a/layouts/shortcodes/cfp_dates.html
+++ b/layouts/shortcodes/cfp_dates.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 

--- a/layouts/shortcodes/email_organizers.html
+++ b/layouts/shortcodes/email_organizers.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 <a href='mailto:{{ $e.organizer_email }}?subject={{ .Get "subject"}}'>{{ $e.organizer_email }}</a>

--- a/layouts/shortcodes/email_proposals.html
+++ b/layouts/shortcodes/email_proposals.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 

--- a/layouts/shortcodes/event_end.html
+++ b/layouts/shortcodes/event_end.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 {{ $enddate := $e.enddate}}

--- a/layouts/shortcodes/event_link.html
+++ b/layouts/shortcodes/event_link.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 
 <a href = "/events/{{ $event_slug }}/{{ .Get "page" }}">{{ .Get "text" }}</a>

--- a/layouts/shortcodes/event_location.html
+++ b/layouts/shortcodes/event_location.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 <a href = "/events/{{ $event_slug }}/location">{{ $e.location }}</a>

--- a/layouts/shortcodes/event_logo.html
+++ b/layouts/shortcodes/event_logo.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 

--- a/layouts/shortcodes/event_map.html
+++ b/layouts/shortcodes/event_map.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 

--- a/layouts/shortcodes/event_start.html
+++ b/layouts/shortcodes/event_start.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 {{ $startdate := $e.startdate}}

--- a/layouts/shortcodes/list_organizers.html
+++ b/layouts/shortcodes/list_organizers.html
@@ -1,4 +1,4 @@
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 

--- a/themes/devopsdays-responsive/layouts/partials/event_header.html
+++ b/themes/devopsdays-responsive/layouts/partials/event_header.html
@@ -7,7 +7,7 @@
   it and paste it. Need to figure out if a partial would expose the variables/elements/array created herein. It could be done in a partial (need to include the trailing .) but I don't think it would work in shortcodes, which is where we need it the most - mattstratton
 */}}
 
-{{ $path := split $.Source.File.Path "/" }}
+{{ $path := split $.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
 {{ $.Scratch.Add "citydisplay" $e.city }}

--- a/themes/devopsdays-responsive/layouts/partials/event_metadata.html
+++ b/themes/devopsdays-responsive/layouts/partials/event_metadata.html
@@ -1,5 +1,5 @@
 {{/* site data query copypasta from event/single.html, per mattstratton's note - esigler */}}
-{{ $path := split $.Source.File.Path "/" }}
+{{ $path := split $.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
 {{/* end site data query */}}

--- a/themes/devopsdays-responsive/layouts/partials/googleanalytics.html
+++ b/themes/devopsdays-responsive/layouts/partials/googleanalytics.html
@@ -11,7 +11,7 @@
 
 {{ if isset .Params "year" }}
 
-  {{ $path := split $.Source.File.Path "/" }}
+  {{ $path := split $.Source.File.Path .Site.Params.PathSeperator }}
   {{ $event_slug := index $path 1 }}
   {{ $event := (print .Params.year (lower .Params.city)) }}
   {{ $e :=  (index $.Site.Data.events $event_slug) }}

--- a/themes/devopsdays-responsive/layouts/partials/sponsors.html
+++ b/themes/devopsdays-responsive/layouts/partials/sponsors.html
@@ -1,4 +1,4 @@
-{{ $path := split $.Source.File.Path "/" }}
+{{ $path := split $.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
 

--- a/themes/devopsdays-responsive/layouts/shortcodes/program_entry.html
+++ b/themes/devopsdays-responsive/layouts/shortcodes/program_entry.html
@@ -1,5 +1,5 @@
 <!-- this div is repeated for each timeslot -->
-{{ $path := split .Page.Source.File.Path "/" }}
+{{ $path := split .Page.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
 {{ $city_slug := substr $e.name 5 }}

--- a/themes/devopsdays-responsive/layouts/speakers/single.html
+++ b/themes/devopsdays-responsive/layouts/speakers/single.html
@@ -1,6 +1,6 @@
 {{ partial "event_header.html" . }}
 
-{{ $path := split $.Source.File.Path "/" }}
+{{ $path := split $.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
 {{ $city_slug := substr $e.name 5 }}

--- a/themes/devopsdays-responsive/layouts/talk/single.html
+++ b/themes/devopsdays-responsive/layouts/talk/single.html
@@ -1,6 +1,6 @@
 {{ partial "event_header.html" . }}
 
-{{ $path := split $.Source.File.Path "/" }}
+{{ $path := split $.Source.File.Path .Site.Params.PathSeperator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
 {{ $city_slug := substr $e.name 5 }}


### PR DESCRIPTION
Previously the `File.Path` property would use OS dependant path seperator, back
slash on Windows and forward slash on *nix and Mac.  However as we are parsing
the event slug based on a path splitting this is problematic.

This commit changes the path splitting character to a Site level parameter which
can be changed prior to building via Hugo. The default value should be set to
`/` otherwise all of the building automation will fail, amongst other things.

A later commit will add documentation around this configuration item.
