### PR TITLE
[SIN-17] Initial version of event page

### DIFF
--- a/content/events/2017-singapore/conduct.md
+++ b/content/events/2017-singapore/conduct.md
@@ -1,0 +1,35 @@
++++
+Title = "Conduct"
+Type = "event"
+Description = "Code of conduct for DevOpsDays Singapore 2017"
++++
+
+## ANTI-HARASSMENT POLICY
+
+Devopsdays is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers.
+
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+
+If a participant engages in harassing behavior, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately.
+
+Conference staff can be identified by distinct staff badges. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+We expect participants to adhere to the code of conduct at all conference venues and conference-related social events.
+
+## CODE OF CONDUCT
+
+I. I am an attendee at devopsdays, learning from and sharing with other devopsdays attendees in an effort to better myself and my industry. I co-create the experience with fellow attendees. I am prepared to give my energy, presence and sensitivity to creating the best possible experience for myself and others.
+
+II. I am coming to devopsdays to interact with people. I understand that imagery and language which is suggestive or derogatory will offend and make people uncomfortable. I also understand that people may have boundaries and sensibilities different from my own. I will accept without question when informed that something is offensive or unacceptable in the context of the devopsdays event.
+
+III. I will never intentionally harass or offend another attendee regardless of gender, sexual orientation, disability, appearance, size, race or religion and will not abide another attendee being harassed or offended. If I am aware that anyone is uncomfortable or unsafe, I will notify those giving offense and the devopsdays event organizers.
+
+IV. If I am offended or harassed, I will inform people around me who make me feel safe and the event organizers. If I feel safe, at my discretion, I will inform those giving offense of the specific actions with the hope that the other party is well-intentioned and ignorant, but I am under no obligation to do so.
+
+V. I understand that people are different and I attempt to be forgiving of others actions at the level of their sincere intent, but my priority is protecting my safety and the safety of others. I will act without hesitation or reservation until there are no question of the safety of all parties.
+
+VI. I trust the devopsdays organizers and attendees will co-create the best possible experience for everyone involved, as I will. I believe devopsdays is about empowering people and I will not forget I am empowered to create a safe and nurturing environment. If I or any other attendee violates this aspect of the event, I expect the conference organizers to protect the attendees by direct action, including expelling those in violation and contacting the proper authorities.

--- a/content/events/2017-singapore/contact.md
+++ b/content/events/2017-singapore/contact.md
@@ -1,0 +1,15 @@
++++
+Title = "Contact"
+Type = "event"
+Description = "Contact information for DevOpsDays Singapore 2017"
++++
+
+If you'd like to contact us by email: {{< email_organizers >}}
+
+**Our local team**
+
+{{< list_organizers >}}
+
+**The core devopsdays organizer group**
+
+{{< list_core >}}

--- a/content/events/2017-singapore/index.md
+++ b/content/events/2017-singapore/index.md
@@ -1,0 +1,87 @@
++++
+Title = "DevOpsDays Singapore 2017"
+Type = "welcome"
+aliases = ["/events/2017-singapore/welcome"]
+Description = "DevOpsDays Singapore 2017"
++++
+
+<!-- <div style="text-align:center;">
+  {{< event_logo >}}
+</div> -->
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Dates</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_start >}} - {{< event_end >}}
+  </div>
+</div>
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Location</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_location >}}
+  </div>
+</div> -->
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Register</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="registration" text="Register to attend the conference!" >}}
+  </div>
+</div> -->
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Propose</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="propose" text="Propose a talk!" >}}
+  </div>
+</div> -->
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Program</strong>
+  </div>
+  <div class = "col-md-8">
+    View the {{< event_link page="program" text="program." >}}
+  </div>
+</div> -->
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Speakers</strong>
+  </div>
+  <div class = "col-md-8">
+    Check out the {{< event_link page="speakers" text="speakers!" >}}
+  </div>
+</div> -->
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Sponsors</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="sponsor" text="Sponsor the conference!" >}}
+  </div>
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Contact</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="contact" text="Get in touch with the organizers" >}}
+  </div>
+</div>
+
+<!-- Uncomment if you added your city twitter name -->
+<!--
+{{< event_twitter >}}
+-->

--- a/content/events/2017-singapore/location.md
+++ b/content/events/2017-singapore/location.md
@@ -1,0 +1,10 @@
++++
+Title = "Location"
+Type = "event"
+Description = "Location for DevOpsDays Singapore 2017"
++++
+
+Watch this space for information about the venue including address, map/direction, parking/transit, and any hotel details.
+
+<!-- Uncomment this only if you have set the coordinates for your location in the config yaml. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html -->
+<!-- {{< event_map >}} -->

--- a/content/events/2017-singapore/propose.md
+++ b/content/events/2017-singapore/propose.md
@@ -1,0 +1,35 @@
++++
+Title = "Propose"
+Type = "event"
+Description = "Propose a talk for DevOpsDays Singapore 2017"
++++
+  {{< cfp_dates >}}
+
+<hr>
+
+There are three ways to propose a topic at devopsdays:
+<ol>
+  <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
+  <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
+  <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
+</ol>
+
+<hr>
+
+Choosing talks is part art, part science; here are some factors we consider when trying to assemble the best possible program for our local audience:
+
+- _broad appeal_: How will your talk play out in a room of people with a variety of backgrounds? Technical deep dives need more levels to provide value for the whole room, some of whom might not use your specific tool.
+- _new local presenters_: You are the only one who can tell your story. We are very interested in the challenges and successes being experienced in our local area. We are happy to provide guidance/coaching for new speakers upon request.
+- _under-represented voices_: We want to hear all voices, including those that may speak less frequently at similar events. Whether you're in a field not typically thought of as a technology field, you're in a large, traditional organization, or you're the only person at your organization with your background, we are interested in your unique experience.
+- _original content_: We will consider talks that have already been presented elsewhere, but we prefer talks that the local area isn't likely to have already seen.
+- _no third-party submissions_: This is a small community-driven event, and speakers need to be directly engaged with the organizers and attendees. If a PR firm or your marketing department is proposing the talk, you've already shown that as a speaker you're distant from the process.
+- _no vendor pitches_: As much as we value vendors and sponsors, we are not going to accept a talk that appears to be a pitch for your product.
+
+<hr>
+
+<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
+<ol>
+  <li>Type (presentation, panel discussion, ignite)</li>
+  <li>Proposal Title (can be changed later)</li>
+  <li>Description (several sentences explaining what attendees will learn)</li>
+</ol>

--- a/content/events/2017-singapore/registration.md
+++ b/content/events/2017-singapore/registration.md
@@ -1,0 +1,9 @@
++++
+Title = "Registration"
+Type = "event"
+Description = "Registration for DevOpsDays Singapore 2017"
++++
+
+<script src='https://js.tito.io/v1'></script>
+<link rel="stylesheet" type="text/css" href='https://css.tito.io/v1' />
+<tito-widget event="devopsdays-singapore/2017"></tito-widget>

--- a/content/events/2017-singapore/sponsor.md
+++ b/content/events/2017-singapore/sponsor.md
@@ -1,0 +1,240 @@
++++
+Title = "Sponsor"
+Type = "event"
+Description = "Sponsor DevOpsDays Singapore 2017"
++++
+
+We greatly value sponsors for this open event. If you are interested in sponsoring, please <a href="mailto:organizers-singapore-2017@devopsdays.org?subject=Sponsor DevOpsDays Singapore 2017">drop us an email</a><!-- or [download the prospectus](https://drive.google.com/open?id=0B-L7Gu-eJct3em15bzFreGZWMU5jVnZ6S2pyckl2TGpZY053) right away -->.
+
+DevOpsDays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute the attendee contact lists.
+
+Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
+
+The best thing to do is send engineers to interact with the experts at DevOpsDays on their own terms.
+
+<!-- <div style="margin: 1.4em 0 2.4em 0;"><center><a href="https://drive.google.com/open?id=0B-L7Gu-eJct3em15bzFreGZWMU5jVnZ6S2pyckl2TGpZY053" target="_blank" class="btn btn-primary btn-lg">Download Sponsorship Prospectus</a></center></div> -->
+
+## Why Sponsor Us?
+
+The DevOpsDays event mandate is to bring the highest­ quality speakers, experts, and the curious together.
+
+Singapore is not only one of the fastest growing startup hubs in the world but is also a trusted healthcare, telecom, and financial services nexus in Asia with strong investment in technology from the Government. We aim to attract representation from large enterprises and the startup community alike.
+
+By sponsoring DevOpsDays, you will be exposing your organizations brand and services to Singapore and Southeast Asia’s top talent in this rapidly growing space.
+
+Sponsoring DevOpsDays Singapore connects your company to some of the greatest technical and business minds in the industry who are influencing decisions in security, monitoring, operations, engineering, quality, and organisational change.
+
+## The Venue
+
+TBA
+
+## Booth Space
+
+Gold and Platinum sponsors receive booth space at the event. This is the perfect spot for your engineers to meet other tech geeks. Your booth space will have a booth table (185 cm x 80 cm) and two chairs. You can set up your table as you like, be it to display signage, products, materials, or swag giveaways. We encourage sponsors to send engineers to interact with attendees during session breaks.
+
+Large displays and oversized marketing material are not allowed in the exhibitor space. Please check with the organizers if your items fall under the restricted category. You may ship your booth materials to the venue prior to the event day.
+
+<a name="packages"></a>
+# SPONSORSHIP PACKAGES
+
+Our sponsorship packages are structured around how you can help be part of the conference.
+
+<div id="sponsorship">
+  <table class="table table-hover table-condensed">
+    <tr>
+      <th><i>Packages</i></th>
+      <th><center><b>Silver<br />TBA&nbsp;SGD</center></b></th>
+      <th><center><b>Gold<br />TBA&nbsp;SGD</center></b></th>
+      <th><center><b>Platinum<br />TBA&nbsp;SGD</center></b></th>
+    </tr>
+    <tr>
+      <td># available</td>
+      <td style="text-align: center">
+        <strong>unlimited</strong>
+      </td>
+      <td style="text-align: center">
+        <strong>6</strong>
+        <!--
+        <span style="color: red">SOLD OUT</a>
+        -->
+      </td>
+      <td style="text-align: center">
+        <strong>2</strong>
+        <!--
+        <span style="color: red">SOLD OUT</a>
+        -->
+      </td>
+    </tr>
+    <tr>
+      <td>Logo on {{< event_link page="welcome" text="DevOpsDays Singapore" >}} event website</td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+    </tr>
+    <tr>
+      <td>Logo on <a href="http://www.meetup.com/devops-singapore/" target="_blank">meetup page</a> for event duration</td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+    </tr>
+    <tr>
+      <td>Complimentary attendee tickets (workshops not included*)</td>
+      <td><center><strong>1</strong></center></td>
+      <td><center><strong>3</strong></center></td>
+      <td><center><strong>6</strong></center></td>
+    </tr>
+    <tr>
+      <td>Logo on shared slide, rotating during breaks</td>
+      <td>&nbsp;</td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+    </tr>
+    <tr>
+      <td>No. of mentions in social media and outgoing material</td>
+      <td><center><strong>1</strong></center></td>
+      <td><center><strong>2</strong></center></td>
+      <td><center><strong>4</strong></center></td>
+    </tr>
+    <tr>
+      <td>Logo size in print program</td>
+      <td>&nbsp;</td>
+      <td><center><strong>Regular</strong></center></td>
+      <td><center><strong>Large</strong></center></td>
+    </tr>
+    <tr>
+      <td>No. of swag in goodie bag - requires approval</td>
+      <td>&nbsp;</td>
+      <td><center><strong>1</strong></center></td>
+      <td><center><strong>2</strong></center></td>
+    </tr>
+    <tr>
+      <td>Dedicated Booth/table space</td>
+      <td>&nbsp;</td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+      <td><center><i class="fa fa-check" aria-hidden="true"></i></center></td>
+    </tr>
+  </table>
+  <small>* Please reach out to us if you would like to purchase workshop passes. We have workshop only special pricing for our sponsors.</small>
+  <h2>SPECIAL SPONSOR PACKS</h2>
+  <table class="table table-condensed table-hover">
+    <tr>
+      <th style="width: 125px;"><i>Packages</i></th>
+      <th><i>Description</i></th>
+      <th><i>#&nbsp;available</i></th>
+      <th><i>Cost</i></th>
+    </tr>
+    <tr>
+      <td>Drink Sponsor
+      <td>Sponsor the drinks for the social event happy hour and have your signage and logo at the bar
+      <td><center>2</center>
+      <td>TBA&nbsp;SGD
+    </tr>
+    <tr>
+      <td>Logo on attendee badge
+      <td>Your logo will be placed on the attendee name badge. Size and placement to be determined by organizers.
+      <td><center>1</center>
+      <td>TBA&nbsp;SGD
+    </tr>
+  </table>
+</div>
+
+<!-- <div style="margin: 1.4em 0 2.4em 0;"><center><a href="https://drive.google.com/open?id=0B-L7Gu-eJct3em15bzFreGZWMU5jVnZ6S2pyckl2TGpZY053" target="_blank" class="btn btn-primary btn-lg">Download Sponsorship Prospectus</a></center></div> -->
+
+## THE SMALL PRINT
+
+WE CANNOT RELEASE ATTENDEE INFORMATION; SIZE & PLACEMENT OF LOGOS VARY ACCORDING TO SPONSORSHIP; PLEASE PROVIDE US WITH A VECTOR / HIGH RESOLUTION LOGO FOR THE PRINT PROGRAM. ALL INCLUDING <a href="https://en.wikipedia.org/wiki/Goods_and_Services_Tax_Singapore" target="_blank">GST</a>.
+
+TO ALLOW US SUFFICIENT TIME TO PREPARE FOR AND ORGANISE THE MARKETING AND OTHER RELEVANT ACTIVITIES, PLEASE PROVIDE IN A TIMELY MANNER YOUR LOGO AND OTHER RELEVANT MATERIALS OR INFORMATION REQUIRED FOR SUCH PURPOSES.
+
+<a name="faq"></a>
+## Sponsor FAQ
+
+### How big is our booth space?
+
+Gold and Platinum sponsors receive booth space at the event. You will receive a table (185 x 80 cm) and two chairs.
+
+### When can we pick our booth spot?
+
+Booths are not selectable. Our team will assign your table. Assignments will be made two weeks before the conference date.
+
+You can enter the venue in the morning at 7:30 am to set up your table.
+
+### How many scanners (and which type) do we get?
+
+None. The booth is a place to talk to people during breaks and this conference is not a typical conference or convention.
+
+We have seen that sponsors benefit the most when they bring engineers to the conference and interact with the attendees during the sessions. You are responsible to collect any information you want in person if you want to do giveaways.
+
+### Can we bring a 1m roll-up as our back wall?
+
+Whatever you bring must fit behind or on your table (185 x 80 cm).
+
+### Will we have any chairs at our booth?
+
+Each booth comes with 2 chairs.
+
+### Will there be a company sign at our booth? When do you need the graphics?
+
+You must bring your own signage and all signage must either fit on or behind the table.
+
+### Do we get any sponsored talks?
+
+No, but you are welcome to submit a proposal for consideration through <a href="http://devopsdays.org/events/2017-singapore/propose/">our CfP form</a>.
+
+### How many talk tracks do you have?
+
+It's a single-track program. You find more details on the program on {{< event_link page="program" text="our program page" >}}.
+
+### Do we get electricity connection for out booth?
+
+Yes, you will get a power strip (Plug <a href="http://www.iec.ch/worldplugs/typeG.htm">Type G</a>).
+
+### Will wifi connection be good enough for showing demos?
+
+TBA
+
+### Do we get an advertising in the program? When do you need the graphics?
+
+We will be using the logos that are sent by you.
+
+### Do we get a dedicated email blast?
+
+No, even better: we will give you a Twitter <a href="https://answers.yahoo.com/question/index?qid=20091205132038AA2uqcy">shout out</a>.
+
+### Who should I send?
+
+Not marketing folks. Send your techie geeks that can interact with attendees during the sessions and the breaks.
+
+### How do I pay the sponsorship package?
+
+Invoices will be handled by our conference partner. You will receive an invoice including GST, if applicable.
+
+For this, we need the official business address, full name of your contact and GST number.
+
+### How do we register our sponsor tickets?
+
+Once payment is complete, we will send you an email requesting registration details of the attendees that will use the tickets associated with your sponsorship level.
+
+### How many people do you expect?
+
+We are planning for 200 attendees.
+
+### What kind of attendees will come to the conference?
+
+We are focusing on people who are architecting and building distributed applications or doing migration projects, especially those away from monolithic software. This will typically include Architects, Lead Developers, and IT-Operations.
+
+### Do you have media partners who will cover the conference?
+
+No; however, if you have an idea to support the event in the media, please <a href="mailto:organizers-singapore-2017@devopsdays.org?subject=Sponsor DevOpsDays Singapore 2017">let us know</a>!
+
+### Can we ship stuff ahead?
+
+Yes. Please <a href="mailto:organizers-singapore-2017@devopsdays.org?subject=Shipping to DevOpsDays Singapore 2017">send us an email</a> so we can work out the details.
+
+### Can we lock things at the venue during the event?
+
+Yes. There is a shared room where you can stash stuff. Access is organized by the venue itself.
+
+### My question is not covered here. What can I do?
+
+If you have any questions not answered above, please do not hesitate to send us an email at <a href="mailto:organizers-singapore-2017@devopsdays.org">organizers-singapore-2017@devopsdays.org</a>.

--- a/data/events/2017-singapore.yml
+++ b/data/events/2017-singapore.yml
@@ -1,0 +1,94 @@
+name: "2017-singapore" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
+year: "2017" # The year of the event. Make sure it is in quotes.
+city: "Singapore" # The displayed city name of the event. Capitalize it.
+event_twitter: "devopsdaysSG" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
+description: "DevOpsDays is coming to Singapore!" # Edit this to suit your preferences
+ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+
+# All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
+startdate: # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: # The end date of your event. Leave blank if you don't have a venue reserved yet.
+
+# Leave CFP dates blank if you don't know yet, or set all three at once.
+cfp_date_start:  # start accepting talk proposals.
+cfp_date_end:  # close your call for proposals.
+cfp_date_announce:  # inform proposers of status
+
+cfp_open: "false"
+cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+
+registration_date_start: # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: # close registration. Leave blank if registration is not open yet.
+
+registration_closed: "" #set this to true if you need to manually close registration before your registration end date
+registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
+
+# Location
+#
+coordinates: "" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+location: "Singapore" # Defaults to city, but you can make it the venue name.
+#
+location_address: "" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+
+nav_elements: # List of pages you want to show up in the navigation of your page.
+ # - name: propose
+ # - name: location
+ # - name: registration
+ # - name: program
+ # - name: speakers
+  - name: sponsor
+  - name: contact
+  - name: conduct
+# - name: example
+#   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/
+#   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
+
+
+# These are the same people you have on the mailing list and Slack channel.
+team_members: # Name is the only required field for team members.
+  - name: "Christian Trabold"
+    twitter: "ctrabold"
+    employer: ""
+  - name: "Flavio Monigatti"
+    twitter: ""
+    employer: ""
+  - name: "Sergiu Bodiu"
+    twitter: "sergiu_bodiu"
+    employer: ""
+  - name: "Sriram Narayanan"
+    twitter: ""
+    employer: ""
+  - name: "Stefan Streichsbier"
+    twitter: "s_streichsbier"
+    employer: ""
+
+organizer_email: "organizers-singapore-2017@devopsdays.org" # Put your organizer email address here
+proposal_email: "proposals-singapore-2017@devopsdays.org" # Put your proposal email address here
+
+# List all of your sponsors here along with what level of sponsorship they have.
+# Check data/sponsors/ to use sponsors already added by others.
+sponsors:
+#  - id: microsoft
+#    level: host
+#  #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
+#   - id: arresteddevops
+#     level: community
+
+sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
+
+# In this section, list the level of sponsorships and the label to use.
+# You may optionally include a "max" attribute to limit the number of sponsors per level. For
+# unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
+# sponsorship for a specific level, it is best to remove the level.
+sponsor_levels:
+  - id: platinum
+    label: Platinum
+    max: 2
+  - id: gold
+    label: Gold
+    max: 6
+  - id: silver
+    label: Silver
+    max: 0 # This is the same as omitting the max limit.
+  - id: community
+    label: Community


### PR DESCRIPTION
This commit creates the initial event page with a basic set of pages. 

The goal is to have a landing page for the event that we can use when reaching out to sponsors or speakers.

No changes on the global scope are made and the event is not yet added to the list of upcoming events as we are still waiting for a final confirmation of the venue.