### PR TITLE
Updating theme to 1.4.0

### DIFF
--- a/gulp/tasks/copy-static-files.js
+++ b/gulp/tasks/copy-static-files.js
@@ -2,7 +2,7 @@ var gulp = require('gulp'),
     runSequence = require('run-sequence');
 
 gulp.task('copy-misc-files', function() {
-    return gulp.src(['public/sitemap.xml', 'public/**/index.xml', 'public/tags/**/*.xml', 'public/**/sharing.jpg', 'public/favicon*', 'public/apple-icon*', 'public/android-icon*', 'public/ms-icon*', 'public/manifest.json', 'public/browserconfig.xml', 'public/**/*.pdf','public/_redirects', 'public/robots.txt'])
+    return gulp.src(['public/sitemap.xml', 'public/**/index.xml', 'public/tags/**/*.xml', 'public/**/sharing.jpg', 'public/favicon*', 'public/apple-icon*', 'public/android-icon*', 'public/ms-icon*', 'public/manifest.json', 'public/browserconfig.xml', 'public/**/*.pdf', 'public/**/*.gif', 'public/_redirects', 'public/robots.txt'])
         .pipe(gulp.dest('dist'));
 });
 

--- a/gulp/tasks/responsive-images.js
+++ b/gulp/tasks/responsive-images.js
@@ -121,12 +121,25 @@ gulp.task('responsive-sponsor-images', function() {
 
 
 gulp.task('responsive-images-remaining', function() {
-    return gulp.src(['public/**/*.png', 'public/**/*.jpg',
+    return gulp.src(['public/**/*.png', 'public/**/*.jpg','public/**/*.jpeg',
             '!public/favicon*', '!public/apple-icon*', '!public/android-icon*', '!public/ms-icon*', '!public/**/sharing.jpg', '!**/logo-square.*', '!public/img/sponsor/*.*', '!public/**/organizers/*.jpg',
         ])
         .pipe(responsive({
             // produce multiple images from one source
             '**/*.png': [{
+                width: '100%'
+            }, {
+                width: '100%',
+                rename: {
+                    suffix: '@2x'
+                }
+            }, {
+                width: '100%',
+                rename: {
+                    suffix: '@3x'
+                }
+            }],
+            '**/*.jpeg': [{
                 width: '100%'
             }, {
                 width: '100%',

--- a/gulp/tasks/revision.js
+++ b/gulp/tasks/revision.js
@@ -4,7 +4,7 @@ var gulp = require('gulp'),
 
 
 gulp.task('revision', function(){
-  return gulp.src(['staging/**/*.+(png|jpg|gif|svg|js|css)','!staging/favicon*', '!staging/apple-icon*', '!staging/android-icon*', '!staging/ms-icon*', '!staging/**/sharing.jpg'])
+  return gulp.src(['staging/**/*.+(png|jpg|jpeg|gif|svg|js|css)','!staging/favicon*', '!staging/apple-icon*', '!staging/android-icon*', '!staging/ms-icon*', '!staging/**/sharing.jpg'])
   .pipe(rev())
   .pipe(gulp.dest('dist'))
   .pipe(rev.manifest())

--- a/themes/devopsdays-theme/CHANGELOG.md
+++ b/themes/devopsdays-theme/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [1.4.0](https://github.com/devopsdays/devopsdays-theme/tree/1.4.0) (2017-03-23)
+[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.3.0...1.4.0)
+
+**Implemented enhancements:**
+
+- Add scripts for managing theme [\#416](https://github.com/devopsdays/devopsdays-theme/issues/416)
+
+**Fixed bugs:**
+
+- Newly created events with no speakers return an error [\#426](https://github.com/devopsdays/devopsdays-theme/issues/426)
+- speaker pics with .jpeg extenstion dropped from site [\#425](https://github.com/devopsdays/devopsdays-theme/issues/425)
+- Replace use of $.Now.Format [\#407](https://github.com/devopsdays/devopsdays-theme/issues/407)
+
 ## [1.3.0](https://github.com/devopsdays/devopsdays-theme/tree/1.3.0) (2017-03-22)
 [Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.2.0...1.3.0)
 
@@ -9,6 +22,7 @@
 - Auto-detect for sharing image and show default if not there - IDEA 24 [\#412](https://github.com/devopsdays/devopsdays-theme/issues/412)
 - Navigation links to propose and register should respect the ones set in the YAML - IDEA 57 [\#406](https://github.com/devopsdays/devopsdays-theme/issues/406)
 - Text set to bold in content pages does not display as bold as it could - IDEA 47 [\#405](https://github.com/devopsdays/devopsdays-theme/issues/405)
+- Add amp conversion [\#27](https://github.com/devopsdays/devopsdays-theme/issues/27)
 - Improve CONTRIBUTING.md [\#18](https://github.com/devopsdays/devopsdays-theme/issues/18)
 
 **Fixed bugs:**

--- a/themes/devopsdays-theme/layouts/events/single.html
+++ b/themes/devopsdays-theme/layouts/events/single.html
@@ -14,7 +14,7 @@
   {{ $.Scratch.Set "close-tag" "false" }}
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}

--- a/themes/devopsdays-theme/layouts/index.html
+++ b/themes/devopsdays-theme/layouts/index.html
@@ -12,7 +12,7 @@
     <div class="row">
         {{- range sort $.Site.Data.events "startdate" -}}
         {{- if .startdate -}}
-        {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+        {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
         {{ $.Scratch.Set "city" .city }}
         {{ $.Scratch.Set "year" .year }}
         {{ $.Scratch.Set "logo" "unset" }}

--- a/themes/devopsdays-theme/layouts/partials/about.html
+++ b/themes/devopsdays-theme/layouts/partials/about.html
@@ -1,6 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}

--- a/themes/devopsdays-theme/layouts/partials/events/cta.html
+++ b/themes/devopsdays-theme/layouts/partials/events/cta.html
@@ -27,7 +27,7 @@
     {{ else }}
       {{ if $e.startdate }}
         {{ if $e.registration_date_start }}
-          {{- if and (ge (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) (dateFormat "2006-01-02" $e.registration_date_start)) (le (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) (dateFormat "2006-01-02" $e.registration_date_end)) }}
+          {{- if and (ge (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.registration_date_start)) (le (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.registration_date_end)) }}
             {{ if $e.registration_link }}
               {{ if eq $e.registration_link "" }}
                 {{ $.Scratch.Set "registration_link" (printf "/events/%s/propose" $event_slug)}}
@@ -57,7 +57,7 @@
   <!-- propose button -->
   {{ if $e.startdate }}
     {{ if $e.cfp_date_start }}
-      {{- if and (ge (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) (dateFormat "2006-01-02" $e.cfp_date_start)) (le (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) (dateFormat "2006-01-02" $e.cfp_date_end)) }}
+      {{- if and (ge (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.cfp_date_start)) (le (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.cfp_date_end)) }}
         {{ if $e.cfp_link }}
           {{ if eq $e.cfp_link "" }}
             {{ $.Scratch.Set "cfp_link" (printf "/events/%s/propose" $event_slug)}}

--- a/themes/devopsdays-theme/layouts/partials/footer.html
+++ b/themes/devopsdays-theme/layouts/partials/footer.html
@@ -47,7 +47,7 @@
       <h3 class="footer-nav">CFP OPEN</h3>
       {{ range sort $.Site.Data.events "startdate" }}
         {{ if .cfp_date_end }}
-          {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+          {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
             <a href = "/events/{{ .name }}/" class = "footer-content">{{ .city }}</a><br />
           {{ end }} {{/* end: date is now or afterwards */}}
         {{ end }} {{/* end: if .cfp_date_end */}}

--- a/themes/devopsdays-theme/layouts/partials/future.html
+++ b/themes/devopsdays-theme/layouts/partials/future.html
@@ -1,6 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}

--- a/themes/devopsdays-theme/layouts/partials/map.html
+++ b/themes/devopsdays-theme/layouts/partials/map.html
@@ -28,7 +28,7 @@ function initialize() {
         {{ if .startdate }}
 
       // if the startdate is today or in the future
-          {{ if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+          {{ if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
 
       // if the startdate month and enddate month are different, show both months
             {{ if ne (dateFormat "Jan" .startdate) (dateFormat "Jan" .enddate) }}

--- a/themes/devopsdays-theme/layouts/partials/past.html
+++ b/themes/devopsdays-theme/layouts/partials/past.html
@@ -11,7 +11,7 @@ Chomping .year has the nice effect of turning an int into string. -->
   {{ range $.Site.Data.events }}
   {{ if .startdate }}
   {{ $my_year := string ((dateFormat "2006" .enddate ))}}
-    {{ if and (eq $my_year (string $r_year)) ( lt (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")))  }}
+    {{ if and (eq $my_year (string $r_year)) ( lt (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)))  }}
       {{ $.Scratch.SetInMap "active_years" (print (chomp $my_year)) (print (chomp $my_year)) }}
       {{ $.Scratch.SetInMap (print (chomp $my_year)) .enddate (.name) }}
     {{ end }}

--- a/themes/devopsdays-theme/layouts/partials/speaking.html
+++ b/themes/devopsdays-theme/layouts/partials/speaking.html
@@ -6,7 +6,7 @@
   {{ range sort $.Site.Data.events "startdate" }}
 
   {{ if .cfp_date_end }}
-    {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+    {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
       {{ $.Scratch.Add "events" "<tr><td><a href = '/events/" }}
       {{ $.Scratch.Add "events" .name }}
       {{ $.Scratch.Add "events" "/' class = 'speaking'>" }}
@@ -24,4 +24,3 @@
 
 
   {{ $.Scratch.Get "events" | safeHTML}}
-

--- a/themes/devopsdays-theme/layouts/partials/sponsors.html
+++ b/themes/devopsdays-theme/layouts/partials/sponsors.html
@@ -15,7 +15,7 @@
                 {{ $.Scratch.Add $level.id 1 }}
               {{ end }}
             {{ end }}
-            {{- if ( $e.startdate) or (ge (dateFormat "2006-01-02" $e.startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02"))) -}}
+            {{- if ( $e.startdate) or (ge (dateFormat "2006-01-02" $e.startdate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now))) -}}
               {{- if ne $e.sponsors_accepted "no" -}}
                 {{- if or (not $level.max) (lt ($.Scratch.Get $level.id) $level.max) -}}
                   <a href = "/events/{{ $e.name }}/sponsor" class="sponsor-cta">

--- a/themes/devopsdays-theme/layouts/section/events.rss.xml
+++ b/themes/devopsdays-theme/layouts/section/events.rss.xml
@@ -12,7 +12,7 @@
 <atom:link href="{{ $.Site.Params.weburl }}/events/index.xml" rel="self" type="application/rss+xml" />
 <link>{{ $.Site.Params.weburl }}</link>
     <description>Upcoming devopsdays events</description>
-<lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" .Now }}</lastBuildDate>
+<lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</lastBuildDate>
 <sy:updatePeriod>hourly</sy:updatePeriod>
 <sy:updateFrequency>1</sy:updateFrequency>
 <language>en-us</language>
@@ -20,12 +20,12 @@
 <generator>Hugo -- gohugo.io</generator>
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
     <item>
       <title>devopsdays {{ .city }} {{ .year }}</title>
       <link>{{ $.Site.Params.weburl }}/events/{{ .name}}</link>
       <guid>{{ $.Site.Params.weburl }}/events/{{ .name}}</guid>
-      <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" $.Now }}</pubDate>
+      <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</pubDate>
       {{ if .description }}
         <description>{{.description | markdownify | htmlEscape}}</description>
       {{ else }}

--- a/themes/devopsdays-theme/layouts/section/speaking.rss.xml
+++ b/themes/devopsdays-theme/layouts/section/speaking.rss.xml
@@ -12,7 +12,7 @@
 <atom:link href="{{ $.Site.Params.weburl }}/events/index.xml" rel="self" type="application/rss+xml" />
 <link>{{ $.Site.Params.weburl }}</link>
     <description>devopsdays events with open CFP's</description>
-<lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" .Now }}</lastBuildDate>
+<lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</lastBuildDate>
 <sy:updatePeriod>hourly</sy:updatePeriod>
 <sy:updateFrequency>1</sy:updateFrequency>
 <language>en-us</language>
@@ -20,14 +20,14 @@
 <generator>Hugo -- gohugo.io</generator>
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
       {{ if .cfp_date_end }}
-        {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+        {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
         <item>
           <title>devopsdays {{ .city }} {{ .year }}</title>
           <link>{{ $.Site.Params.weburl }}/events/{{ .name}}</link>
           <guid>{{ $.Site.Params.weburl }}/events/{{ .name}}</guid>
-          <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" $.Now }}</pubDate>
+          <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</pubDate>
           {{ if .description }}
             <description>{{.description }}</description>
           {{ else }}

--- a/themes/devopsdays-theme/layouts/speakers/single.html
+++ b/themes/devopsdays-theme/layouts/speakers/single.html
@@ -59,23 +59,25 @@
 <!-- old stuff -->
 {{ if ne ($.Scratch.Get "speakers-exist") "true" }}
   {{ .Content }}
-
-  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) $city_slug }}
-<div class="row">
-  <div class="col-md-12 col-lg-3">
-      <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="speakers-page old-speaker">
-  </div>
-  <div class= "col-md-12 col-lg-9 old-speaker-bio speakers-page">
-     <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
-     {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
-     {{ if $s.website }}Website: <a href="{{ $s.website }}">{{ $s.website }}</a><br>{{ end }}
-     {{ if $s.pronouns }}Pronouns: {{ $s.pronouns }}{{ end }}
-   <br>
-   {{ $s.bio | markdownify }}
-<hr>
-  </div>
-</div>
-
+  {{ if (where (readDir "data/speakers") "Name" (chomp $e.year))}}
+    {{ if (where (readDir (printf "data/speakers/%s" (chomp $e.year) )) "Name" $city_slug )}}
+      {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) $city_slug }}
+        <div class="row">
+          <div class="col-md-12 col-lg-3">
+              <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="speakers-page old-speaker">
+          </div>
+          <div class= "col-md-12 col-lg-9 old-speaker-bio speakers-page">
+             <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
+             {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
+             {{ if $s.website }}Website: <a href="{{ $s.website }}">{{ $s.website }}</a><br>{{ end }}
+             {{ if $s.pronouns }}Pronouns: {{ $s.pronouns }}{{ end }}
+           <br>
+           {{ $s.bio | markdownify }}
+        <hr>
+          </div>
+        </div>
+    {{ end }}
+  {{end }}
 {{ end }}
 
 <style>

--- a/themes/devopsdays-theme/theme.toml
+++ b/themes/devopsdays-theme/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/devopsdays/devopsdays-theme/"
 tags = ["", ""]
 features = ["", ""]
 min_version = 0.18
-theme_version = 1.3.0
+theme_version = 1.4.0
 
 [author]
   name = "Matt Stratton"


### PR DESCRIPTION
## [1.4.0](https://github.com/devopsdays/devopsdays-theme/tree/1.4.0) (2017-03-23)
[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.3.0...1.4.0)

**Implemented enhancements:**

- Add scripts for managing theme [\#416](https://github.com/devopsdays/devopsdays-theme/issues/416)

**Fixed bugs:**

- Newly created events with no speakers return an error [\#426](https://github.com/devopsdays/devopsdays-theme/issues/426)
- speaker pics with .jpeg extenstion dropped from site [\#425](https://github.com/devopsdays/devopsdays-theme/issues/425)
- Replace use of $.Now.Format [\#407](https://github.com/devopsdays/devopsdays-theme/issues/407)