### PR TITLE
Old blog links got rewritten. fixing old links.

### DIFF
--- a/content/blog/announcing-devopsdays-mountainview-2011.md
+++ b/content/blog/announcing-devopsdays-mountainview-2011.md
@@ -2,6 +2,7 @@
 Title = "DevOpsDays 2011 - Mountain View Announcement"
 Date = "2011-04-13T00:00:00+01:00"
 Tags = ["mountainview-2011"]
+aliases = ["/blog/2011/04/13/announcing-devopsdays-mountainview-2011/"]
 +++
 
 ## Announcing the 2011 DevOps Days - Mt. View

--- a/content/blog/boston-devopsdays-7-8-march-2011.md
+++ b/content/blog/boston-devopsdays-7-8-march-2011.md
@@ -2,6 +2,7 @@
 Title = "Boston Devopsdays 7-8 March 2011 Call for papers"
 Date = "2011-01-08T23:16:57+01:00"
 Tags = ["boston-2011"]
+aliases = ["/blog/2011/01/08/boston-devopsdays-7-8-march-2011/"]
 +++
 
 Another year, another devopsdays! This time in the marvelous city of Boston.

--- a/content/blog/call-for-proposals-devops-us-opens.md
+++ b/content/blog/call-for-proposals-devops-us-opens.md
@@ -3,6 +3,7 @@ Title = "Devopsday 2010 US - Call for proposals"
 Author = "patrick.debois"
 Date = "2010-02-13T13:17:18+00:00"
 Tags = ["devops", "devopsdays"]
+aliases = ["/blog/2010/02/13/call-for-proposals-devops-us-opens/"]
 +++
 
 Devopsday USA 2010 will be held in **Mountain View, California on Friday, June 25, 2010**. This event is inspired by and a continuation of the conversation from [Devopsdays Belgium 2009](/events/2009-ghent/program)

--- a/content/blog/devopsday-brazil-2010-devops-go-samba.md
+++ b/content/blog/devopsday-brazil-2010-devops-go-samba.md
@@ -2,6 +2,7 @@
 Title = "devopsday Brazil 2010 - devops go samba!"
 Date = "2010-11-04T11:38:11+00:00"
 Tags = ["2010-Brazil"]
+aliases = ["/blog/2010/11/04/devopsday-brazil-2010-devops-go-samba/"]
 +++
 
 <table>

--- a/content/blog/devopsdays-2009-belgium-was-a-great-succes.md
+++ b/content/blog/devopsdays-2009-belgium-was-a-great-succes.md
@@ -2,6 +2,7 @@
 Title = "Devopsdays 2009 Belgium: A great success"
 Author = "patrick.debois"
 Date = "2009-11-11T19:52:12+00:00"
+aliases = ["/blog/2009/11/11/devopsdays-2009-belgium-was-a-great-succes/"]
 +++
 
 <a href="/blog/wp-content/uploads/2010/02/devopsdays-large-transparent.png"><img title="devopsdays-large-transparent" class="size-medium wp-image-122 alignnone" src="/blog/wp-content/uploads/2010/02/devopsdays-large-transparent.png" height="121" alt="" width="201" /></a>

--- a/content/blog/devopsdays-belgium-videos-and-presentations-are-online.md
+++ b/content/blog/devopsdays-belgium-videos-and-presentations-are-online.md
@@ -2,6 +2,7 @@
 Title = "Devopsdays 2009 Belgium - Videos and presentations"
 Author = "patrick.debois"
 Date = "2009-12-21T20:07:17+00:00"
+aliases = ["/blog/2009/12/21/devopsdays-belgium-videos-and-presentations-are-online/"]
 +++
 
 Subject says it all ;-)

--- a/content/blog/devopsdays-europe-2010-call-for-speakers-open.md
+++ b/content/blog/devopsdays-europe-2010-call-for-speakers-open.md
@@ -2,6 +2,7 @@
 Title = "Devopsdays Europe 2010 - Call for Speakers open"
 Date = "2010-08-02T14:36:20+00:00"
 Tags = ["2010-Europe", "Uncategorized"]
+aliases = ["/blog/2010/08/02/devopsdays-europe-2010-call-for-speakers-open/"]
 +++
 
 <table>

--- a/content/blog/dod-barcelona-2013.md
+++ b/content/blog/dod-barcelona-2013.md
@@ -2,6 +2,7 @@
 Title = "DevOpsDays Barcelona 2013"
 Date = "2013-08-26T14:02:27+01:00"
 Tags = ["2013", "barcelona"]
+aliases = ["/blog/2013/08/26/dod-barcelona-2013/"]
 
 +++
 

--- a/content/blog/dod-paris-2013.md
+++ b/content/blog/dod-paris-2013.md
@@ -2,6 +2,7 @@
 Title = "DevOpsDays Paris 2013"
 Date = "2013-03-08T14:02:27+01:00"
 Tags = ["2013", "paris"]
+aliases = ["/blog/2013/03/08/dod-paris-2013/"]
 
 +++
 

--- a/content/blog/final-speakers-rome-2012.md
+++ b/content/blog/final-speakers-rome-2012.md
@@ -2,6 +2,7 @@
 Title = "DevOpsDays 2012 - Rome Final Speakerslist"
 Date = "2012-08-30T20:16:57+01:00"
 Tags = ["2012"]
+aliases = ["/blog/2012/08/30/final-speakers-rome-2012/"]
 
 +++
 

--- a/content/blog/mountainview-t-shirt-contest.md
+++ b/content/blog/mountainview-t-shirt-contest.md
@@ -2,6 +2,7 @@
 Title = "DevOpsDays 2011 - Mountain View T-Shirt Design Contest"
 Date = "2011-04-26T23:16:57+01:00"
 Tags = ["mountainview-2011"]
+aliases = ["/blog/2011/04/26/mountainview-t-shirt-contest/"]
 +++
 
 For the upcoming [DevOpsDays in Mountain View](/events/2011-mountainview) we're looking to create t-shirts based off of your design.  We're going to run a design submission period, followed by a brief rating period.  The design with the most votes will get printed on the back of the Devopsdays 2011 - Mountain View event shirt.  How cool is that?


### PR DESCRIPTION
At some point we rewrote old blog links, and it also appears that some changed over time. This attempts to fix the broken links that have turned up in google's tools. In local testing these rewrites work like it says on the tin.