### PR TITLE
Updating theme to 1.7.2

### DIFF
--- a/themes/devopsdays-theme/CHANGELOG.md
+++ b/themes/devopsdays-theme/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.7.2](https://github.com/devopsdays/devopsdays-theme/tree/1.7.2) (2017-04-18)
+[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.7.1...1.7.2)
+
+**Fixed bugs:**
+
+- adjust dates as shown on frontpage [\#481](https://github.com/devopsdays/devopsdays-theme/issues/481)
+- old style event twitters not showing up [\#479](https://github.com/devopsdays/devopsdays-theme/issues/479)
+
 ## [1.7.1](https://github.com/devopsdays/devopsdays-theme/tree/1.7.1) (2017-04-05)
 [Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.7.0...1.7.1)
 

--- a/themes/devopsdays-theme/layouts/index.html
+++ b/themes/devopsdays-theme/layouts/index.html
@@ -29,11 +29,23 @@
                 <a href="/events/{{ .name }}"><img src="/img/event-logo-square.jpg" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
                 {{- end -}}
                 <br/>
-                <span class="homepage-grid-date">
-                    {{- dateFormat "Jan 2" .startdate -}}
-                    &nbsp;-&nbsp;
-                    {{-  dateFormat "Jan 2, 2006" .enddate -}}<br/>
-                </span>
+
+        {{- if ne .startdate .enddate }}
+          {{- if eq (dateFormat "January" .startdate) (dateFormat "January" .enddate ) -}}
+            <span class="homepage-grid-date">
+            {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2, 2006" .enddate }}<br />
+            </span>
+          {{- else -}}
+            <span class="homepage-grid-date">
+            {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2, 2006" .enddate }}<br />
+            </span>
+          {{- end -}}
+      {{- else -}}
+            <span class="homepage-grid-date">
+          {{ dateFormat "Jan 2, 2006" .startdate }}<br />
+            </span>
+      {{- end -}}
+
                 <span class="homepage-grid-city">
                     <a href="/events/{{ .name }}">{{ .city }}</a>
                 </span>

--- a/themes/devopsdays-theme/layouts/shortcodes/event_twitter.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/event_twitter.html
@@ -2,5 +2,9 @@
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 
+{{ if $e.event_twitter}}
 <a href="https://twitter.com/{{ $e.event_twitter }}" class="twitter-follow-button" data-show-count="false">Follow @{{ $e.event_twitter }}</a>
+{{ else }}
+<a href="https://twitter.com/{{ index .Params 0 }}" class="twitter-follow-button" data-show-count="false">Follow @{{ index .Params 0 }}</a>
+{{ end }}
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>

--- a/themes/devopsdays-theme/theme.toml
+++ b/themes/devopsdays-theme/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/devopsdays/devopsdays-theme/"
 tags = ["", ""]
 features = ["", ""]
 min_version = 0.18
-theme_version = 1.7.1
+theme_version = 1.7.2
 
 [author]
   name = "Matt Stratton"


### PR DESCRIPTION
## [1.7.2](https://github.com/devopsdays/devopsdays-theme/tree/1.7.2) (2017-04-18)
[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.7.1...1.7.2)

**Fixed bugs:**

- adjust dates as shown on frontpage [\#481](https://github.com/devopsdays/devopsdays-theme/issues/481)
- old style event twitters not showing up [\#479](https://github.com/devopsdays/devopsdays-theme/issues/479)