### PR TITLE
[ZRH-2017] Corrected URL of sponsor opsgenie-zurich-2017

### DIFF
--- a/data/sponsors/opsgenie-zurich-2017.yml
+++ b/data/sponsors/opsgenie-zurich-2017.yml
@@ -1,3 +1,3 @@
 name: "OpsGenie"
-url: "www.opsgenie.com?utm_source=Events&utm_campaign=DevOpsDays_Zurich_%20May&utm_medium=banner"
+url: "http://www.opsgenie.com?utm_source=Events&utm_campaign=DevOpsDays_Zurich_%20May&utm_medium=banner"
 twitter: "opsgenie"


### PR DESCRIPTION
Corrected URL of sponsor opsgenie-zurich-2017, HTTP:// prefix was missing.
