### PR TITLE
Add content about open spaces to program template

### DIFF
--- a/utilities/examples/templates/program.md
+++ b/utilities/examples/templates/program.md
@@ -7,7 +7,7 @@ Description = "Program for devopsdays CITY YYYY"
 <div class = "row">
   <div class = "col">
     <hr />
-    If you are new to the Open Space concept you may <a href="/pages/open-space-format">want to read some more details</a>.
+    If Open Space is new to you, you may be interested in <a href="/pages/open-space-format">more details about Open Space</a>.
     <hr />
   </div>
 </div>

--- a/utilities/examples/templates/program.md
+++ b/utilities/examples/templates/program.md
@@ -3,3 +3,11 @@ Title = "Program"
 Type = "program"
 Description = "Program for devopsdays CITY YYYY"
 +++
+
+<div class = "row">
+  <div class = "col">
+    <hr />
+    If you are new to the Open Space concept you may <a href="/pages/open-space-format">want to read some more details</a>.
+    <hr />
+  </div>
+</div>


### PR DESCRIPTION
We used to have this in the program page; since the content of the file displays above the generated program now, it seemed prudent to put it in again.
