### PR TITLE
Use binrc for hugo

### DIFF
--- a/bin/netlify-production.sh
+++ b/bin/netlify-production.sh
@@ -1,3 +1,3 @@
-bin/hugo version
-bin/hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="https://www.devopsdays.org/"
+hugo version
+hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="https://www.devopsdays.org/"
 gulp

--- a/bin/netlify.sh
+++ b/bin/netlify.sh
@@ -1,2 +1,2 @@
-bin/hugo version
-bin/hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="/"
+hugo version
+hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
  publish = "dist/"
  
 [context.production.environment]
-   HUGO_VERSION = "0.19"
+   HUGO_VERSION = "0.20.7"
 
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.
@@ -15,7 +15,10 @@
   publish = "public/"
   command = "bin/netlify.sh"
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.19"
+  HUGO_VERSION = "0.20.7"
+  
+[context.branch-deploy.environment]
+  HUGO_VERSION = "0.20.7"
 
 [context.test]
  command = "bin/netlify-production.sh"


### PR DESCRIPTION
This change removes the dependency on the embedded hugo binary and uses the mappings in `netlify.toml`.
