### PR TITLE
Remove Chef as Honorary Sponsor of Havana

### DIFF
--- a/data/events/2016-cuba.yml
+++ b/data/events/2016-cuba.yml
@@ -63,8 +63,6 @@ sponsors:
     level: honorary
   - id: itrevolution
     level: honorary
-  - id: chef
-    level: honorary
   - id: ado
     level: honorary
   - id: seekatv


### PR DESCRIPTION
The US Embargo does not permit U.S. companies to sponsor conferences in Cuba at this time.

Signed-off-by: Nathen Harvey <nharvey@chef.io>