### PR TITLE
[DC-2017] "CAVA" should be uppercase

### DIFF
--- a/data/events/2017-washington-dc.yml
+++ b/data/events/2017-washington-dc.yml
@@ -42,7 +42,7 @@ team_members: # Name is the only required field for team members.
     twitter: "hfbazemore"
     employer: Comcast
   - name: "Mark Cornick"
-    employer: "Cava"
+    employer: "CAVA"
   - name: "Jeffrey Damick"
     twitter: "jeffreydamick"
     employer: "CapitalOne"


### PR DESCRIPTION
Signed-off-by: Nathen Harvey <nharvey@chef.io>
