### PR TITLE
Script to generate new organizer fields (+README update)

### DIFF
--- a/utilities/README.md
+++ b/utilities/README.md
@@ -76,9 +76,14 @@ Guidelines regarding sponsor logo files and formatting:
 
 All logos will be resized at release time, to 200px wide. Versions for high-density display (ex. Retina) will also be created. It is recommended that you do not use a sponsor logo that is smaller than 200px wide to keep from quality degradation at resize time.
 
-## Team members
+## Local Organizers
 
-See the example team members listed in the generated data file. You can now add additional fields for each team member, as well as a photo. The photo must be in JPG format, and should be a minimum 300px x 300px, but optimally 600px x 600px. These images are located in the `static/events/YYYY-CITY/organizers` directory. Any PRs adding a team member will need to be accompanied by an email to `info@devopsdays.org` with their full name and email address.
+See the example local organizer team members listed in the generated data file found in `data/events/201?-yourcity.yml`. To generate the  `team_members: ` section you can use [add_organizers.sh](add_organizers.sh).
+
+The organizer photo must be in JPG format, and should be a minimum 300px x 300px, but optimally 600px x 600px. These images should be placed in the `static/events/YYYY-CITY/organizers` directory (which the `add_organizers.sh` script will do).
+
+Any PRs adding a new local organizer will need to be accompanied by an email to `info@devopsdays.org` with their full name and email address.
+
 
 ## Social sharing image
 

--- a/utilities/add_organizers.sh
+++ b/utilities/add_organizers.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+set -e
+
+OUT=$(mktemp /tmp/output.XXXXXXXXXX) || { echo "Failed to create temp file"; exit 1; }
+
+
+# Detect OS for correct 'sed' syntax
+OSNAME=`uname`
+SEDCMD(){
+  if [[ $OSNAME == 'Linux' ]]; then
+    sed -i "$@"
+  elif [[ $OSNAME == 'Darwin' ]]; then
+    sed -i '' "$@"
+  fi
+}
+
+# Get year
+read -p "Enter your event year (default: $(date +"%Y")): " year
+[ -z "${year}" ] && year='2017'
+
+# Get city
+read -p "Enter your city name: " city
+city_slug=$(echo $city | tr '-' ' ' | tr -dc '[:alpha:][:blank:]' | tr '[:upper:]' '[:lower:]'| tr 'āáǎàãâēéěèīíǐìōóǒòöūúǔùǖǘǚǜü' 'aaaaaaeeeeiiiiooooouuuuuuuuu' | tr ' ' '-')
+# Generate event slug
+event_slug=$year-$city_slug
+
+# Create necessary directories
+mkdir -p ../static/events/$event_slug/organizers
+
+# Set the creation date to current timestamp
+datestamp=$(date +%Y-%m-%dT%H:%M:%S%z | sed 's/^\(.\{22\}\)/\1:/')
+
+# Prompt for inputting organizers
+
+while true; do
+echo "What would you like to do?"
+echo "1.  Add info for an organizer"
+echo "2.  View organizers thus far"
+echo "3.  Exit"
+echo
+
+echo -n "Enter your choice: "
+read choice
+echo
+
+case $choice in
+     1)
+
+#################
+# Organizer entry
+#################
+read -p "Enter organizer name: " organizername
+organizer_slug=$(echo $organizername | tr -dc '[:alpha:][:blank:]' | tr '[:upper:]' '[:lower:]'| tr 'āáǎàãâēéěèīíǐìōóǒòöūúǔùǖǘǚǜü' 'aaaaaaeeeeiiiiooooouuuuuuuuu' | tr ' ' '-')
+
+# employer
+
+read -p "Enter organizer's employer (return to skip): " employer
+[ -z "${employer}" ] && employer=""
+
+# twitter handle
+read -p "Enter organizer twitter handle (return to skip): " twitter
+[ -z "${twitter}" ] && twitter=''
+# remove @ if they added it
+twitter=$(echo $twitter | sed 's/@//')
+
+# bio
+read -p "Enter organizer bio (return to skip): " bio
+[ -z "${bio}" ] && bio=""
+
+#######################
+# Set organizer image
+#######################
+
+read -p "Enter path to organizer image as jpg (return to skip): " organizerimage
+[ -z "${organizerimage}" ] && organizerimage=''
+
+if [ $organizerimage ]; then
+  cp "$organizerimage" ../static/events/$event_slug/organizers/$organizer_slug.jpg
+else
+  echo "Put organizer image at ../static/events/$event_slug/organizers/$organizer_slug.jpg before creating the pull request, if desired."
+fi
+
+####################
+# Populate data file
+####################
+
+echo "
+  - name: \"$organizername\"
+    employer: \"$employer\"
+    twitter: \"$twitter\"
+    bio: \"$bio\"" >> $OUT
+
+if [ $organizerimage ]; then
+echo "    image: \"$organizer_slug.jpg\"" >> $OUT
+fi
+
+     ;;
+
+     2)
+	cat "$OUT"
+     ;;
+     3)
+     echo "Add to ../data/events/$event_slug.yml under team_members: "
+     cat "$OUT"
+     break
+     ;;
+     *)
+     echo "Invalid choice. Choose a number from 1 to 3."
+     ;;
+esac
+done
+rm $OUT


### PR DESCRIPTION
This is some basic bash that generates the entries for new organizers. I minimally updated the README too. This is MVP and doesn't prompt for every conceivable field; we could update the README to link to the relevant doc. @mattstratton, please take a look and see if this is okay to add as MVP.