### PR TITLE
Fix old upload links

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,6 @@
 /events/2009-ghent/*          http://legacy.devopsdays.org/events/2009-ghent/:splat     301!
 /events/2010*                 http://legacy.devopsdays.org/events/2010:splat            301!
-/blog/wp-content/*            http://legacy.devopsdays.org/blog/wp-content:splat        301!
+/blog/wp-content/*            http://legacy.devopsdays.org/blog/wp-content/:splat       301!
 /events/2011*                 http://legacy.devopsdays.org/events/2011:splat            301!
 /events/2012*                 http://legacy.devopsdays.org/events/2012:splat            301!
 /events/2013*                 http://legacy.devopsdays.org/events/2013:splat            301!

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,6 @@
 /events/2009-ghent/*          http://legacy.devopsdays.org/events/2009-ghent/:splat     301!
 /events/2010*                 http://legacy.devopsdays.org/events/2010:splat            301!
+/blog/wp-content/*            http://legacy.devopsdays.org/blog/wp-content:splat        301!
 /events/2011*                 http://legacy.devopsdays.org/events/2011:splat            301!
 /events/2012*                 http://legacy.devopsdays.org/events/2012:splat            301!
 /events/2013*                 http://legacy.devopsdays.org/events/2013:splat            301!


### PR DESCRIPTION
I'm not positive this is the right way to fix https://github.com/devopsdays/devopsdays-web/issues/2202 but since a local test doesn't cover the legacy URLs I'm not sure how to check.

