### PR TITLE
Updating theme to 1.7.1

### DIFF
--- a/config-windows.toml
+++ b/config-windows.toml
@@ -9,6 +9,7 @@ dataDir = "data"
 archetypedir = "archetypes"
 PaginatePath = "blog"
 buildDrafts = false
+disableKinds = ["taxonomy", "taxonomyTerm"]
 
 [[menu.main]]
   name = "events"

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,7 @@ dataDir = "data"
 archetypedir = "archetypes"
 PaginatePath = "blog"
 buildDrafts = false
+disableKinds = ["taxonomy", "taxonomyTerm"]
 
 [[menu.main]]
   name = "events"

--- a/themes/devopsdays-theme/CHANGELOG.md
+++ b/themes/devopsdays-theme/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.7.1](https://github.com/devopsdays/devopsdays-theme/tree/1.7.1) (2017-04-05)
+[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.7.0...1.7.1)
+
+**Implemented enhancements:**
+
+- Disable generation of unnecessary content [\#467](https://github.com/devopsdays/devopsdays-theme/issues/467)
+
+**Fixed bugs:**
+
+- Extra space in welcome pages  [\#472](https://github.com/devopsdays/devopsdays-theme/issues/472)
+- removing broken-link home icon on events page [\#468](https://github.com/devopsdays/devopsdays-theme/issues/468)
+
 ## [1.7.0](https://github.com/devopsdays/devopsdays-theme/tree/1.7.0) (2017-03-31)
 [Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.6.1...1.7.0)
 

--- a/themes/devopsdays-theme/layouts/_default/baseof.html
+++ b/themes/devopsdays-theme/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
 
   {{- partial "global_navbar.html" . -}}
   {{ $path := split $.Source.File.Path .Site.Params.PathSeparator }}
-  {{ if or (eq (index $path 0) "events") (eq .Type "events") }}
+  {{ if eq (index $path 0) "events" }}
     {{- partial "events/event_navbar.html" . -}}
   {{ end }}
   <div class="container-fluid">

--- a/themes/devopsdays-theme/layouts/shortcodes/event_location.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/event_location.html
@@ -1,4 +1,4 @@
 {{ $path := split .Page.Source.File.Path .Site.Params.PathSeparator }}
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
-<a href = "/events/{{ $event_slug }}/location">{{ $e.location }}</a>
+{{- (printf "<a href = \"/events/%s/location\">%s</a>" $event_slug $e.location) | safeHTML -}}

--- a/themes/devopsdays-theme/theme.toml
+++ b/themes/devopsdays-theme/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/devopsdays/devopsdays-theme/"
 tags = ["", ""]
 features = ["", ""]
 min_version = 0.18
-theme_version = 1.7.0
+theme_version = 1.7.1
 
 [author]
   name = "Matt Stratton"


### PR DESCRIPTION
## [1.7.1](https://github.com/devopsdays/devopsdays-theme/tree/1.7.1) (2017-04-05)
[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.7.0...1.7.1)

**Implemented enhancements:**

- Disable generation of unnecessary content [\#467](https://github.com/devopsdays/devopsdays-theme/issues/467)

**Fixed bugs:**

- Extra space in welcome pages  [\#472](https://github.com/devopsdays/devopsdays-theme/issues/472)
- removing broken-link home icon on events page [\#468](https://github.com/devopsdays/devopsdays-theme/issues/468)