### PR TITLE
Deprecate the status: parameters (current & past)

### DIFF
--- a/data/events/2016-paris.yml
+++ b/data/events/2016-paris.yml
@@ -1,7 +1,6 @@
 name: "2016-paris" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2016" # The year of the event. Make sure it is in quotes.
 city: "Paris" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2016-MM-DD, like this:   variable: 2016-01-05

--- a/data/events/2016-sydney.yml
+++ b/data/events/2016-sydney.yml
@@ -1,7 +1,6 @@
 name: "2016-sydney" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2016" # The year of the event. Make sure it is in quotes.
 city: "Sydney" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 
 # All dates are in unquoted 2016-MM-DD, like this:   variable: 2016-01-05
 startdate: 2016-12-01  # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2016-warsaw.yml
+++ b/data/events/2016-warsaw.yml
@@ -2,7 +2,6 @@ name: "2016-warsaw" # The name of the event. Four digit year with the city name 
 year: "2016" # The year of the event. Make sure it is in quotes.
 city: "Warsaw" # The city name of the event. Capitalize it.
 friendly: "2016-warsaw" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 
 # All dates are in unquoted 2016-MM-DD, like this:   variable: 2016-01-05
 startdate: 2016-11-22 # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2017-amsterdam.yml
+++ b/data/events/2017-amsterdam.yml
@@ -2,7 +2,6 @@ name: "2017-amsterdam" # The name of the event. Four digit year with the city na
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Amsterdam" # The city name of the event. Capitalize it.
 friendly: "2017-amsterdam" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate:  2017-06-28

--- a/data/events/2017-austin.yml
+++ b/data/events/2017-austin.yml
@@ -1,7 +1,6 @@
 name: "2017-austin" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Austin" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate:  2017-05-04

--- a/data/events/2017-baltimore.yml
+++ b/data/events/2017-baltimore.yml
@@ -2,7 +2,6 @@ name: "2017-baltimore"
 year: "2017"
 city: "Baltimore"
 friendly: "2017-baltimore"
-status: "current"
 
 startdate:  2017-03-07
 enddate:  2017-03-08

--- a/data/events/2017-charlotte.yml
+++ b/data/events/2017-charlotte.yml
@@ -1,7 +1,6 @@
 name: "2017-charlotte" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Charlotte" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05

--- a/data/events/2017-chicago.yml
+++ b/data/events/2017-chicago.yml
@@ -1,7 +1,6 @@
 name: "2017-chicago" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Chicago" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05

--- a/data/events/2017-minneapolis.yml
+++ b/data/events/2017-minneapolis.yml
@@ -1,7 +1,6 @@
 name: "2017-minneapolis"
 year: "2017"
 city: "Minneapolis"
-status: "current"
 
 startdate: 2017-07-25
 enddate: 2017-07-26

--- a/data/events/2017-moscow.yml
+++ b/data/events/2017-moscow.yml
@@ -1,7 +1,6 @@
 name: "2017-moscow" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Moscow" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 
 # All dates are in unquoted 2016-MM-DD, like this:   variable: 2016-01-05
 startdate: 2017-02-11 # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2017-paris.yml
+++ b/data/events/2017-paris.yml
@@ -1,7 +1,6 @@
 name: "2017-paris" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Paris" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05

--- a/data/events/2017-portland.yml
+++ b/data/events/2017-portland.yml
@@ -2,7 +2,6 @@ name: "2017-portland" # The name of the event. Four digit year with the city nam
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Portland" # The displayed city name of the event. Capitalize it.
 friendly: "2017-portland"
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2017-salt-lake-city.yml
+++ b/data/events/2017-salt-lake-city.yml
@@ -1,7 +1,6 @@
 name: "2017-salt-lake-city" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Salt Lake City" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: "DevOpsDays returns to the Silicon Slopes!"# A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05

--- a/data/events/2017-seattle.yml
+++ b/data/events/2017-seattle.yml
@@ -1,7 +1,6 @@
 name: "2017-seattle" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Seattle" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: "DevOpsDays is returning to Seattle in 2017" # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05

--- a/data/events/2017-toronto.yml
+++ b/data/events/2017-toronto.yml
@@ -1,7 +1,6 @@
 name: "2017-toronto" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Toronto" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05

--- a/data/events/2017-zurich.yml
+++ b/data/events/2017-zurich.yml
@@ -2,7 +2,6 @@ name: "2017-zurich" # The name of the event. Four digit year with the city name 
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Zürich" # The city name of the event. Capitalize it.
 friendly: "2017-zurich" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate: 2017-05-03

--- a/themes/devopsdays-responsive/layouts/partials/cfp.html
+++ b/themes/devopsdays-responsive/layouts/partials/cfp.html
@@ -6,7 +6,7 @@
   {{ range sort $.Site.Data.events "startdate" }}
 
   {{ if .cfp_date_end }}
-    {{ if  ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+    {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
       {{ $.Scratch.Add "events" "<tr><td><a href = '/events/" }}
       {{ $.Scratch.Add "events" .name }}
       {{ $.Scratch.Add "events" "/welcome' class = 'cfp'>" }}
@@ -16,10 +16,10 @@
       {{ $.Scratch.Add "events" "</td><td data-dateformat='YYYY-MM-DD'>&nbsp;&nbsp;&nbsp;&nbsp;" }}
       {{ $.Scratch.Add "events" .startdate}}
       {{ $.Scratch.Add "events" "</td></tr>" }}
-    {{ end }} {{/* end: if  and ( eq .status "current") ( .startdate ) */}}
+    {{ end }} {{/* end: date is now or afterwards */}}
 
-  {{ end }} {{/* end: range sort $.Site.Data.events "startdate" */}}
-{{ end }}
+  {{ end }} {{/* end: if .cfp_date_end */}}
+{{ end }} {{/* end: range sort $.Site.Data.events "startdate" */}}
 {{ $.Scratch.Add "events" "</tbody></table>" }}
 
 

--- a/themes/devopsdays-responsive/layouts/partials/future.html
+++ b/themes/devopsdays-responsive/layouts/partials/future.html
@@ -7,8 +7,6 @@ This code creates 2-3 lists: One of current years and a list of current events
 for each year (namespaced with "future" to prevent collisions). Later we loop
 through these lists to generate our event info.
 
-There are currently two hard-coded references to 2017-01-01 which at or before
-that point will need to be changed.
 -->
 
 
@@ -23,24 +21,9 @@ that point will need to be changed.
                 <tr>
                     <div style="display:table-cell; vertical-align:top">
                         <div style="margin:1px;">
-                            <strong>{{ $.Now.Format "2006" }}</strong><br/>
                             {{ range sort $.Site.Data.events "startdate" }}
                               {{ if .startdate }}
-                              {{ if and (ge (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02"))) (lt (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" "2017-01-01" )) }}
-                              <a href = "/events/{{ .name }}/welcome">
-                                  {{ .city }}
-                                {{ dateFormat "Jan 2, 2006" .startdate }}
-                                -
-                                {{ dateFormat "Jan 2, 2006" .enddate }}
-                              </a><br />
-                              {{ end }}
-                              {{ end }}
-                            {{ end }}
-
-                            <br/><strong>{{ .Now.AddDate 1 0 0 | dateFormat "2006" }}</strong><br/>
-                            {{ range sort $.Site.Data.events "startdate" }}
-                              {{ if .startdate }}
-                              {{ if ge (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" "2017-01-01" ) }}
+                              {{ if ge (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
                               <a href = "/events/{{ .name }}/welcome">
                                   {{ .city }}
                                 {{ dateFormat "Jan 2, 2006" .startdate }}

--- a/themes/devopsdays-responsive/layouts/partials/map.html
+++ b/themes/devopsdays-responsive/layouts/partials/map.html
@@ -22,8 +22,10 @@ function initialize() {
     // Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
     var markers = [
       {{ range $.Site.Data.events }}
-        {{ if  and (eq .status "current") ( .startdate ) }}
+        {{ if .startdate }}
+        {{ if ge (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
           ['{{ .city}}', {{ .coordinates | safeJS }}, '{{ dateFormat "Jan 2" .startdate }}', '/events/{{ .name }}'],
+        {{ end }}
         {{ end }}
       {{ end }}
     ];

--- a/themes/devopsdays-responsive/layouts/partials/sponsors.html
+++ b/themes/devopsdays-responsive/layouts/partials/sponsors.html
@@ -19,7 +19,8 @@
           {{ end }}
         </div>
 
-        {{ if eq $e.status "current" }}
+        {{ if $e.startdate }}
+          {{ if ge (dateFormat "2006-01-02" $e.startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
           {{ if ne $e.sponsors_accepted "no" }}
             {{ if or (not $level.max) (lt ($.Scratch.Get $level.id) $level.max) }}
               <div class = "row">
@@ -29,6 +30,7 @@
               </div>
             {{ end }}
           {{ end }}
+        {{ end }}
         {{ end }}
 
       </div>

--- a/themes/devopsdays-responsive/layouts/partials/upcoming_headline.html
+++ b/themes/devopsdays-responsive/layouts/partials/upcoming_headline.html
@@ -1,12 +1,15 @@
 <div class="upcoming-headline">
   <h3 class = "upcoming-headline">
   {{ range sort $.Site.Data.events "startdate" }}
-    {{ if  and ( eq .status "current") ( .startdate ) }}
+    {{ if .startdate }}
+    {{ if ge (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
       {{ $.Scratch.Add "events" "<a href = '/events/" }}
       {{ $.Scratch.Add "events" .name }}
       {{ $.Scratch.Add "events" "/welcome' class = 'upcoming-headline'>" }}
         {{ $.Scratch.Add "events" .city }}
       {{ $.Scratch.Add "events" "</a> - " }}
+
+    {{ end }}
     {{ end }}
   {{ end }}
   {{ substr ($.Scratch.Get "events") 0 -3 | safeHTML }}

--- a/utilities/examples/yyyy-city.yml
+++ b/utilities/examples/yyyy-city.yml
@@ -1,7 +1,6 @@
 name: "yyyy-city" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "YYYY" # The year of the event. Make sure it is in quotes.
 city: "City" # The displayed city name of the event. Capitalize it.
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05


### PR DESCRIPTION
The reason this was worth doing is that manually setting an event to "past" in a timely fashion is annoying to have to remember.

I think I've corrected all the places that were using this parameter. I've also corrected the data file for the template (and for upcoming events - while not strictly speaking necessary, might as well work cleaner). 

There are a few subtle tradeoffs - I went into some detail in the commit messages.

I'd appreciate @mattstratton taking a look since this is a change with some scope to it.

