### PR TITLE
Add core.toml file for new theme capability

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -6,7 +6,7 @@
   "alwaysNotifyForPaths": [
     {
       "name": "mattstratton",
-      "files": [".gitignore","config.toml","config-windows.toml", "gulpfile.js", "utilities/**/*", "themes/**/*", "content/page/**/*", "static/_redirects"], 
+      "files": [".gitignore","config.toml","config-windows.toml", "gulpfile.js", "utilities/**/*", "themes/**/*", "content/page/**/*", "static/_redirects", "data/core.toml"], 
       "skipTeamPrs": true 
     },
         {
@@ -21,7 +21,7 @@
     },
     {
       "name": "bridgetkromhout",
-      "files": [".gitignore","config.toml","config-windows.toml", "utilities/**/*", "themes/**/*", "content/page/**/*"],
+      "files": [".gitignore","config.toml","config-windows.toml", "utilities/**/*", "themes/**/*", "content/page/**/*", "data/core.toml"],
       "skipTeamPrs": false
      }
   ],

--- a/data/core.toml
+++ b/data/core.toml
@@ -1,0 +1,25 @@
+active = [
+"Bridget Kromhout (lead)",
+"Kris Buytaert",
+"Jennifer Davis",
+"Bernd Erk",
+"Matthew Jones",
+"Dan Maher",
+"Mike Rosado",
+"Andrew Clay Shafer",
+"Matt Stratton (web team lead)",
+"John Willis"
+]
+
+historic = [
+"Patrick Debois (founder)",
+"Damon Edwards",
+"Anthony Goddard",
+"Lindsay Holmwood",
+"Gildas Le Nadan",
+"Stephen Nelson-Smith",
+"Julian Simpson",
+"Christian Trabold",
+"John Vincent",
+"James Wickett"
+]


### PR DESCRIPTION
This is required for https://github.com/devopsdays/devopsdays-theme/pull/555

This is a backwards-compatible change - the file will not be used until the new theme is released.

