### PR TITLE
Remove unneeded requests

### DIFF
--- a/utilities/add_speakers.sh
+++ b/utilities/add_speakers.sh
@@ -27,9 +27,6 @@ mkdir -p ../content/events/$event_slug/program
 mkdir -p ../content/events/$event_slug/speakers
 mkdir -p ../static/events/$event_slug/speakers
 
-# Set the creation date to current timestamp
-datestamp=$(date +%Y-%m-%dT%H:%M:%S%z | sed 's/^\(.\{22\}\)/\1:/')
-
 # Create empty speakers page file (will be auto-filled for display)
 speakerspage="../content/events/$event_slug/speakers.md"
 cp examples/templates/speakers.md $speakerspage
@@ -56,7 +53,6 @@ speakerfile="../content/events/$event_slug/speakers/$speaker_slug.md"
 cp examples/templates/speakers-speaker-full-name.md $speakerfile
 
 SEDCMD "s/SPEAKERNAME/$speakername/" $speakerfile
-SEDCMD "s/2000-01-01T01:01:01-06:00/$datestamp/" $speakerfile
 SEDCMD "s/SPEAKERSLUG/$speaker_slug/" $speakerfile
 
 # twitter handle
@@ -77,7 +73,6 @@ SEDCMD "s/SPEAKERBIO/$bio/" $speakerfile
 talkfile="../content/events/$event_slug/program/$speaker_slug.md"
 cp examples/templates/program-speaker-full-name.md $talkfile
 
-SEDCMD "s/2000-01-01T01:01:01-06:00/$datestamp/" $talkfile
 SEDCMD "s/SPEAKERSLUG/$speaker_slug/" $talkfile
 
 # talk title


### PR DESCRIPTION
Speaker creation shouldn't ask for data it doesn't use. The "datestamp" frontmatter field no longer exists in those templates, so this sed command is a no-op.

This is meant to address https://github.com/devopsdays/devopsdays-web/issues/2559 - we can bikeshed over there as to whether it solves what that issue was meant to solve.