### PR TITLE
Increase the height of the future events div

### DIFF
--- a/themes/devopsdays-responsive/layouts/partials/future.html
+++ b/themes/devopsdays-responsive/layouts/partials/future.html
@@ -16,7 +16,7 @@ through these lists to generate our event info.
     </div>
 
     <div class="span-6 last">
-        <div style="height:700px;" id="quicklinks">
+        <div style="height:750px;" id="quicklinks">
             <table>
                 <tr>
                     <div style="display:table-cell; vertical-align:top">


### PR DESCRIPTION
This prevents the past events from overlapping the future events.

Resolves #1833

Signed-off-by: Nathen Harvey <nharvey@chef.io>

