### PR TITLE
Update docker scripts for hugo 0.21

### DIFF
--- a/hugoserver.ps1
+++ b/hugoserver.ps1
@@ -4,4 +4,4 @@ $MyPath = $PSScriptRoot
 
 docker stop hugo-server
 docker rm hugo-server 
-docker run -p 1313:1313 -v ${MyPath}:/site --name hugo-server devopsdays/docker-hugo-server:v0.20
+docker run -p 1313:1313 -v ${MyPath}:/site --name hugo-server devopsdays/docker-hugo-server:v0.21

--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -7,4 +7,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tp 1313:1313 -v $(pwd):/site -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.20
+docker run -tp 1313:1313 -v $(pwd):/site:cached -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.21

--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -7,4 +7,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tp 1313:1313 -v $(pwd):/site:cached -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.21
+docker run -tp 1313:1313 -v $(pwd):/site -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.21


### PR DESCRIPTION
Updates both scripts to use the latest version of hugo, as well as add caching to make things (hopefully) better on OS X.
