### PR TITLE
[2016-BNA] Swapping Keynotes due to scheduling conflicts

### DIFF
--- a/content/events/2016-nashville/program.md
+++ b/content/events/2016-nashville/program.md
@@ -50,7 +50,7 @@ type = "event"
         <time>09:15-10:00</time>
       </div>
       <div class = "col-md-6 box">
-        <a href="/events/2016-nashville/program/jill-jubinski">Jill Jubinski - Raised This Way: DevOps Lessons I Learned From My Family</a>
+        <a href="/events/2016-nashville/program/andrew-clay-shafer">Andrew Clay Shafer - Chop Wood, Carry Water</a>
       </div>
     </div> <!-- end timeslot div -->
     <!-- this div is repeated for each timeslot -->
@@ -235,7 +235,7 @@ type = "event"
         <time>09:15-10:00</time>
       </div>
       <div class = "col-md-6 box">
-        <a href="/events/2016-nashville/program/andrew-clay-shafer">Andrew Clay Shafer - TBD</a>
+        <a href="/events/2016-nashville/program/jill-jubinski">Jill Jubinski - Raised This Way: DevOps Lessons I Learned From My Family</a>
       </div>
     </div> <!-- end timeslot div -->
     <!-- this div is repeated for each timeslot -->

--- a/content/events/2016-nashville/program/andrew-clay-shafer.md
+++ b/content/events/2016-nashville/program/andrew-clay-shafer.md
@@ -9,14 +9,13 @@ type = "talk"
 <div class="span-15  ">
   <div class="span-15  last ">
   <p><strong>Title:</strong>
-  TBD
+  Chop Wood, Carry Water
 </p>
 
-<p><strong>Bio:</strong></p>
+<p><strong>Description:</strong></p>
 
 <p>
- Andrew Clay Shafer has built a career helping people improve technology and processes for delivering software services. As a co-founder of Puppet Labs, he evangelized devops practices and tools before devops was a word. He got first hand experience implementing and operating cloud infrastructure as the the VP of Engineering at Cloudscaling. Now at Pivotal, Andrew focuses on helping the Cloud Foundry ecosystem and Pivotal customers leverage platforms to build the future.
-
+Everyone is looking for the secret techniques, the one true way. Devops never had secrets, with the possible exception of the secret everyone is hiding, devops is hard. The search for secrets leads to nowhere. Now we better get back to work.
 </p>
 <p>
 


### PR DESCRIPTION
Due to some scheduling conflicts, this PR updates our schedule to swap out Keynotes on Nov 10/11.
