### PR TITLE
Removing speakers files that aren't used yet

### DIFF
--- a/content/events/2017-boston/speakers.md
+++ b/content/events/2017-boston/speakers.md
@@ -1,5 +1,0 @@
-+++
-Title = "Speakers"
-Type = "speakers"
-Description = "Speakers for devopsdays Boston 2017"
-+++

--- a/content/events/2017-brasilia/speakers.md
+++ b/content/events/2017-brasilia/speakers.md
@@ -1,5 +1,0 @@
-+++
-Title = "Speakers"
-Type = "speakers"
-Description = "Speakers for devopsdays Brasilia 2017"
-+++

--- a/content/events/2017-kansascity/speakers.md
+++ b/content/events/2017-kansascity/speakers.md
@@ -1,6 +1,0 @@
-+++
-date = "2016-09-06T21:56:55-05:00"
-title = "speakers"
-type = "speakers"
-
-+++

--- a/content/events/2017-philadelphia/speakers.md
+++ b/content/events/2017-philadelphia/speakers.md
@@ -1,7 +1,0 @@
-+++
-Year = "2017"
-date = "2017-02-28"
-title = "speakers"
-type = "speakers"
-
-+++

--- a/content/events/2018-kiel/speakers.md
+++ b/content/events/2018-kiel/speakers.md
@@ -1,5 +1,0 @@
-+++
-Title = "Speakers"
-Type = "speakers"
-Description = "Speakers for devopsdays Kiel 2018"
-+++


### PR DESCRIPTION
These files aren't used yet, and now they'll be added when the event uses the script to add speakers (see https://github.com/devopsdays/devopsdays-web/pull/2125).