### PR TITLE
[ATL-2017] Remove "twitter" as an organizer for Atlanta

### DIFF
--- a/data/events/2017-atlanta.yml
+++ b/data/events/2017-atlanta.yml
@@ -41,8 +41,7 @@ team_members: # Name is the only required field for team members.
   - name: "Greg Cordell"
   - name: "Jim Song"
   - name: "Andre Thenot"
-  - name: "Twitter"
-    twitter: "devopsdaysATL"
+
 organizer_email: "organizers-atlanta-2017@devopsdays.org" # Put your organizer email address here
 proposal_email: "proposals-atlanta-2017@devopsdays.org" # Put your proposal email address here
 


### PR DESCRIPTION
Twitter is not a person :)

Remember, the names of people on the organizer page must be real people.

Also, trying to get the twitter handle to show up on the page this way is going to go really south in the new theme :)
