### PR TITLE
Fix unclosed br tag in stockholm sponsor file

### DIFF
--- a/content/events/2017-stockholm/sponsor.md
+++ b/content/events/2017-stockholm/sponsor.md
@@ -14,9 +14,9 @@ Please keep in mind, that you accept our Code of Conduct with sponsoring this ev
 <table border="0" width="100%" style="padding: 5px;">
   <tr>
     <th><b>Packages</b></th>
-    <th><center><b><u>Bronze<br </u>1000 €</center></b></th>
-    <th><center><b><u>Silver<br </u>3000 €</center></b></th>
-    <th><center><b><u>Gold<br </u>5000 €</center></b></th>
+    <th><center><b><u>Bronze<br />/u>1000 €</center></b></th>
+    <th><center><b><u>Silver<br />/u>3000 €</center></b></th>
+    <th><center><b><u>Gold<br />/u>5000 €</center></b></th>
     <th></th>
   </tr>
 


### PR DESCRIPTION
When merging the other Stockholm changes, the unclosed `<br />` tag snuck in again. This fixes that.