### PR TITLE
Standardizing the "about" page.

### DIFF
--- a/content/page/about.md
+++ b/content/page/about.md
@@ -4,7 +4,6 @@ Description = ""
 Tags = []
 date = "2017-02-13T11:24:58-05:00"
 title = "About devopsdays"
-type = "about"
 aliases = ["/contact/"]
 
 +++
@@ -28,6 +27,4 @@ If you have questions about hosting your own event or about potential future eve
 ### Contact a specific event
 
 Organization is decentralized. Local events handle their own sponsorships, registration, and all other organization. For questions about a specific event you see listed on the site, contact the local organizers for that event; their email is on their contact page.
-
-To contact the organizers for a given city:
 


### PR DESCRIPTION
There isn't a good reason for the "/about" page to use a slightly-outdated, special-cased version of the "future" partial to provide individually clickable links to the contact pages for each event (and it doesn't scale well or look particularly good).

This is the data-side cleanup for the issue noted in https://github.com/devopsdays/devopsdays-theme/issues/532.