### PR TITLE
[MSP-2017] Correcting logo for Thoughtworks

### DIFF
--- a/data/events/2017-minneapolis.yml
+++ b/data/events/2017-minneapolis.yml
@@ -89,7 +89,7 @@ sponsors:
     level: gold
   - id: veritas
     level: silver
-  - id: thoughtworks-products
+  - id: gocd
     level: platinum
   - id: mesosphere
     level: silver


### PR DESCRIPTION
I think we were using last year's logo for MSP's Thoughtworks sponsorship. CCing @zruty as a heads-up, and we'll want a 👍  from @kmugrage to merge this.