### PR TITLE
[paris-2017] standardise the contact email address

### DIFF
--- a/data/events/2017-paris.yml
+++ b/data/events/2017-paris.yml
@@ -38,7 +38,7 @@ team_members: # Name is the only required field for team members.
     employer: "Normation"
   - name: "Dan Maher"
     twitter: "phrawzty"
-organizer_email: "devops-rex-orga@googlegroups.com" # Put your organizer email address here
+organizer_email: "organizers-paris-2017@devopsdays.org" # Put your organizer email address here
 proposal_email: "cfp@devopsrex.fr" # Put your proposal email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.


### PR DESCRIPTION
All devopsdays events use official @devopsdays.org email contact addresses.

cc @jooooooon @bridgetkromhout 