### PR TITLE
[Scripts] Changing the default to 2017

### DIFF
--- a/utilities/make_new_event.sh
+++ b/utilities/make_new_event.sh
@@ -4,7 +4,7 @@ set -e
 
 # We assume the current year (and also assume bash 3, because macs)
 read -p "Enter your event year (default: $(date +"%Y")): " year
-[ -z "${year}" ] && year='2016'
+[ -z "${year}" ] && year='2017'
 
 # We urlize the city slug
 read -p "Enter your city name: " city


### PR DESCRIPTION
Using `utilities/make_new_event`, when not entering a value for the year, it displays that it will use `2017`, but creates the event as `2016`.  

```
$ ./make_new_event.sh
Enter your event year (default: 2017):
Enter your city name: Cape Town
Enter your devopsdays event twitter handle (defaults to devopsdays): devopsdayscpt

$ git status
  content/events/2016-cape-town/
  data/events/2016-cape-town.yml
```

Updated the bash scrip to fix this.