### PR TITLE
[2016-BNA] Adding Comcast as WiFi sponsor

### DIFF
--- a/data/events/2016-nashville.yml
+++ b/data/events/2016-nashville.yml
@@ -81,6 +81,8 @@ sponsors: # List all of your sponsors here along with what level of sponsorship 
     level: bronze
   - id: arresteddevops
     level: media
+  - id: comcast
+    level: wifi
 sponsor_levels: # In this section, list the level of sponsorships and the label to use.
   - id: gold
     label: Gold
@@ -88,6 +90,8 @@ sponsor_levels: # In this section, list the level of sponsorships and the label 
     label: Silver
   - id: bronze
     label: Bronze
+  - id: wifi
+    label: WiFi
   - id: badges
     label: Badges
   - id: beverage


### PR DESCRIPTION
This PR updates the sponsor list for Nashville to add Comcast as a WiFi sponsor in the event.