### PR TITLE
[ZRH-2017] Added workaround URL in case of payment page problems

### DIFF
--- a/content/events/2017-zurich/registration.md
+++ b/content/events/2017-zurich/registration.md
@@ -5,7 +5,8 @@ type = "event"
 
 
 +++
-Registration for DevOpsDays Zürich is now open. If you have any questions please contact us at {{< email_organizers >}}.
+Registration for DevOpsDays Zürich is now open.<br> 
+<a href="https://user.ticketpark.ch/en/embed/ticketing/show/9FBB6FB2-4F52-4819-8CFC-174D39322177?customCssFiles=&language=en&bookingData=%7B%22booking%22%3A%7B%22origin%22%3A%22www.devopsdays.org%22%7D%7D&embedId=singleEmbed&entryPoint=https%3A%2F%2Fuser.ticketpark.ch%2Fen%2Fembed%2Fticketing%2Fshow%2F9FBB6FB2-4F52-4819-8CFC-174D39322177" target="_blank">Please click here if you don't see the payment page</a><br>
 
 <script type="text/javascript">
   var _tp_customCssFiles = "";


### PR DESCRIPTION
We added a workaround url into the registration page as it some time seems that the devopsdays.org rocketscript js intervenes with our javascript snippet.