### PR TITLE
[ATL-2017] Change Atlanta to use logo shortcode

### DIFF
--- a/content/events/2017-atlanta/welcome.md
+++ b/content/events/2017-atlanta/welcome.md
@@ -12,8 +12,8 @@ aliases = ["/events/2017-atlanta"]
 **devopsdays is coming to {{< event_location >}}!**
 <h3>Opening Keynote from <a href="https://github.com/kelseyhightower">Kelsey Hightower</a></h3>
 
- <div style="text-align:center;">
- <img alt="DevOpsDays Atlanta 2017" src="/events/2017-atlanta/logo.png" style="max-width: 90%;">
+<div style="text-align:center;">
+  {{< event_logo >}}
 </div>
 
 <div class = "row">


### PR DESCRIPTION
This keeps the image from being too huge

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>

