### PR TITLE
Different date to work around past events display bug.

### DIFF
--- a/data/events/2016-kiel.yml
+++ b/data/events/2016-kiel.yml
@@ -4,7 +4,7 @@ city: "Kiel"
 friendly: "2016-kiel"
 status: "past"
 startdate: 2016-05-11
-enddate: 2016-05-13
+enddate: 2016-05-12
 coordinates: "54.3233, 10.1228"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.


### PR DESCRIPTION
This is to work around the bug described in https://github.com/devopsdays/devopsdays-theme/issues/444.