### PR TITLE
Redirects for old presentations

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -30,3 +30,5 @@
 /events/2016-saltlakecity/proposals/* http://legacy.devopsdays.org/events/2016-saltlakecity/proposals/:splat     301!
 /events/2016-toronto/proposals/* http://legacy.devopsdays.org/events/2016-toronto/proposals/:splat     301!
 /events/2016-vancouver/proposals/* http://legacy.devopsdays.org/events/2016-vancouver/proposals/:splat     301!
+/presentations/2011-goteborg/* http://legacy.devopsdays.org/presentations/2011-goteborg/:splat     301!
+/presentations/2009-ghent/* http://legacy.devopsdays.org/presentations/2009-ghent/:splat     301!


### PR DESCRIPTION
The Goteberg links got hit in the last few months - best to have them all work.