### PR TITLE
Better defaults for sharing

### DIFF
--- a/content/events/2017-amsterdam/welcome.md
+++ b/content/events/2017-amsterdam/welcome.md
@@ -5,6 +5,7 @@ type = "event"
 aliases = ["/events/2017-amsterdam"]
 tags = ["amsterdam","amsterdam-2017"]
 heading = "devopsdays Amsterdam - Welcome"
+Description = "devopsdays Amsterdam 2017"
 +++
 
 <div style="text-align:center;">

--- a/content/events/2017-atlanta/welcome.md
+++ b/content/events/2017-atlanta/welcome.md
@@ -3,6 +3,7 @@ date = "2016-12-17T13:55:35-05:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-atlanta"]
+Description = "devopsdays Atlanta 2017"
 
 +++
 

--- a/content/events/2017-austin/welcome.md
+++ b/content/events/2017-austin/welcome.md
@@ -5,6 +5,7 @@ date = "2016-08-25T06:01:53-05:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-austin"]
+Description = "devopsdays Austin 2017"
 
 +++
 

--- a/content/events/2017-baltimore/welcome.md
+++ b/content/events/2017-baltimore/welcome.md
@@ -8,6 +8,7 @@ aliases = [
   "/events/2017-baltimore/welcome",
   "/events/2016-baltimore/welcome"
 ]
+Description = "devopsdays Baltimore 2017"
 
 +++
 

--- a/content/events/2017-beijing/welcome.md
+++ b/content/events/2017-beijing/welcome.md
@@ -3,6 +3,7 @@ date = "2016-12-12T09:30:11+08:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-beijing"]
+Description = "devopsdays Beijing 2017"
 
 +++
 

--- a/content/events/2017-berlin/welcome.md
+++ b/content/events/2017-berlin/welcome.md
@@ -3,6 +3,7 @@ date = "2017-03-21T18:12:13+02:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-berlin"]
+Description = "devopsdays Berlin 2017"
 
 +++
 

--- a/content/events/2017-boise/welcome.md
+++ b/content/events/2017-boise/welcome.md
@@ -3,6 +3,7 @@ date = "2017-03-14T16:25:12-07:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-boise"]
+Description = "devopsdays Boise 2017"
 
 +++
 

--- a/content/events/2017-cape-town/welcome.md
+++ b/content/events/2017-cape-town/welcome.md
@@ -3,6 +3,7 @@ date = "2017-01-21T10:28:40+02:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-cape-town"]
+Description = "devopsdays Cape Town 2017"
 
 +++
 

--- a/content/events/2017-charlotte/welcome.md
+++ b/content/events/2017-charlotte/welcome.md
@@ -3,6 +3,7 @@ date = "2016-09-22T10:34:20-04:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-charlotte"]
+Description = "devopsdays Charlotte 2017"
 
 +++
 

--- a/content/events/2017-denver/welcome.md
+++ b/content/events/2017-denver/welcome.md
@@ -5,6 +5,7 @@ date = "2017-03-06T21:15:25-06:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-denver"]
+Description = "devopsdays Denver 2017"
 
 
 +++

--- a/content/events/2017-detroit/welcome.md
+++ b/content/events/2017-detroit/welcome.md
@@ -3,6 +3,7 @@ date = "2016-12-11T14:38:53-05:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-detroit"]
+Description = "devopsdays Detroit 2017"
 
 +++
 

--- a/content/events/2017-edinburgh/welcome.md
+++ b/content/events/2017-edinburgh/welcome.md
@@ -3,6 +3,7 @@ date = "2017-02-06T21:06:13+00:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-edinburgh"]
+Description = "devopsdays Edinburgh 2017"
 
 +++
 

--- a/content/events/2017-hartford/welcome.md
+++ b/content/events/2017-hartford/welcome.md
@@ -3,6 +3,7 @@ date = "2017-01-09T10:01:31-05:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-hartford"]
+Description = "devopsdays Hartford 2017"
 
 +++
 

--- a/content/events/2017-indianapolis/welcome.md
+++ b/content/events/2017-indianapolis/welcome.md
@@ -3,6 +3,7 @@ date = "2016-12-16T15:40:27-05:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-indianapolis"]
+Description = "devopsdays Indianapolis 2017"
 
 +++
 

--- a/content/events/2017-istanbul/welcome.md
+++ b/content/events/2017-istanbul/welcome.md
@@ -3,6 +3,7 @@ date = "2017-02-05T20:43:53+03:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-istanbul"]
+Description = "devopsdays Istanbul 2017"
 
 +++
 

--- a/content/events/2017-kansascity/welcome.md
+++ b/content/events/2017-kansascity/welcome.md
@@ -3,6 +3,7 @@ date = "2016-05-07T09:30:25-05:00"
 title = "Welcome"
 type = "event"
 aliases = ["/events/2017-kansascity"]
+Description = "devopsdays Kansas City 2017"
 
 +++
 

--- a/content/events/2017-london/welcome.md
+++ b/content/events/2017-london/welcome.md
@@ -3,6 +3,7 @@ date = "2016-12-21T13:55:35-05:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-london"]
+Description = "devopsdays London 2017"
 
 +++
 

--- a/content/events/2017-los-angeles/welcome.md
+++ b/content/events/2017-los-angeles/welcome.md
@@ -2,6 +2,7 @@
 title = "Welcome"
 type = "event"
 aliases = ["/events/2017-los-angeles", "/events/2017-losangeles"]
+Description = "devopsdays Los Angeles 2017"
 +++
 
 <h2>{{< event_start >}}</h2>

--- a/content/events/2017-madison/welcome.md
+++ b/content/events/2017-madison/welcome.md
@@ -3,6 +3,7 @@ date = "2017-02-01T09:20:34-06:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-madison"]
+Description = "devopsdays Madison 2017"
 
 +++
 

--- a/content/events/2017-moscow/welcome.md
+++ b/content/events/2017-moscow/welcome.md
@@ -3,6 +3,7 @@ date = "2016-09-05T09:42:50+03:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-moscow"]
+Description = "devopsdays Moscow 2017"
 
 +++
 

--- a/content/events/2017-ohio/welcome.md
+++ b/content/events/2017-ohio/welcome.md
@@ -5,7 +5,7 @@ type = "event"
 City = "ohio"
 Year = "2017"
 aliases = ["/events/2017-ohio"]
-draft = false
+Description = "devopsdays Ohio 2017"
 
 +++
 

--- a/content/events/2017-oslo/conduct.md
+++ b/content/events/2017-oslo/conduct.md
@@ -1,7 +1,7 @@
 +++
 Title = "Conduct"
 Type = "event"
-Description = "Code of conduct for devopsdays OSLO 2017"
+Description = "Code of conduct for devopsdays Oslo 2017"
 +++
 
 ## ANTI-HARASSMENT POLICY

--- a/content/events/2017-oslo/contact.md
+++ b/content/events/2017-oslo/contact.md
@@ -1,7 +1,7 @@
 +++
 Title = "Contact"
 Type = "event"
-Description = "Contact information for devopsdays OSLO 2017"
+Description = "Contact information for devopsdays Oslo 2017"
 +++
 
 <div class = "card" style="max-width: 600px;padding-left:0px;padding-right:0px">

--- a/content/events/2017-oslo/index.md
+++ b/content/events/2017-oslo/index.md
@@ -1,8 +1,8 @@
 +++
-Title = "devopsdays OSLO 2017"
+Title = "devopsdays Oslo 2017"
 Type = "welcome"
 aliases = ["/events/2017-oslo/","/events/2017-oslo/welcome/","/events/2017-oslo/index/"]
-Description = "devopsdays OSLO 2017"
+Description = "devopsdays Oslo 2017"
 +++
 
 <div style="text-align:center;">

--- a/content/events/2017-oslo/program.md
+++ b/content/events/2017-oslo/program.md
@@ -1,7 +1,7 @@
 +++
 Title = "Program"
 Type = "program"
-Description = "Program for devopsdays OSLO 2017"
+Description = "Program for devopsdays Oslo 2017"
 +++
 
 <div class = "row">

--- a/content/events/2017-oslo/propose.md
+++ b/content/events/2017-oslo/propose.md
@@ -1,7 +1,7 @@
 +++
 Title = "Propose"
 Type = "event"
-Description = "Propose a talk for devopsdays OSLO 2017"
+Description = "Propose a talk for devopsdays Oslo 2017"
 +++
   {{< cfp_dates >}}
 

--- a/content/events/2017-oslo/registration.md
+++ b/content/events/2017-oslo/registration.md
@@ -1,7 +1,7 @@
 +++
 Title = "Registration"
 Type = "event"
-Description = "Registration for devopsdays OSLO 2017"
+Description = "Registration for devopsdays Oslo 2017"
 +++
 
 <div style="width:100%; text-align:left;">

--- a/content/events/2017-oslo/speakers.md
+++ b/content/events/2017-oslo/speakers.md
@@ -1,5 +1,5 @@
 +++
 Title = "Speakers"
 Type = "speakers"
-Description = "Speakers for devopsdays OSLO 2017"
+Description = "Speakers for devopsdays Oslo 2017"
 +++

--- a/content/events/2017-oslo/sponsor.md
+++ b/content/events/2017-oslo/sponsor.md
@@ -1,7 +1,7 @@
 +++
 Title = "Sponsor"
 Type = "event"
-Description = "Sponsor devopsdays OSLO 2017"
+Description = "Sponsor devopsdays Oslo 2017"
 +++
 
 We greatly value sponsors for this open event. If you are interested in sponsoring, please drop us an email at {{< email_organizers >}}

--- a/content/events/2017-paris/welcome.md
+++ b/content/events/2017-paris/welcome.md
@@ -3,6 +3,7 @@ date = "2017-02-16T14:22:48+02:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-paris"]
+Description = "devopsdays Paris 2017"
 
 +++
 

--- a/content/events/2017-philadelphia/welcome.md
+++ b/content/events/2017-philadelphia/welcome.md
@@ -5,6 +5,7 @@ date = "2017-02-28"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-philadelphia"]
+Description = "devopsdays Philadelphia 2017"
 
 
 +++

--- a/content/events/2017-portland/welcome.md
+++ b/content/events/2017-portland/welcome.md
@@ -3,6 +3,7 @@ date = "2016-08-28T14:00:07-07:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-portland"]
+Description = "devopsdays Portland 2017"
 
 +++
 

--- a/content/events/2017-raleigh/welcome.md
+++ b/content/events/2017-raleigh/welcome.md
@@ -3,6 +3,7 @@ date = "2017-02-13T15:57:00-05:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-raleigh"]
+Description = "devopsdays Raleigh 2017"
 
 +++
 

--- a/content/events/2017-saint-louis/welcome.md
+++ b/content/events/2017-saint-louis/welcome.md
@@ -3,6 +3,7 @@ date = "2016-12-14T09:07:19-06:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-saint-louis"]
+Description = "devopsdays Saint Louis 2017"
 
 +++
 

--- a/content/events/2017-salt-lake-city/welcome.md
+++ b/content/events/2017-salt-lake-city/welcome.md
@@ -3,6 +3,7 @@ date = "2016-10-18T19:59:04-06:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-salt-lake-city"]
+Description = "devopsdays Salt Lake City 2017"
 
 +++
 

--- a/content/events/2017-seattle/welcome.md
+++ b/content/events/2017-seattle/welcome.md
@@ -3,6 +3,7 @@ date = "2016-09-20T21:46:51+01:00"
 title = "DevOpsDays Seattle 2017"
 type = "event"
 aliases = ["/events/2017-seattle"]
+Description = "devopsdays Seattle 2017"
 
 +++
 

--- a/content/events/2017-tokyo/welcome.md
+++ b/content/events/2017-tokyo/welcome.md
@@ -3,6 +3,7 @@ date = "2017-01-06T11:12:21-06:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-tokyo"]
+Description = "devopsdays Tokyo 2017"
 
 +++
 

--- a/content/events/2017-toronto/welcome.md
+++ b/content/events/2017-toronto/welcome.md
@@ -3,6 +3,7 @@ date = "2016-03-06T21:15:25-06:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-toronto"]
+Description = "devopsdays Toronto 2017"
 
 
 +++

--- a/content/events/2017-vancouver/welcome.md
+++ b/content/events/2017-vancouver/welcome.md
@@ -3,6 +3,7 @@ date = "2017-11-09T22:35:17-08:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-vancouver"]
+Description = "devopsdays Vancouver 2017"
 
 +++
 

--- a/content/events/2017-washington-dc/welcome.md
+++ b/content/events/2017-washington-dc/welcome.md
@@ -3,6 +3,7 @@ date = "2016-09-26T12:57:27-04:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-washington-dc"]
+Description = "devopsdays Washington, D.C. 2017"
 
 +++
 

--- a/content/events/2017-zurich/welcome.md
+++ b/content/events/2017-zurich/welcome.md
@@ -3,6 +3,7 @@ date = "2016-07-20T13:45:44+02:00"
 title = "welcome"
 type = "event"
 aliases = ["/events/2017-zurich"]
+Description = "devopsdays Zürich 2017"
 
 +++
 


### PR DESCRIPTION
Because of the long cache clearing time Twitter has by default as seen in https://github.com/devopsdays/devopsdays-theme/issues/477, I'm adjusting existing 2017 events that were created before the addition of https://github.com/devopsdays/devopsdays-web/blame/master/utilities/examples/content/events/yyyy-city/index.md#L5.

This will ensure that the first time someone shares one of these events on twitter and then notices some annoying javascript, they won't have to wait a week for it to be fixed.