### PR TITLE
[ATL-2017] fixed Atlanta coordinates

### DIFF
--- a/data/events/2017-atlanta.yml
+++ b/data/events/2017-atlanta.yml
@@ -14,7 +14,7 @@ cfp_date_announce:  2017-03-01
 
 # Location
 #
-coordinates: "41.882219, -87.640530" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+coordinates: "33.778376, -84.386701" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "Atlanta" # Defaults to city, but you can make it the venue name.
 #
 


### PR DESCRIPTION
Atlanta's coordinates were in Chicago. 