### PR TITLE
Updating theme to 1.6.1

### DIFF
--- a/themes/devopsdays-theme/CHANGELOG.md
+++ b/themes/devopsdays-theme/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.6.1](https://github.com/devopsdays/devopsdays-theme/tree/1.6.1) (2017-03-30)
+[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.6.0...1.6.1)
+
+**Fixed bugs:**
+
+- CTA buttons don't change color with custom masthead [\#456](https://github.com/devopsdays/devopsdays-theme/issues/456)
+
 ## [1.6.0](https://github.com/devopsdays/devopsdays-theme/tree/1.6.0) (2017-03-30)
 [Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.5.2...1.6.0)
 

--- a/themes/devopsdays-theme/layouts/partials/events/cta.html
+++ b/themes/devopsdays-theme/layouts/partials/events/cta.html
@@ -88,8 +88,8 @@
 
 </div>
 
-{{ if $e.background }}
-  {{ if ne $e.background "" }}
+{{ if $e.masthead_background }}
+  {{ if ne $e.masthead_background "" }}
     <style>
     a.jssocials-share-link {
       color: #fff;

--- a/themes/devopsdays-theme/theme.toml
+++ b/themes/devopsdays-theme/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/devopsdays/devopsdays-theme/"
 tags = ["", ""]
 features = ["", ""]
 min_version = 0.18
-theme_version = 1.6.0
+theme_version = 1.6.1
 
 [author]
   name = "Matt Stratton"


### PR DESCRIPTION
**Fixed bugs:**

- CTA buttons don't change color with custom masthead [\#456](https://github.com/devopsdays/devopsdays-theme/issues/456)