### PR TITLE
Cleanup for event_twitter changes

### DIFF
--- a/content/events/2017-amsterdam/welcome.md
+++ b/content/events/2017-amsterdam/welcome.md
@@ -90,4 +90,4 @@ heading = "devopsdays Amsterdam - Welcome"
   </div>
 </div>
 
-{{< event_twitter devopsams >}}
+{{< event_twitter >}}

--- a/content/events/2017-atlanta/welcome.md
+++ b/content/events/2017-atlanta/welcome.md
@@ -88,7 +88,6 @@ aliases = ["/events/2017-atlanta"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-austin/welcome.md
+++ b/content/events/2017-austin/welcome.md
@@ -10,7 +10,7 @@ aliases = ["/events/2017-austin"]
 
 <h2>{{< event_start >}} - {{< event_end >}}</h2>
 
-{{< event_twitter dodaustin >}}
+{{< event_twitter >}}
 
 Watch [www.devopsdaysaustin.com](http://www.devopsdaysaustin.com) for more up to date information as it becomes available.
 

--- a/content/events/2017-baltimore/welcome.md
+++ b/content/events/2017-baltimore/welcome.md
@@ -139,7 +139,7 @@ aliases = [
 
 <div class = "row">
   <p>
-    {{< event_twitter devopsdaysbmore >}}
+    {{< event_twitter >}}
   </p>
 </div>
 

--- a/content/events/2017-beijing/welcome.md
+++ b/content/events/2017-beijing/welcome.md
@@ -93,7 +93,6 @@ aliases = ["/events/2017-beijing"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-boise/welcome.md
+++ b/content/events/2017-boise/welcome.md
@@ -87,7 +87,6 @@ aliases = ["/events/2017-boise"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-cape-town/welcome.md
+++ b/content/events/2017-cape-town/welcome.md
@@ -87,6 +87,4 @@ aliases = ["/events/2017-cape-town"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
-
-{{< event_twitter devopsdayscpt >}}
+{{< event_twitter >}}

--- a/content/events/2017-charlotte/welcome.md
+++ b/content/events/2017-charlotte/welcome.md
@@ -101,8 +101,7 @@ DevOpsDays is at the forefront of shared knowledge, collaboration, culture and i
 
 <br>
 
-<!-- add your city twitter name here without the @ sign -->
-{{< event_twitter devopsdays_clt >}}
+{{< event_twitter >}}
 
 <hr>
 <h3>Featured speaker</h3>

--- a/content/events/2017-chicago/welcome.md
+++ b/content/events/2017-chicago/welcome.md
@@ -87,6 +87,5 @@ Welcome!  The group that brought you DevOpsDays Chicago 2014-2016 is back togeth
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 
-{{< event_twitter devopsdayschi >}}
+{{< event_twitter >}}

--- a/content/events/2017-dallas/welcome.md
+++ b/content/events/2017-dallas/welcome.md
@@ -98,7 +98,6 @@ We're still working out all the details, more to come.
 <!-- Go to www.addthis.com/dashboard to customize your tools -->
 <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5724f5b54cc142a1"></script>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-denver/welcome.md
+++ b/content/events/2017-denver/welcome.md
@@ -49,5 +49,5 @@ DevOpsDays is back for its 3rd anual event in the Rocky Mountains {{< event_star
     {{< event_link page="contact" text="Get in touch with the organizers" >}}
   </div>
 </div>
-<!-- add your city twitter name here without the @ sign -->
-{{< event_twitter devopsdaysrox >}}
+
+{{< event_twitter >}}

--- a/content/events/2017-detroit/welcome.md
+++ b/content/events/2017-detroit/welcome.md
@@ -87,4 +87,4 @@ aliases = ["/events/2017-detroit"]
   </div>
 </div>
 
-{{< event_twitter devopsdaysdet >}}
+{{< event_twitter >}}

--- a/content/events/2017-edinburgh/welcome.md
+++ b/content/events/2017-edinburgh/welcome.md
@@ -88,7 +88,6 @@ aliases = ["/events/2017-edinburgh"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-hartford/welcome.md
+++ b/content/events/2017-hartford/welcome.md
@@ -87,5 +87,4 @@ aliases = ["/events/2017-hartford"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
-{{< event_twitter devopsdayshfd >}}
+{{< event_twitter >}}

--- a/content/events/2017-indianapolis/welcome.md
+++ b/content/events/2017-indianapolis/welcome.md
@@ -87,7 +87,6 @@ aliases = ["/events/2017-indianapolis"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-istanbul/welcome.md
+++ b/content/events/2017-istanbul/welcome.md
@@ -88,4 +88,4 @@ aliases = ["/events/2017-istanbul"]
 </div>
 
 
-{{< event_twitter devopsdaysist >}}
+{{< event_twitter >}}

--- a/content/events/2017-kansascity/welcome.md
+++ b/content/events/2017-kansascity/welcome.md
@@ -95,4 +95,4 @@ Where large enterprise software companies and a growing startup community are fu
   </div>
 </div>
 
-{{< event_twitter devopsdayskc >}}
+{{< event_twitter >}}

--- a/content/events/2017-london/welcome.md
+++ b/content/events/2017-london/welcome.md
@@ -87,7 +87,6 @@ aliases = ["/events/2017-london"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-los-angeles/welcome.md
+++ b/content/events/2017-los-angeles/welcome.md
@@ -83,7 +83,6 @@ DevOps Day LA is a single day event held annually in Southern California. This v
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-madison/welcome.md
+++ b/content/events/2017-madison/welcome.md
@@ -87,5 +87,4 @@ aliases = ["/events/2017-madison"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
-{{< event_twitter devopsdaysmsn >}}
+{{< event_twitter >}}

--- a/content/events/2017-minneapolis/welcome.md
+++ b/content/events/2017-minneapolis/welcome.md
@@ -81,5 +81,5 @@ aliases = ["/events/2017-minneapolis"]
 </div>
 
 
-{{< event_twitter devopsdaysmsp >}}
+{{< event_twitter >}}
 

--- a/content/events/2017-moscow/welcome.md
+++ b/content/events/2017-moscow/welcome.md
@@ -96,8 +96,8 @@ aliases = ["/events/2017-moscow"]
     </em>
   </div>
 </div>
-<!-- add your city twitter name here without the @ sign -->
+
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->
 

--- a/content/events/2017-ohio/welcome.md
+++ b/content/events/2017-ohio/welcome.md
@@ -93,6 +93,6 @@ In the mean time, check out the 2016 <a href="/events/2016-ohio/program">Program
   </div>
 </div>
 
-{{< event_twitter DevOpsDaysOhio >}} <!-- add your twitter name here without the @ sign -->
+{{< event_twitter >}}
 
 <a class="twitter-timeline" data-height="600" data-theme="light" href="https://twitter.com/DevOpsDaysOhio">Tweets by DevOpsDaysOhio</a> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/content/events/2017-paris/welcome.md
+++ b/content/events/2017-paris/welcome.md
@@ -109,5 +109,5 @@ discussions from industry practitioners and taste-makers.
 
 <br />
 <br />
-<!-- add your city twitter name here without the @ sign -->
-{{< event_twitter devopsrex >}}
+
+{{< event_twitter >}}

--- a/content/events/2017-philadelphia/welcome.md
+++ b/content/events/2017-philadelphia/welcome.md
@@ -72,4 +72,4 @@ aliases = ["/events/2017-philadelphia"]
   </div>
 </div>
 
-{{< event_twitter devopsdaysphl >}} <!-- add your twitter name here without the @ sign -->
+{{< event_twitter >}}

--- a/content/events/2017-portland/welcome.md
+++ b/content/events/2017-portland/welcome.md
@@ -89,7 +89,7 @@ Our event will be August 1st and 2nd. However, keep an eye out for a special fol
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
+
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-raleigh/welcome.md
+++ b/content/events/2017-raleigh/welcome.md
@@ -81,4 +81,4 @@ aliases = ["/events/2017-raleigh"]
   </div>
 </div>
 <br>
-{{< event_twitter devopsdaysrdu >}} <!-- add your twitter name here without the @ sign -->
+{{< event_twitter >}}

--- a/content/events/2017-salt-lake-city/welcome.md
+++ b/content/events/2017-salt-lake-city/welcome.md
@@ -99,5 +99,4 @@ The beauty of a Continuous Delivery pipeline and all of its components is knowin
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
-{{< event_twitter devopsdaysslc >}}
+{{< event_twitter >}}

--- a/content/events/2017-seattle/welcome.md
+++ b/content/events/2017-seattle/welcome.md
@@ -97,7 +97,6 @@ will be great for both speakers and attendees.
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-stockholm/welcome.md
+++ b/content/events/2017-stockholm/welcome.md
@@ -6,7 +6,7 @@ aliases = ["/events/2017-stockholm"]
 
 +++
 
-{{< event_twitter devopsdayssthlm >}}
+{{< event_twitter >}}
 
 **devopsdays is coming to {{<event_location>}}!**
 
@@ -87,7 +87,3 @@ aliases = ["/events/2017-stockholm"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
-<!--
-{{< event_twitter devopsdaysyourcity >}}
--->

--- a/content/events/2017-tokyo/welcome.md
+++ b/content/events/2017-tokyo/welcome.md
@@ -114,7 +114,6 @@ While English is becoming the de-facto language of software development, we will
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <!--
-{{< event_twitter devopsdaysyourcity >}}
+{{< event_twitter >}}
 -->

--- a/content/events/2017-toronto/welcome.md
+++ b/content/events/2017-toronto/welcome.md
@@ -86,10 +86,9 @@ aliases = ["/events/2017-toronto"]
   </div>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
 <div style="text-align:center;">
     <br/>
-    {{< event_twitter DevOpsDaysTO >}}
+    {{< event_twitter >}}
 </div>
 
 <!-- Begin MailChimp Signup Form -->

--- a/content/events/2017-washington-dc/welcome.md
+++ b/content/events/2017-washington-dc/welcome.md
@@ -88,14 +88,10 @@ aliases = ["/events/2017-washington-dc"]
 </div>
 
 <p>
-  {{< event_twitter devopsdaysdc >}}
+  {{< event_twitter >}}
 </p>
 
 <div>
 <a class="twitter-timeline" data-width="800" data-height="600" data-theme="light" href="https://twitter.com/DevOpsDaysDC">Tweets by DevOpsDaysDC</a> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
-<!-- add your city twitter name here without the @ sign -->
-<!--
-{{< event_twitter devopsdaysyourcity >}}
--->

--- a/content/events/2017-zurich/welcome.md
+++ b/content/events/2017-zurich/welcome.md
@@ -83,6 +83,6 @@ aliases = ["/events/2017-zurich"]
   </div>
   <div class = "col-md-8">
     {{< event_link page="contact" text="Get in touch with the organizers" >}}<br>
-    {{< event_twitter devopszh >}}
+    {{< event_twitter >}}
   </div>
 </div>

--- a/data/events/2017-kansascity.yml
+++ b/data/events/2017-kansascity.yml
@@ -1,8 +1,8 @@
 name: "2017-kansascity" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Kansas City" # The city name of the event. Capitalize it.
-friendly: "2017-kansascity" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "current" # Options are "past" or "current". Use "current" for upcoming.
+description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
+event_twitter: "devopsdayskc"
 
 # All dates are in unquoted 2016-MM-DD, like this:   variable: 2016-01-05
 #startdate: 2016-10-20 # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2017-madison.yml
+++ b/data/events/2017-madison.yml
@@ -2,6 +2,7 @@ name: "2017-madison" # The name of the event. Four digit year with the city name
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Madison" # The displayed city name of the event. Capitalize it.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
+event_twitter: "devopsdaysmsn"
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2017-ohio.yml
+++ b/data/events/2017-ohio.yml
@@ -2,8 +2,7 @@ name: "2017-ohio" # The name of the event. Four digit year with the city name in
 year: 2017 # The year of the event. Make sure it is in quotes.
 city: "Ohio" # The city name of the event. Capitalize it.
 event_twitter: "DevOpsDaysOhio"
-friendly: "2017-ohio" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "past" # Options are "past" or "current".
+
 startdate: "" # The start date of your event, in YYYY-MM-DD format. Leave blank if you don't have a date yet.
 enddate: "" # The end date of your event, in YYYY-MM-DD format. Leave blank if you don't have a date yet.
 cfp_date_start: ""

--- a/data/events/2017-zurich.yml
+++ b/data/events/2017-zurich.yml
@@ -2,7 +2,6 @@ name: "2017-zurich" # The name of the event. Four digit year with the city name 
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Zürich" # The city name of the event. Capitalize it.
 event_twitter: "DevOpsZH"
-friendly: "2017-zurich" # Four digit year and the city name in lower-case. Don't forget the dash!
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate: 2017-05-03


### PR DESCRIPTION
Cleanup for https://github.com/devopsdays/devopsdays-theme/issues/214 to prevent confusion. All event twitter handles I'm removing from welcome.md files already exist in the datafile for that city.

Some unavoidable changes because I'm adding an EOL that the file was missing.

Cleanup for some other detritus like `friendly`, etc.