### PR TITLE
Clarifying sponsor updates

### DIFF
--- a/utilities/README.md
+++ b/utilities/README.md
@@ -53,6 +53,8 @@ sponsors:
 
 If you want to update a sponsor, keep in mind that we don't want to retroactively change history for past events. See this [previous discussion](https://github.com/devopsdays/devopsdays-web/pull/503) for guidance. Basically you need to preserve past history before defining a changed default.
 
+Note that if a sponsor asks for an update affecting all future events, the shared sponsor entry will be changed for all events without any intervention needed from local organizers who have listed that sponsor. This is a benefit to using the shared sponsor entry.
+
 
 ### Adding a new sponsor
 


### PR DESCRIPTION
Sponsor updates only need to happen once if people are using the shared sponsor entry. They will affect all future events but not past ones.