### PR TITLE
[paris-2017] add date and update welcome page

### DIFF
--- a/content/events/2017-paris/welcome.md
+++ b/content/events/2017-paris/welcome.md
@@ -1,27 +1,46 @@
 +++
-date = "2016-10-11T18:48:25+02:00"
+date = "2017-02-16T14:22:48+02:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-paris"]
 
 +++
 
-<!-- <h2>{{< event_start >}} - {{< event_end >}}</h2> -->
+<h2>{{< event_start >}}</h2>
 
-<h2>devopsdays is coming to {{< event_location >}} in Spring 2017!</h2>
+L'équipe derrière devopsdays Paris 2013 et 2015, devops REX 2016, ainsi
+que les meetups Paris Devops, présente **devops REX 2017** : une
+conférence d'un jour, 100% retours d'expériences concrets du terrain,
+comprenant présentations, questions-réponses et échanges informels,
+directement auprès des décideurs informatiques qui pilotent et conçoivent
+ces changements.
+
+**La langue principale de cette conférence sera le français.**
+
+*(en)* From the team that brought you devopsdays Paris 2013 and 2015,
+devops REX 2016, as well as the Paris Devops Meetup, comes **devops
+REX 2017**: a one-day, single-track conference focusing on real world
+experience and feedback, featuring presentations, Q&A sessions, and
+discussions from industry practitioners and taste-makers.
+
+**The principal language of this conference will be French.**
+
+## Pour plus d'informations, veuillez visiter notre site principal: **https://www.devopsrex.fr/**
+
+<br />
 
 <!-- <div style="text-align:center;">
   {{< event_logo >}}
 </div> -->
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
-    <strong>Dates</strong>
+    <strong>Date</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_start >}} - {{< event_end >}}
+    {{< event_start >}}
   </div>
-</div> -->
+</div>
 
 <!-- <div class = "row">
   <div class = "col-md-2">
@@ -68,14 +87,16 @@ aliases = ["/events/2017-paris"]
   </div>
 </div> -->
 
-<!-- <div class = "row">
+<!--
+<div class = "row">
   <div class = "col-md-2">
     <strong>Sponsors</strong>
   </div>
   <div class = "col-md-8">
     {{< event_link page="sponsor" text="Sponsor the conference!" >}}
   </div>
-</div> -->
+</div>
+-->
 
 <div class = "row">
   <div class = "col-md-2">
@@ -86,4 +107,7 @@ aliases = ["/events/2017-paris"]
   </div>
 </div>
 
-{{< event_twitter devopsdaysparis >}}
+<br />
+<br />
+<!-- add your city twitter name here without the @ sign -->
+{{< event_twitter devopsdaysrex >}}

--- a/content/events/2017-paris/welcome.md
+++ b/content/events/2017-paris/welcome.md
@@ -110,4 +110,4 @@ discussions from industry practitioners and taste-makers.
 <br />
 <br />
 <!-- add your city twitter name here without the @ sign -->
-{{< event_twitter devopsdaysrex >}}
+{{< event_twitter devopsrex >}}

--- a/data/events/2017-paris.yml
+++ b/data/events/2017-paris.yml
@@ -1,7 +1,7 @@
 name: "2017-paris" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Paris" # The displayed city name of the event. Capitalize it.
-event_twitter: "devopsdaysparis"
+event_twitter: "devopsrex"
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
@@ -38,8 +38,8 @@ team_members: # Name is the only required field for team members.
     employer: "Normation"
   - name: "Dan Maher"
     twitter: "phrawzty"
-organizer_email: "organizers-paris-2017@devopsdays.org" # Put your organizer email address here
-proposal_email: "proposals-paris-2017@devopsdays.org" # Put your proposal email address here
+organizer_email: "devops-rex-orga@googlegroups.com" # Put your organizer email address here
+proposal_email: "cfp@devopsrex.fr" # Put your proposal email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.

--- a/data/events/2017-paris.yml
+++ b/data/events/2017-paris.yml
@@ -5,8 +5,8 @@ event_twitter: "devopsdaysparis"
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2017-10-02 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2017-10-02 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
@@ -14,7 +14,7 @@ cfp_date_announce:  # inform proposers of status
 
 # Location
 #
-coordinates: "48.871047, 2.345704" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+coordinates: "48.870564, 2.347487" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "Paris" # Defaults to city, but you can make it the venue name.
 #
 
@@ -24,10 +24,12 @@ nav_elements: # List of pages you want to show up in the navigation of your page
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
 #  - name: location
+  - name: devopsrex.fr
+    url: https://www.devopsrex.fr
 #  - name: registration
 #  - name: sponsor
   - name: contact
-#  - name: conduct
+  - name: conduct
 
 # These are the same people you have on the mailing list and Slack channel.
 team_members: # Name is the only required field for team members.
@@ -36,7 +38,6 @@ team_members: # Name is the only required field for team members.
     employer: "Normation"
   - name: "Dan Maher"
     twitter: "phrawzty"
-    employer: "Mozilla"
 organizer_email: "organizers-paris-2017@devopsdays.org" # Put your organizer email address here
 proposal_email: "proposals-paris-2017@devopsdays.org" # Put your proposal email address here
 


### PR DESCRIPTION
* Add date for the October "Rex" event, like last year.
* Update the Welcome page (basically the same as last year).
* Adjust the long/lat ever so slightly (it's actually on the venue now).
* Remove old employer for an organiser.
* Link the CoC.
* Fix Twitter handle.
* Fix email addresses.

`r?` @jooooooon 