### PR TITLE
Updating theme to 1.10.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ install: go get -v github.com/spf13/hugo
 # - npm install
 script:
   - hugo
+  - hugo version
   # - gulp min-html

--- a/themes/devopsdays-theme/CHANGELOG.md
+++ b/themes/devopsdays-theme/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.10.3](https://github.com/devopsdays/devopsdays-theme/tree/1.10.3) (2017-06-05)
+[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.10.2...1.10.3)
+
+**Fixed bugs:**
+
+- Stray curly brace on welcome pages [\#550](https://github.com/devopsdays/devopsdays-theme/issues/550)
+
 ## [1.10.2](https://github.com/devopsdays/devopsdays-theme/tree/1.10.2) (2017-06-02)
 [Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.10.1...1.10.2)
 

--- a/themes/devopsdays-theme/layouts/welcome/single.html
+++ b/themes/devopsdays-theme/layouts/welcome/single.html
@@ -3,6 +3,6 @@
     <div class="col-md-12">
         {{- partial "welcome.html" . -}}
         {{- partial "sponsors.html" . -}}
-    </div>{
+    </div>
 </div>
 {{ end }}

--- a/themes/devopsdays-theme/theme.toml
+++ b/themes/devopsdays-theme/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/devopsdays/devopsdays-theme/"
 tags = ["", ""]
 features = ["", ""]
 min_version = 0.18
-theme_version = 1.10.2
+theme_version = 1.10.3
 
 [author]
   name = "Matt Stratton"


### PR DESCRIPTION
# Change Log

## [1.10.3](https://github.com/devopsdays/devopsdays-theme/tree/1.10.3) (2017-06-05)
[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.10.2...1.10.3)

**Fixed bugs:**

- Stray curly brace on welcome pages [\#550](https://github.com/devopsdays/devopsdays-theme/issues/550)