### PR TITLE
Add CFP and Registration keys for events

### DIFF
--- a/content/events/2017-denver/welcome.md
+++ b/content/events/2017-denver/welcome.md
@@ -15,14 +15,14 @@ aliases = ["/events/2017-denver"]
   {{< event_logo >}}
 </div>
 
-DevOpsDays is back for its 3rd anual event in the Rocky Mountains {{< event_start >}} - {{< event_end >}}
+DevOpsDays is back for its 3rd annual event in the Rocky Mountains {{< event_start >}} - {{< event_end >}}
 
 <div class = "row">
   <div class = "col-md-2">
     <strong>Program</strong>
   </div>
   <div class = "col-md-8">
-    [Speakers List](/events/2017-denver/speakers/)
+    <a href = "/events/2017-denver/speakers/">Speakers List</a>
   </div>
 </div>
 <div class = "row">
@@ -30,7 +30,7 @@ DevOpsDays is back for its 3rd anual event in the Rocky Mountains {{< event_star
     <strong>Tickets</strong>
   </div>
   <div class = "col-md-8">
-    [Tickets are now availible](https://www.eventbrite.com/e/devopsdays-denver-2017-tickets-31187069364)
+    <a href = "https://www.eventbrite.com/e/devopsdays-denver-2017-tickets-31187069364">Tickets are now available</a>
   </div>
 </div>
 <div class = "row">

--- a/data/events/2017-amsterdam.yml
+++ b/data/events/2017-amsterdam.yml
@@ -13,6 +13,7 @@ cfp_date_end:  2017-04-01 # close your call for proposals.
 cfp_date_announce: 2017-04-15 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://devopsdays.typeform.com/to/hbkd2j"
+registration_open: "true"
 
 # Location
 coordinates: "52.376862, 4.922078" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html

--- a/data/events/2017-amsterdam.yml
+++ b/data/events/2017-amsterdam.yml
@@ -11,6 +11,8 @@ enddate:  2017-06-30
 cfp_date_start: 2017-01-15  # start accepting talk proposals.
 cfp_date_end:  2017-04-01 # close your call for proposals.
 cfp_date_announce: 2017-04-15 # inform proposers of status
+cfp_open: "true"
+cfp_link: "https://devopsdays.typeform.com/to/hbkd2j"
 
 # Location
 coordinates: "52.376862, 4.922078" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
@@ -25,7 +27,7 @@ organizer_email: "organizers-amsterdam-2017@devopsdays.org" # Put your organizer
 proposal_email: "organizers-amsterdam-2017@devopsdays.org" # Put your proposal email address here
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
 #  - name: program
   - name: propose
     url: https://devopsdays.typeform.com/to/hbkd2j

--- a/data/events/2017-atlanta.yml
+++ b/data/events/2017-atlanta.yml
@@ -11,6 +11,8 @@ enddate:  2017-04-19
 cfp_date_start:  2017-01-05
 cfp_date_end:  2017-02-27
 cfp_date_announce:  2017-03-01
+registration_open: "true"
+registration_link: "https://www.eventbrite.com/e/devopsdaysatl-2017-tickets-30968684168"
 
 # Location
 #
@@ -19,7 +21,7 @@ location: "Atlanta" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
   - name: program
 #  - name: propose
 #    url: https://www.papercall.io/devopsdaysatl2017 # The url setting is optional, and only if you want the navigation to link off-site

--- a/data/events/2017-denver.yml
+++ b/data/events/2017-denver.yml
@@ -11,9 +11,11 @@ cfp_date_end: 2017-02-17
 cfp_date_announce: 2017-03-01
 coordinates: "39.739236, -104.990251" # The corrodinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "Denver" # The name of your location
+registration_open: "true"
+registration_link: "https://www.eventbrite.com/e/devopsdays-denver-2017-tickets-31187069364"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
   - name: sponsor
   - name: speakers
   - name: contact

--- a/data/events/2017-istanbul.yml
+++ b/data/events/2017-istanbul.yml
@@ -11,6 +11,7 @@ enddate:  2017-09-29 # The end date of your event. Leave blank if you don't have
 cfp_date_start:  2017-02-10 # start accepting talk proposals.
 cfp_date_end: 2017-05-10 # close your call for proposals.
 cfp_date_announce: 2017-06-10 # inform proposers of status
+cfp_open: "true"
 
 # Location
 #
@@ -19,7 +20,7 @@ location: "Dedeman Bostanci Istanbul" # Defaults to city, but you can make it th
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
 #  - name: program
   - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/data/events/2017-minneapolis.yml
+++ b/data/events/2017-minneapolis.yml
@@ -10,12 +10,13 @@ enddate: 2017-07-26
 cfp_date_start: 2016-12-22
 cfp_date_end: 2017-04-09
 cfp_date_announce: 2017-05-07
+cfp_open: "true"
 
 coordinates: "44.972610,-93.272960"
 location: "Minneapolis"
 
 nav_elements:
- 
+
 #  - name: program
 #  - name: speakers
   - name: propose
@@ -49,7 +50,7 @@ proposal_email: "proposals-minneapolis-2017@devopsdays.org"
 sponsors:
   - id: arresteddevops
     level: community
-  - id: pivotal 
+  - id: pivotal
     level: platinum
   - id: deis
     level: silver

--- a/data/events/2017-minneapolis.yml
+++ b/data/events/2017-minneapolis.yml
@@ -11,6 +11,7 @@ cfp_date_start: 2016-12-22
 cfp_date_end: 2017-04-09
 cfp_date_announce: 2017-05-07
 cfp_open: "true"
+registration_open: "true"
 
 coordinates: "44.972610,-93.272960"
 location: "Minneapolis"

--- a/data/events/2017-oslo.yml
+++ b/data/events/2017-oslo.yml
@@ -12,6 +12,7 @@ cfp_date_start: 2017-02-09
 cfp_date_end: 2017-08-01
 cfp_date_announce: 2017-08-15
 cfp_open: "true"
+registration_open: "true"
 
 #cfp_date_start: 2017-03-18 # start accepting talk proposals.
 #cfp_date_end: 2017-05-29 # close your call for proposals.

--- a/data/events/2017-oslo.yml
+++ b/data/events/2017-oslo.yml
@@ -11,6 +11,7 @@ enddate: 2017-11-02  # The end date of your event. Leave blank if you don't have
 cfp_date_start: 2017-02-09
 cfp_date_end: 2017-08-01
 cfp_date_announce: 2017-08-15
+cfp_open: "true"
 
 #cfp_date_start: 2017-03-18 # start accepting talk proposals.
 #cfp_date_end: 2017-05-29 # close your call for proposals.
@@ -25,7 +26,7 @@ location: "Gamle Museet / The Old Museum" # Defaults to city, but you can make i
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
 #  - name: program
 #  - name: speakers
   - name: propose

--- a/data/events/2017-salt-lake-city.yml
+++ b/data/events/2017-salt-lake-city.yml
@@ -11,6 +11,8 @@ enddate: 2017-05-17 # The end date of your event. Leave blank if you don't have 
 cfp_date_start: 2016-12-14 # start accepting talk proposals.
 cfp_date_end: 2017-02-15 # close your call for proposals.
 cfp_date_announce: 2017-03-01 # inform proposers of status
+registration_open: "true"
+registration_link: "http://slcdevopsdays.org/tc-events/slc-devops-days-2917/"
 
 # Location
 #
@@ -19,7 +21,7 @@ location: "Noah's Event Venue" # Defaults to city, but you can make it the venue
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
 #  - name: program
   - name: propose
     url: https://www.papercall.io/slc-dev-ops-days

--- a/data/events/2017-seattle.yml
+++ b/data/events/2017-seattle.yml
@@ -11,6 +11,7 @@ enddate:  2017-04-27 # The end date of your event. Leave blank if you don't have
 cfp_date_start: 2016-10-24 # start accepting talk proposals.
 cfp_date_end: 2017-01-24 # close your call for proposals.
 cfp_date_announce: 2017-02-07 # inform proposers of status
+registration_open: "true"
 
 # Location
 #
@@ -19,7 +20,7 @@ location: "Seattle" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-# 
+#
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/data/events/2017-stockholm.yml
+++ b/data/events/2017-stockholm.yml
@@ -11,6 +11,7 @@ enddate:  2017-05-09 # The end date of your event. Leave blank if you don't have
 cfp_date_start: 2017-02-03  # start accepting talk proposals.
 cfp_date_end:  2017-03-05 # close your call for proposals.
 cfp_date_announce: 2017-03-26 # inform proposers of status
+registration_open: "true"
 
 # Location
 #
@@ -19,7 +20,7 @@ location: "Stockholm, Ballroom 12" # Defaults to city, but you can make it the v
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
 #  - name: program
   - name: propose
     #url: https://devopsdayssthlm.typeform.com/to/eMaXqd

--- a/data/events/2017-toronto.yml
+++ b/data/events/2017-toronto.yml
@@ -11,6 +11,7 @@ enddate: 2017-05-26 # The end date of your event. Leave blank if you don't have 
 cfp_date_start: 2016-12-21 # start accepting talk proposals.
 cfp_date_end:  2017-02-07 # close your call for proposals.
 cfp_date_announce: 2017-03-07 # inform proposers of status.
+registration_open: "true"
 
 # Location
 #
@@ -19,7 +20,7 @@ location: "Glenn Gould Studio" # The name of your location
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
   - name: program
   - name: speakers
   - name: propose

--- a/data/events/2017-vancouver.yml
+++ b/data/events/2017-vancouver.yml
@@ -12,6 +12,8 @@ enddate:  2017-04-01 # The end date of your event. Leave blank if you don't have
 cfp_date_start: 2016-12-01 # start accepting talk proposals.
 cfp_date_end: 2017-02-01 # close your call for proposals.
 cfp_date_announce: 2017-02-11 # inform proposers of status
+registration_open: "true"
+registration_link: "https://www.eventbrite.ca/e/devops-days-vancouver-2017-mar-31st-apr-1st-tickets-29634403298"
 
 # Location
 #
@@ -20,7 +22,7 @@ location: "Vancouver" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
   - name: program
   - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/data/events/2017-washington-dc.yml
+++ b/data/events/2017-washington-dc.yml
@@ -14,6 +14,8 @@ cfp_date_end:  2017-05-04
 cfp_date_announce: 2017-06-04
 cfp_open: "true"
 cfp_link: "https://devopsdaysdc2017.busyconf.com/proposals/new"
+registration_open: "true"
+registration_link: "https://devopsdaysdc2017.busyconf.com/bookings/new"
 
 # Location
 #

--- a/data/events/2017-washington-dc.yml
+++ b/data/events/2017-washington-dc.yml
@@ -11,7 +11,9 @@ enddate:  2017-07-18
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2017-03-07
 cfp_date_end:  2017-05-04
-cfp_date_announce: 2017-06-04 
+cfp_date_announce: 2017-06-04
+cfp_open: "true"
+cfp_link: "https://devopsdaysdc2017.busyconf.com/proposals/new"
 
 # Location
 #
@@ -20,7 +22,7 @@ location: "Washington, DC" # Defaults to city, but you can make it the venue nam
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
 #  - name: program
   - name: propose
     url: https://devopsdaysdc2017.busyconf.com/proposals/new

--- a/data/events/2017-zurich.yml
+++ b/data/events/2017-zurich.yml
@@ -10,6 +10,7 @@ enddate: 2017-05-04
 cfp_date_start: 2016-11-01 # start accepting talk proposals.
 cfp_date_end: 2017-02-01 # close your call for proposals.
 cfp_date_announce: 2017-04-01 # inform proposers of status
+registration_open: "true"
 
 # Location
 #
@@ -18,7 +19,7 @@ location: "Zürich Winterthur" # Defaults to city, but you can make it the venue
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- 
+
   - name: speakers
   - name: program
 # - name: propose


### PR DESCRIPTION
For events that have open CFP's and registrations, i have updated their data files which will make the CTA buttons display on their event pages.
