### PR TITLE
Redirection for incorrect LA url

### DIFF
--- a/content/events/2017-los-angeles/conduct.md
+++ b/content/events/2017-los-angeles/conduct.md
@@ -1,6 +1,7 @@
 +++
 title = "Code of Conduct"
 type = "event"
+aliases = ["/events/2017-losangeles/conduct"]
 +++
 
 ## ANTI-HARASSMENT POLICY

--- a/content/events/2017-los-angeles/contact.md
+++ b/content/events/2017-los-angeles/contact.md
@@ -1,6 +1,7 @@
 +++
 title = "Contact Information"
 type = "event"
+aliases = ["/events/2017-losangeles/contact"]
 +++
 
 If you'd like to contact us by email: {{< email_organizers >}}

--- a/content/events/2017-los-angeles/location.md
+++ b/content/events/2017-los-angeles/location.md
@@ -1,6 +1,7 @@
 +++
 title = "Location"
 type = "event"
+aliases = ["/events/2017-losangeles/location"]
 +++
 
 <h2>Venue</h2>

--- a/content/events/2017-los-angeles/program.md
+++ b/content/events/2017-los-angeles/program.md
@@ -2,6 +2,7 @@
 date = "2016-03-06T21:28:07-06:00"
 title = "Schedule"
 type = "event"
+aliases = ["/events/2017-losangeles/program"]
 
 +++
 

--- a/content/events/2017-los-angeles/program/amye-scavarda.md
+++ b/content/events/2017-los-angeles/program/amye-scavarda.md
@@ -3,6 +3,7 @@ date = "2017-01-25T01:21:56-08:00"
 linktitle = "amye-scavarda"
 title = "Amye Scavarda"
 type = "talk"
+aliases = ["/events/2017-losangeles/program/amye-scavarda"]
 
 +++
 

--- a/content/events/2017-los-angeles/program/bob-reselman.md
+++ b/content/events/2017-los-angeles/program/bob-reselman.md
@@ -3,6 +3,7 @@ date = "2017-01-25T01:20:39-08:00"
 linktitle = "bob-reselman"
 title = "What Do We Do After We've Automated Everything?"
 type = "talk"
+aliases = ["/events/2017-losangeles/program/bob-reselman"]
 
 +++
 

--- a/content/events/2017-los-angeles/program/john-dewey.md
+++ b/content/events/2017-los-angeles/program/john-dewey.md
@@ -3,6 +3,7 @@ date = "2017-01-25T01:22:45-08:00"
 linktitle = "john-dewey"
 title = "John Dewey"
 type = "talk"
+aliases = ["/events/2017-losangeles/program/john-dewey"]
 +++
 
 <div class="span-15  ">

--- a/content/events/2017-los-angeles/program/john-willis.md
+++ b/content/events/2017-los-angeles/program/john-willis.md
@@ -3,6 +3,7 @@ date = "2017-01-25T01:15:27-08:00"
 linktitle = "john-willis"
 title = "John Willis"
 type = "talk"
+aliases = ["/events/2017-losangeles/program/john-willis"]
 
 +++
 

--- a/content/events/2017-los-angeles/program/kevin-smith.md
+++ b/content/events/2017-los-angeles/program/kevin-smith.md
@@ -3,6 +3,7 @@ date = "2017-01-25T01:20:13-08:00"
 linktitle = "kevin-smith"
 title = "Kevin Smith"
 type = "talk"
+aliases = ["/events/2017-losangeles/program/kevin-smith"]
 
 +++
 

--- a/content/events/2017-los-angeles/program/kiyor-cai.md
+++ b/content/events/2017-los-angeles/program/kiyor-cai.md
@@ -3,6 +3,7 @@ date = "2017-01-25T01:19:31-08:00"
 linktitle = "kiyor-cai"
 title = "Kiyor Cai"
 type = "talk"
+aliases = ["/events/2017-losangeles/program/kiyor-cai"]
 
 +++
 

--- a/content/events/2017-los-angeles/propose.md
+++ b/content/events/2017-los-angeles/propose.md
@@ -1,6 +1,7 @@
 +++
 title = "Call for Proposals"
 type = "event"
+aliases = ["/events/2017-losangeles/propose"]
 +++
   {{< cfp_dates >}}
 

--- a/content/events/2017-los-angeles/registration.md
+++ b/content/events/2017-los-angeles/registration.md
@@ -1,6 +1,7 @@
 +++
 title = "Registration"
 type = "event"
+aliases = ["/events/2017-losangeles/registration"]
 +++
 
 <hr>

--- a/content/events/2017-los-angeles/speakers.md
+++ b/content/events/2017-los-angeles/speakers.md
@@ -2,5 +2,6 @@
 date = "2017-01-25T01:13:37-08:00"
 title = "speakers"
 type = "speakers"
+aliases = ["/events/2017-losangeles/speakers"]
 
 +++

--- a/content/events/2017-los-angeles/sponsor.md
+++ b/content/events/2017-los-angeles/sponsor.md
@@ -1,6 +1,7 @@
 +++
 title = "Sponsorship Info"
 type = "event"
+aliases = ["/events/2017-losangeles/sponsor"]
 +++
 
 As a not for profit community organized event, we greatly value our sponsors.

--- a/content/events/2017-los-angeles/welcome.md
+++ b/content/events/2017-los-angeles/welcome.md
@@ -1,7 +1,7 @@
 +++
 title = "Welcome"
 type = "event"
-aliases = ["/events/2017-los-angeles"]
+aliases = ["/events/2017-los-angeles", "/events/2017-losangeles"]
 +++
 
 <h2>{{< event_start >}}</h2>


### PR DESCRIPTION
The google webmaster tools showed that the incorrect URL was apparently being referenced for Los Angeles 2017 (I believe we had them add the `-` shortly after going live). This redirection ensures that any incorrect URLs for that event get rewritten to the correct ones. Tested locally.