### PR TITLE
create_sponsors.sh: Support logo paths with whitespace

### DIFF
--- a/utilities/create_sponsors.sh
+++ b/utilities/create_sponsors.sh
@@ -42,7 +42,7 @@ sed -i '' "s%URL%$url%" ../data/sponsors/$sponsor_slug.yml
 
 # Set logo
 
-cp $logo ../static/img/sponsors/$sponsor_slug.png
+cp "$logo" ../static/img/sponsors/$sponsor_slug.png
 
 echo "Add this to ../data/events/"$event_slug".yml under sponsors:"
 echo "  - id: " $sponsor_slug


### PR DESCRIPTION
This is useful when storing files on Google Drive for example:

    ~/Google\ Drive/DOD/sponsors/example.png

The whitespace issue hit me when I was dragging a file from Google Drive onto the terminal to set the logo path – the script just crashed  :collision: