### PR TITLE
Change travis tests to use Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
 script:
   - cd public
   - ls
-  - gulp min-html --cwd public/
+  - gulp min-html --cwd .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ services:
 before_install:
   - docker run --rm -e SITE_URL="https://wwww.devopsdays.org" -v $(pwd):/site devopsdays/docker-hugo-compiler
 
+before_script:
+- npm install -g gulp
+- npm install
+- cd public
+
 script:
-  - cd public
   - ls
   - gulp min-html --cwd .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
 script:
   - cd public
   - ls
-  # - gulp min-html
+  - gulp min-html --cwd public/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ services:
 before_install:
   - docker run --rm -e SITE_URL="https://wwww.devopsdays.org" -v $(pwd):/site devopsdays/docker-hugo-compiler
 
-install: go get -v github.com/spf13/hugo
-
 script:
   - cd public
   - ls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
-sudo: false
-language: go
+sudo: required
+
+language: ruby
+
+services:
+  - docker
+
+before_install:
+  - docker run --rm -e SITE_URL="https://wwww.devopsdays.org" -v $(pwd):/site devopsdays/docker-hugo-compiler
+
 install: go get -v github.com/spf13/hugo
-# before_install:
-# - sudo apt-get update
-# - sudo apt-get install nodejs
-# - sudo apt-get install npm
-# before_script:
-# - npm install -g gulp
-# - npm install
+
 script:
-  - hugo
-  - hugo version
+  - cd public
+  - ls
   # - gulp min-html


### PR DESCRIPTION
This change causes the travis build job to use Docker, which will allow us to control the version of hugo.
