### PR TITLE
[PDX-2017] Explicitly add reg link

### DIFF
--- a/content/events/2017-portland/welcome.md
+++ b/content/events/2017-portland/welcome.md
@@ -36,14 +36,14 @@ Our event will be August 1st and 2nd. However, keep an eye out for a special fol
   </div>
 </div> -->
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
     <strong>Register</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_link page="registration" text="Register to attend the conference!" >}}
+    <a href="https://devopsdayspdx2017.busyconf.com/bookings/new">Register to attend the conference!</a>
   </div>
-</div> -->
+</div>
 
 <div class = "row">
   <div class = "col-md-2">


### PR DESCRIPTION
The magic registration link (from data/events/2017-portland.yml) doesn't
show up on mobile, or at least I can't find it. Bummer :(

Ken points out that it's the person-with-a-plus-symbol icon. I didn't guess that, and at least one other person didn't either, so I'm still adding it.