### PR TITLE
Adding logo square for new theme to yaml.

### DIFF
--- a/data/events/2017-amsterdam.yml
+++ b/data/events/2017-amsterdam.yml
@@ -12,6 +12,8 @@ cfp_date_start: 2017-01-15  # start accepting talk proposals.
 cfp_date_end:  2017-04-01 # close your call for proposals.
 cfp_date_announce: 2017-05-15 # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 coordinates: "52.376862, 4.922078" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "Pakhuis de Zwijger - Amsterdam" # Defaults to city, but you can make it the venue name.

--- a/data/events/2017-atlanta.yml
+++ b/data/events/2017-atlanta.yml
@@ -12,6 +12,8 @@ cfp_date_start:  2017-01-05
 cfp_date_end:  2017-02-27
 cfp_date_announce:  2017-03-01
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "41.882219, -87.640530" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-austin.yml
+++ b/data/events/2017-austin.yml
@@ -11,6 +11,8 @@ cfp_date_start:  2017-01-23
 cfp_date_end:  2017-02-14
 cfp_date_announce:  2017-03-01
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "30.284901, -97.732391" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-baltimore.yml
+++ b/data/events/2017-baltimore.yml
@@ -12,6 +12,8 @@ cfp_date_start: 2016-05-26
 cfp_date_end: 2016-12-09
 cfp_date_announce: 2017-01-06
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 coordinates: "39.286400, -76.605606" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "Baltimore" # Defaults to city, but you can make it the venue name.

--- a/data/events/2017-beijing.yml
+++ b/data/events/2017-beijing.yml
@@ -12,6 +12,8 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "39.905523, 116.455078" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-charlotte.yml
+++ b/data/events/2017-charlotte.yml
@@ -12,6 +12,8 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "35.2271, -80.8431" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-chicago.yml
+++ b/data/events/2017-chicago.yml
@@ -12,6 +12,8 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "41.882219, -87.640530" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-dallas.yml
+++ b/data/events/2017-dallas.yml
@@ -14,6 +14,8 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "41.882219, -87.640530" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-denver.yml
+++ b/data/events/2017-denver.yml
@@ -9,6 +9,7 @@ enddate: 2017-04-11 # The end date of your event, in YYYY-MM-DD format. Leave bl
 cfp_date_start: 2017-01-13
 cfp_date_end: 2017-02-17
 cfp_date_announce: 2017-03-01
+event_logo_square: "logo-square.jpg"
 coordinates: "39.739236, -104.990251" # The corrodinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "Denver" # The name of your location
 

--- a/data/events/2017-detroit.yml
+++ b/data/events/2017-detroit.yml
@@ -13,6 +13,8 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "42.331034, -83.046382" # The corrodinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-indianapolis.yml
+++ b/data/events/2017-indianapolis.yml
@@ -12,6 +12,8 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "41.882219, -87.640530" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-istanbul.yml
+++ b/data/events/2017-istanbul.yml
@@ -12,6 +12,8 @@ cfp_date_start:  2017-02-10 # start accepting talk proposals.
 cfp_date_end: 2017-05-10 # close your call for proposals.
 cfp_date_announce: 2017-06-10 # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "40.962189, 29.110926" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-minneapolis.yml
+++ b/data/events/2017-minneapolis.yml
@@ -10,6 +10,8 @@ cfp_date_start: 2016-12-22
 cfp_date_end: 2017-04-09
 cfp_date_announce: 2017-05-07
 
+event_logo_square: "logo-square.jpg"
+
 coordinates: "44.972610,-93.272960"
 location: "Minneapolis"
 

--- a/data/events/2017-moscow.yml
+++ b/data/events/2017-moscow.yml
@@ -12,6 +12,8 @@ cfp_date_start:  2016-12-01 # start accepting talk proposals.
 cfp_date_end:  2017-02-08 # close your call for proposals.
 cfp_date_announce:  2017-02-08 # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "55.708244, 37.724118" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-portland.yml
+++ b/data/events/2017-portland.yml
@@ -12,6 +12,8 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "45.528562, -122.663028" # The coordinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-salt-lake-city.yml
+++ b/data/events/2017-salt-lake-city.yml
@@ -12,6 +12,8 @@ cfp_date_start: 2016-12-14 # start accepting talk proposals.
 cfp_date_end: 2017-02-15 # close your call for proposals.
 cfp_date_announce: 2017-03-01 # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "40.552756, -111.901249" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-seattle.yml
+++ b/data/events/2017-seattle.yml
@@ -12,6 +12,8 @@ cfp_date_start: 2016-10-24 # start accepting talk proposals.
 cfp_date_end: 2017-01-24 # close your call for proposals.
 cfp_date_announce: 2017-02-07 # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "47.623948, -122.350088" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-stockholm.yml
+++ b/data/events/2017-stockholm.yml
@@ -12,6 +12,8 @@ cfp_date_start: 2017-02-03  # start accepting talk proposals.
 cfp_date_end:  2017-03-05 # close your call for proposals.
 cfp_date_announce: 2017-03-26 # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "59.290555, 18.084346" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-tokyo.yml
+++ b/data/events/2017-tokyo.yml
@@ -11,6 +11,8 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "35.6223187, 139.7294709" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-toronto.yml
+++ b/data/events/2017-toronto.yml
@@ -12,6 +12,8 @@ cfp_date_start: 2016-12-21 # start accepting talk proposals.
 cfp_date_end:  2017-02-07 # close your call for proposals.
 cfp_date_announce: 2017-03-07 # inform proposers of status.
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "43.644489,-79.388044" # The corrodinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-vancouver.yml
+++ b/data/events/2017-vancouver.yml
@@ -13,6 +13,8 @@ cfp_date_start: 2016-12-01 # start accepting talk proposals.
 cfp_date_end: 2017-02-01 # close your call for proposals.
 cfp_date_announce: 2017-02-11 # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "49.282729, -123.120738" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-zurich.yml
+++ b/data/events/2017-zurich.yml
@@ -12,6 +12,8 @@ cfp_date_start: 2016-11-01 # start accepting talk proposals.
 cfp_date_end: 2017-02-01 # close your call for proposals.
 cfp_date_announce: 2017-04-01 # inform proposers of status
 
+event_logo_square: "logo-square.jpg"
+
 # Location
 #
 coordinates: "47.497854, 8.731663" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html


### PR DESCRIPTION
This adds the line necessary to resolve https://github.com/devopsdays/devopsdays-web/issues/1499#issuecomment-277351274. tl;dr: the new theme uses a version of an event's logo which must be square; in this variable, it's defined as to what it's called. (Makes it much easier to use it.)