### PR TITLE
Adding registration button for Portland

### DIFF
--- a/data/events/2017-portland.yml
+++ b/data/events/2017-portland.yml
@@ -13,6 +13,8 @@ cfp_date_end: 2017-05-09 # close your call for proposals.
 cfp_date_announce: 2017-06-01 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://devopsdayspdx2017.busyconf.com/proposals/new"
+registration_open: "true"
+registration_link: "https://devopsdayspdx2017.busyconf.com/bookings/new"
 
 # Location
 #


### PR DESCRIPTION
I think this is what @BillWeiss was asking for in https://github.com/devopsdays/devopsdays-web/pull/2355.

Before:

![screen shot 2017-04-30 at 9 20 09 pm](https://cloud.githubusercontent.com/assets/2104453/25570494/51dee808-2deb-11e7-9c97-b85d9ba19ca3.png)

After:

![screen shot 2017-04-30 at 9 20 27 pm](https://cloud.githubusercontent.com/assets/2104453/25570497/5779d5ca-2deb-11e7-8795-031b9d5f2221.png)

If @BillWeiss gives this a thumbs up, feel free to merge.