### PR TITLE
Remove config.toml from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /public
 # General CodeKit files to ignore
 config.codekit
-config.toml
+# config.toml # This is a dangerous file, but we need it not in here.
 /min
 .DS_Store
 .AppleDouble

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,11 @@ To watch for changes and rebuild on the fly, open a new terminal, change directo
 hugo server -w --baseUrl="http://localhost:1313"
 ```
 
+If you are running Windows, change the command to 
+```
+hugo server -w --baseUrl="http://localhost:1313" --config config-windows.toml
+```
+
 Now open `baseURL` in a browser and navigate to the content that you're editing - voilà!
 
 ## Pull requests

--- a/config-windows.toml
+++ b/config-windows.toml
@@ -36,17 +36,19 @@ buildDrafts = false
   weight = -100
 
 [permalinks]
-	page = "/:filename/"
+  page = "/:filename/"
   blog = "/blog/:year/:month/:day/:title/"
 
 [params]
-	Facebook = "//www.facebook.com/group.php?gid=106761636771"
-	Twitter = "http://www.twitter.com/devopsdays"
-	Linkedin = "http://www.linkedin.com/groups?home=&gid=2445279"
-	Groups = "http://groups.google.com/group/devopsdays"
+  Facebook = "//www.facebook.com/group.php?gid=106761636771"
+  Twitter = "http://www.twitter.com/devopsdays"
+  Linkedin = "http://www.linkedin.com/groups?home=&gid=2445279"
+  Groups = "http://groups.google.com/group/devopsdays"
 
-	# Set to "/" on *nix and Mac, "\\" on Windows
-	# Refer to https://github.com/spf13/hugo/issues/2394 for more information
-	PathSeperator = "\\"
+  # Set to "/" on *nix and Mac, "\\" on Windows
+  # Refer to https://github.com/spf13/hugo/issues/2394 for more information
+  # Do not change this setting in the file directly. Instead run hugo with the --config flag if using Windows. 
+  # See CONTRIBUTING.md on devopsdays/devopsdays-web for more details
+  PathSeperator = "\\" # this will be deprecated with devopsdays-theme
   pathSeparator = "\\"
   weburl = "https://www.devopsdays.org"

--- a/config-windows.toml
+++ b/config-windows.toml
@@ -1,0 +1,52 @@
+theme = "devopsdays-responsive"
+baseurl = "https://www.devopsdays.org/"
+# baseurl = "http://localhost:1313/"
+languageCode = "en-us"
+GoogleAnalytics = "UA-9713393-1"
+title = "DevOpsDays"
+canonifyurls = false
+dataDir = "data"
+archetypedir = "archetypes"
+PaginatePath = "blog"
+buildDrafts = false
+
+[[menu.main]]
+  name = "events"
+  url = "/events"
+  weight = -150
+[[menu.main]]
+  name = "blog"
+  url = "/blog"
+  weight = -140
+[[menu.main]]
+  name = "sponsor"
+  url = "/sponsor"
+  weight = -130
+[[menu.main]]
+  name = "speaking"
+  url = "/speaking"
+  weight = -120
+[[menu.main]]
+  name = "organizing"
+  url = "/organizing"
+  weight = -110
+[[menu.main]]
+  name = "about"
+  url = "/about"
+  weight = -100
+
+[permalinks]
+	page = "/:filename/"
+  blog = "/blog/:year/:month/:day/:title/"
+
+[params]
+	Facebook = "//www.facebook.com/group.php?gid=106761636771"
+	Twitter = "http://www.twitter.com/devopsdays"
+	Linkedin = "http://www.linkedin.com/groups?home=&gid=2445279"
+	Groups = "http://groups.google.com/group/devopsdays"
+
+	# Set to "/" on *nix and Mac, "\\" on Windows
+	# Refer to https://github.com/spf13/hugo/issues/2394 for more information
+	PathSeperator = "\\"
+  pathSeparator = "\\"
+  weburl = "https://www.devopsdays.org"

--- a/config.toml
+++ b/config.toml
@@ -36,18 +36,18 @@ buildDrafts = false
   weight = -100
 
 [permalinks]
-	page = "/:filename/"
+  page = "/:filename/"
   blog = "/blog/:year/:month/:day/:title/"
 
 [params]
-	Facebook = "//www.facebook.com/group.php?gid=106761636771"
-	Twitter = "http://www.twitter.com/devopsdays"
-	Linkedin = "http://www.linkedin.com/groups?home=&gid=2445279"
-	Groups = "http://groups.google.com/group/devopsdays"
+  Facebook = "//www.facebook.com/group.php?gid=106761636771"
+  Twitter = "http://www.twitter.com/devopsdays"
+  Linkedin = "http://www.linkedin.com/groups?home=&gid=2445279"
+  Groups = "http://groups.google.com/group/devopsdays"
 
-	# Set to "/" on *nix and Mac, "\\" on Windows
-	# Refer to https://github.com/spf13/hugo/issues/2394 for more information
-	# Do not change in this file directly - use the --config flag to hugo with the config-windows.toml file instead
-	PathSeperator = "/"
+  # Set to "/" on *nix and Mac, "\\" on Windows
+  # Refer to https://github.com/spf13/hugo/issues/2394 for more information
+  # Do not change in this file directly - use the --config flag to hugo with the config-windows.toml file instead
+  PathSeperator = "/" # this will be deprecated with devopsdays-theme
   pathSeparator = "/"
   weburl = "https://www.devopsdays.org"

--- a/config.toml
+++ b/config.toml
@@ -47,6 +47,7 @@ buildDrafts = false
 
 	# Set to "/" on *nix and Mac, "\\" on Windows
 	# Refer to https://github.com/spf13/hugo/issues/2394 for more information
+	# Do not change in this file directly - use the --config flag to hugo with the config-windows.toml file instead
 	PathSeperator = "/"
   pathSeparator = "/"
   weburl = "https://www.devopsdays.org"


### PR DESCRIPTION
When the `config.toml`is in `.gitignore`, it means that folks who do a `git pull` won't get any updates. This is going to be a big problem when we release the new theme.

However, my concern is with people making changes to this file. We need to watch for changes on this file before merging PR's.

I need a couple 👍  from maintainers before this gets merged.