### PR TITLE
[Baltimore-2017] Add twitter handles for sponsors

### DIFF
--- a/data/sponsors/acesinc.yml
+++ b/data/sponsors/acesinc.yml
@@ -1,2 +1,3 @@
 name: "Aces Inc."
 url: "http://acesinc.net/"
+twitter: "acesinc"

--- a/data/sponsors/bookerdimaio.yml
+++ b/data/sponsors/bookerdimaio.yml
@@ -1,2 +1,3 @@
 name: "Booker DiMaio"
 url: "https://bookerdimaio.com/"
+twitter: "bookerdimaio"

--- a/data/sponsors/cloudpassage.yml
+++ b/data/sponsors/cloudpassage.yml
@@ -1,2 +1,3 @@
-name: cloudpassage
-url: http://www.cloudpassage.com/
+name: "cloudpassage"
+url: "http://www.cloudpassage.com/"
+twitter: "cloudpassage"

--- a/data/sponsors/columntech.yml
+++ b/data/sponsors/columntech.yml
@@ -1,2 +1,3 @@
 name: "Column Technologies"
 url: "http://www.columnit.com/"
+twitter: "columnit"

--- a/data/sponsors/fearless.yml
+++ b/data/sponsors/fearless.yml
@@ -1,2 +1,3 @@
 name: "Fearless"
 url: "http://www.fearless.tech/"
+twitter: "fearlesssol"

--- a/data/sponsors/ns1.yml
+++ b/data/sponsors/ns1.yml
@@ -1,2 +1,3 @@
-name: ns1
-url: https://ns1.com
+name: "ns1"
+url: "https://ns1.com"
+twitter: "nsoneinc"

--- a/data/sponsors/opsgenie.yml
+++ b/data/sponsors/opsgenie.yml
@@ -1,2 +1,3 @@
 name: "OpsGenie"
 url: "http://www.opsgenie.com"
+twitter: "opsgenie"

--- a/data/sponsors/pivotal.yml
+++ b/data/sponsors/pivotal.yml
@@ -1,3 +1,3 @@
-
 name: "Pivotal"
 url: "http://www.pivotal.io"
+twitter: "pivotal"

--- a/data/sponsors/puppet.yml
+++ b/data/sponsors/puppet.yml
@@ -1,2 +1,3 @@
-name: Puppet
-url: http://www.puppet.com
+name: "Puppet"
+url: "http://www.puppet.com"
+twitter: "puppetize"

--- a/data/sponsors/que-technology-group.yml
+++ b/data/sponsors/que-technology-group.yml
@@ -1,3 +1,3 @@
 name: "QUE Technology Group"
 url: "http://www.qtg-hq.com/"
-twitter: quetechnology
+twitter: "quetechnology"

--- a/data/sponsors/redhat.yml
+++ b/data/sponsors/redhat.yml
@@ -1,2 +1,3 @@
 name: "Red Hat, Inc"
 url: "https://www.redhat.com"
+twitter: "redhatsoftware"

--- a/data/sponsors/sdtp.yml
+++ b/data/sponsors/sdtp.yml
@@ -1,2 +1,3 @@
 name: "Software Defined Talk Podcast"
 url: "http://softwaredefinedtalk.com"
+twitter: "softwaredeftalk"


### PR DESCRIPTION
* @acesinc
* @bookerdimaio
* @cloudpassage
* @columnit
* @fearlesssol
* @nsoneinc
* @opsgenie
* @pivotal
* @puppetize
* @quetechnology
* @redhatsoftware
* @softwaredeftalk

Signed-off-by: Nathen Harvey <nharvey@chef.io>
