### PR TITLE
Change to use embedded hugo

### DIFF
--- a/bin/netlify-production.sh
+++ b/bin/netlify-production.sh
@@ -1,3 +1,3 @@
-hugo version
-hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="https://www.devopsdays.org/"
+bin/hugo version
+bin/hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="https://www.devopsdays.org/"
 gulp

--- a/bin/netlify.sh
+++ b/bin/netlify.sh
@@ -1,1 +1,2 @@
-hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="/"
+bin/hugo version
+bin/hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="/"


### PR DESCRIPTION
This change forces the use of `hugo 0.20.7` by using the embedded binary in `bin`.

The binary is 4mb which should not be too painful to the repo; we do NOT want to keep this pattern, but until we can figure out how to get Netlify to use 0.20.7 instead of 0.20, we need this to prevent a defect.
