### PR TITLE
We need to hide the propose page for Amsterdam

### DIFF
--- a/data/events/2017-amsterdam.yml
+++ b/data/events/2017-amsterdam.yml
@@ -26,7 +26,7 @@ proposal_email: "organizers-amsterdam-2017@devopsdays.org" # Put your proposal e
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: welcome
 #  - name: program
-  - name: propose
+#  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
   - name: location
 #  - name: registration


### PR DESCRIPTION
Since our CFP isn't officially open we should not have this link public yet. The page which people land on is also not up to date with how we handle proposals yet.