### PR TITLE
Resize speaker images properly

### DIFF
--- a/gulp/tasks/responsive-images.js
+++ b/gulp/tasks/responsive-images.js
@@ -8,7 +8,7 @@ runSequence = require('run-sequence');
 //     )
 // });
 
-gulp.task('responsive-images', ['responsive-images-logos', 'responsive-sponsor-images', 'responsive-organizer-images', 'responsive-images-remaining'])
+gulp.task('responsive-images', ['responsive-images-logos', 'responsive-speaker-images','responsive-sponsor-images', 'responsive-organizer-images','responsive-images-remaining'])
 
 
 
@@ -78,6 +78,54 @@ gulp.task('responsive-organizer-images', function() {
     .pipe(gulp.dest('dist'));
 });
 
+gulp.task('responsive-speaker-images', function() {
+    return gulp.src(['public/**/speakers/*.jpg', 'public/**/speakers/*.png'])
+        .pipe(responsive({
+            '**/*.png': [{
+                width: 300,
+                height: 300
+            }, {
+                width: 600,
+                height: 600,
+                rename: {
+                    suffix: '@2x'
+                }
+            }, {
+                width: 900,
+                height: 900,
+                rename: {
+                    suffix: '@3x'
+                }
+            }],
+            '**/*.jpg': [{
+                width: 300,
+                height: 300
+            }, {
+                width: 600,
+                height: 600,
+                rename: {
+                    suffix: '@2x'
+                }
+            }, {
+                width: 900,
+                height: 900,
+                rename: {
+                    suffix: '@3x'
+                }
+            }]
+        }, {
+            // global configuration
+            quality: 80,
+            errorOnEnlargement: false,
+            withoutEnlargement: false,
+            progressive: true,
+            silent: true,
+            withMetadata: false,
+        }))
+        .pipe(gulp.dest('dist'));
+});
+
+
 gulp.task('responsive-sponsor-images', function() {
     return gulp.src(['public/img/sponsors/*.png', 'public/img/sponsors/*.jpg'])
         .pipe(responsive({
@@ -122,7 +170,7 @@ gulp.task('responsive-sponsor-images', function() {
 
 gulp.task('responsive-images-remaining', function() {
     return gulp.src(['public/**/*.png', 'public/**/*.jpg','public/**/*.jpeg',
-            '!public/favicon*', '!public/apple-icon*', '!public/android-icon*', '!public/ms-icon*', '!public/**/sharing.jpg', '!**/logo-square.*', '!public/img/sponsor/*.*', '!public/**/organizers/*.jpg',
+            '!public/favicon*', '!public/apple-icon*', '!public/android-icon*', '!public/ms-icon*', '!public/**/sharing.jpg', '!**/logo-square.*', '!public/img/sponsor/*.*', '!public/**/organizers/*.jpg','!public/**/speakers/*.jpg','!public/**/organizers/*.png'
         ])
         .pipe(responsive({
             // produce multiple images from one source


### PR DESCRIPTION
Fixes devopsdays/devopsdays-theme#485

This handles the issue where different sized speaker images act weird.

Do not merge this change until https://github.com/devopsdays/devopsdays-theme/issues/485 has been approved.

 
