### PR TITLE
[Paris-2017] adjust style to avoid auto-caps

### DIFF
--- a/content/events/2017-paris/welcome.md
+++ b/content/events/2017-paris/welcome.md
@@ -25,7 +25,7 @@ discussions from industry practitioners and taste-makers.
 
 **The principal language of this conference will be French.**
 
-## Pour plus d'informations, veuillez visiter notre site principal: **https://www.devopsrex.fr/**
+<div style="font-weight: bolder; font-size: 125%">Pour plus d'informations, veuillez visiter notre site principal: <a href="https://www.devopsrex.fr/">https://www.devopsrex.fr/</a></div>
 
 <br />
 


### PR DESCRIPTION
The default style for `##` auto-capitalises each word, which looks horrendous in French. 😉  This makes it hurt less.

`r?` @jooooooon