### PR TITLE
[2016-BNA] Adding NetApp as sponsor

### DIFF
--- a/data/events/2016-nashville.yml
+++ b/data/events/2016-nashville.yml
@@ -51,6 +51,8 @@ sponsors: # List all of your sponsors here along with what level of sponsorship 
     level: beverage
   - id: pivotal
     level: gold
+  - id: netapp
+    level: silver
 sponsor_levels: # In this section, list the level of sponsorships and the label to use.
   - id: gold
     label: Gold


### PR DESCRIPTION
This commits adds NetApp as a silver sponsor to the 2016 DevOpsDays Nashville conf.