### PR TITLE
[BNA-2016] Change Nashville's welcome page for 2016

### DIFF
--- a/content/events/2016-nashville/welcome.md
+++ b/content/events/2016-nashville/welcome.md
@@ -1,6 +1,6 @@
 +++
 date = "2016-11-10T21:15:25-06:00"
-title = "welcome"
+title = "devopsdays nashville 2016"
 type = "event"
 aliases = ["/events/2016-nashville"]
 


### PR DESCRIPTION
This is an example change of creating a proper title for older events, to help prevent google conflicts.
