### PR TITLE
Fixing broken element

### DIFF
--- a/content/events/2017-nashville/index.md
+++ b/content/events/2017-nashville/index.md
@@ -5,9 +5,9 @@ aliases = ["/events/2017-nashville/welcome"]
 Description = "devopsdays Nashville 2017"
 +++
 
-<-- <div style="text-align:center;">
+<div style="text-align:center;">
   {{< event_logo >}}
-</div> -->
+</div>
 
 <div class = "row">
   <div class = "col-md-2">

--- a/content/events/2017-nashville/sponsor.md
+++ b/content/events/2017-nashville/sponsor.md
@@ -132,7 +132,7 @@ Please do not hesitate to reach out to us at {{< email_organizers >}} if you hav
         <li>Coffee – signage by the coffee displays with your logo throughout the day (option to have coffee cup sleeves printed is extra cost)</li>
         <li>T-shirt logo printed on sleeve (only available to Gold sponsor)</li>
         <li>Breakfast - signage by the breakfast tables and in the eating area with your logo in the morning before sessions</li>
-<       li>Lunch - signage by the lunch tables and in the eating area with your logo during lunch</li>
+	<li>Lunch - signage by the lunch tables and in the eating area with your logo during lunch</li>
       </ul>
   </td>
   <td>


### PR DESCRIPTION
I noticed we had some failed builds. In netlify, this is the error:

![screen shot 2017-05-06 at 9 17 23 am](https://cloud.githubusercontent.com/assets/2104453/25773105/4b7014b4-323d-11e7-8525-bc6fa67697fd.png)

In https://github.com/devopsdays/devopsdays-web/pull/2382 I noticed extra space in an `<li>` tag:

![screen shot 2017-05-06 at 9 13 58 am](https://cloud.githubusercontent.com/assets/2104453/25773114/74fd85aa-323d-11e7-96cf-a6d42e7019e6.png)

The build failed, but locally it looked like this:

![screen shot 2017-05-06 at 9 16 28 am](https://cloud.githubusercontent.com/assets/2104453/25773118/7e3f1598-323d-11e7-82a1-432bcc9ac6d0.png)

Heads up to @mattstratton because this may be relevant to some testing/parsing he has done or considered.

