### PR TITLE
[OSL-2017] Add twitter handle for Hans Kristian Flaatten

### DIFF
--- a/data/events/2017-oslo.yml
+++ b/data/events/2017-oslo.yml
@@ -85,7 +85,7 @@ team_members: # Name is the only required field for team members.
     image: "anders-bruvik.jpg"
 #    employer: ""
   - name: "Hans Kristian Flaatten"
-#    twitter: ""
+    twitter: "Starefossen"
     image: "hans-kristian-flaatten.jpg"
 #    employer: "Evry"
   - name: "Tor Magnus Castberg"


### PR DESCRIPTION
Add twitter handle for DevOps Days Oslo 2017 organiser Hans Kristian Flaatten.

CC @steinim @sveinung 
