### PR TITLE
Updating theme to 1.12.0

### DIFF
--- a/themes/devopsdays-theme/CHANGELOG.md
+++ b/themes/devopsdays-theme/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.12.0](https://github.com/devopsdays/devopsdays-theme/tree/1.12.0) (2017-06-28)
+[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.11.0...1.12.0)
+
+**Implemented enhancements:**
+
+- Improve title tags to remove duplication in Google [\#539](https://github.com/devopsdays/devopsdays-theme/issues/539)
+- Add embedded support for Google Forms on main pages [\#230](https://github.com/devopsdays/devopsdays-theme/issues/230)
+
+**Fixed bugs:**
+
+- List of other events should not say "past" [\#568](https://github.com/devopsdays/devopsdays-theme/issues/568)
+
 ## [1.11.0](https://github.com/devopsdays/devopsdays-theme/tree/1.11.0) (2017-06-08)
 [Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.10.3...1.11.0)
 

--- a/themes/devopsdays-theme/REFERENCE.md
+++ b/themes/devopsdays-theme/REFERENCE.md
@@ -23,6 +23,8 @@
 &emsp;[Talk Page Fields](#talk-page-fields)   
 &emsp;[Speaker Page Fields](#speaker-page-fields)   
 &emsp;[Blog Post Fields](#blog-post-fields)   
+[Shortcodes](#shortcodes)   
+&emsp;[google_form](#google_form)   
 
 <!-- /MDTOC -->
 
@@ -277,3 +279,13 @@ Pages of the type `speaker` have a few additional frontmatter elements available
 | `Author`        | No       | The name of the person who wrote the blog post.                                                                                                                                     | "Matt Stratton"                                                                                                                                                                                                                                                                                      |
 | `title`         | Yes      | The title for the blog post.                                                                                                                                                        | "Chicago 2016 In Review"                                                                                                                                                                                                                                                                             |
 | `sharing_image` | No       | The image to use for social sharing. This is a path relative to the `static` directory.                                                                                             | "img/blog/chicago-2016-sharing.jpg"                                                                                                                                                                                                                                                                  |
+
+## Shortcodes
+
+Shortcodes can be used in any of your content (i.e., ".md" files. They provide easy ways to add content without having to write a lot of coding.)
+
+### google_form
+This shortcode allows for the embedding of a Google form on a page, in a manner that maintains the responsive, mobile-friendly design of the site. To use it, you only need the URL of your form (not the full embed code) and enter this on your page (substituting the proper URL):
+```
+{{< google_form "https://docs.google.com/forms/d/e/1FAIpQLScvv-ty_wEBlYkJaEC1OU0qqqbIHjf9JVa-Ptdo5TcHqz5EDA/viewform?usp=sf_link" >}}
+```

--- a/themes/devopsdays-theme/layouts/partials/head.html
+++ b/themes/devopsdays-theme/layouts/partials/head.html
@@ -2,16 +2,49 @@
 {{- partial "head/seo.html" . -}}
 
 <title>
-    {{- $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" -}}
-    {{- if eq $url "/" -}}
-      {{ .Site.Title }}
+    {{- if .IsHome -}}
+      {{ $.Scratch.Set "title" "devopsdays" }}
     {{- else -}}
-      {{- if .Params.Heading -}}
-        {{ .Params.Heading }}
+      {{- if .IsPage -}}
+        {{- if or (eq .Type "welcome") (eq .Type "event") (eq .Type "speakers") (eq .Type "talk") (eq .Type "speaker") -}}
+          {{- $e := (index $.Site.Data.events (index (split (.Permalink | relURL) "/") 2)) -}}
+          {{- if eq (lower .Title) "welcome" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s" $e.city (chomp $e.year)) -}}
+          {{- else if eq (lower .Title) "conduct" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s - code of conduct" $e.city (chomp $e.year)) -}}
+          {{- else if eq (lower .Title) "contact" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s - contact information" $e.city (chomp $e.year)) -}}
+          {{- else if eq (lower .Title) "location" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s - location information" $e.city (chomp $e.year)) -}}
+          {{- else if eq (lower .Title) "program" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s - program" $e.city (chomp $e.year)) -}}
+          {{- else if eq (lower .Title) "propose" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s - propose a talk" $e.city (chomp $e.year)) -}}
+          {{- else if eq (lower .Title) "registration" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s - register" $e.city (chomp $e.year)) -}}
+          {{- else if eq (lower .Title) "speakers" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s - speakers" $e.city (chomp $e.year)) -}}
+          {{- else if eq (lower .Title) "sponsor" -}}
+            {{- $.Scratch.Set "title" (printf "devopsdays %s %s - sponsorship information" $e.city (chomp $e.year)) -}}
+          {{- else if eq .Type "talk" -}}
+            {{- $.Scratch.Set "title" (printf "%s - devopsdays %s %s" .Title $e.city (chomp $e.year)) -}}
+          {{- else if eq .Type "speaker" -}}
+            {{- $.Scratch.Set "title" (printf "%s - devopsdays %s %s" .Title $e.city (chomp $e.year)) -}}
+          {{- else -}}
+            {{- $.Scratch.Set "title" .Title -}}
+          {{- end -}}
+          {{- if not ($.Scratch.Get "title") -}}
+            {{- $.Scratch.Set "title" .Title -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if not ($.Scratch.Get "title") -}}
+          {{- $.Scratch.Set "title" .Title -}}
+        {{- end -}}
       {{- else -}}
-        {{ .Title }}
+        {{- $.Scratch.Set "title" .Title -}}
       {{- end -}}
     {{- end -}}
+  {{ $.Scratch.Get "title" }}
 </title>
 <link rel="canonical" href="{{ .Permalink | absURL }}">
 {{- partial "head_includes.html" . -}}

--- a/themes/devopsdays-theme/layouts/partials/welcome.html
+++ b/themes/devopsdays-theme/layouts/partials/welcome.html
@@ -82,7 +82,7 @@
           {{- if .startdate -}} <!-- for some reason, it bails on the city Chicago, and also Paris -->
               {{- if eq (lower .city) (lower $e.city) -}}
                 {{- if and (ne .startdate $e.startdate) (ne ($.Scratch.Get "past-counter") 1 ) -}}
-                  <i>Past {{ $e.city }} Events</i><br />
+                  <i>Other {{ $e.city }} Events</i><br />
                   {{- $.Scratch.Set "past-counter" 1 -}}
                 {{- end -}}
               {{- if eq (lower .city) (lower $e.city)}}

--- a/themes/devopsdays-theme/layouts/shortcodes/google_form.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/google_form.html
@@ -1,0 +1,3 @@
+<div style="width:100%; text-align:left;">
+<iframe src="{{ .Get 0 }}" width="100%" height="800px" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+</div>

--- a/themes/devopsdays-theme/theme.toml
+++ b/themes/devopsdays-theme/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/devopsdays/devopsdays-theme/"
 tags = ["", ""]
 features = ["", ""]
 min_version = 0.18
-theme_version = 1.11.0
+theme_version = 1.12.0
 
 [author]
   name = "Matt Stratton"


### PR DESCRIPTION
## [1.12.0](https://github.com/devopsdays/devopsdays-theme/tree/1.12.0) (2017-06-28)
[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.11.0...1.12.0)

**Implemented enhancements:**

- Improve title tags to remove duplication in Google [\#539](https://github.com/devopsdays/devopsdays-theme/issues/539)
- Add embedded support for Google Forms on main pages [\#230](https://github.com/devopsdays/devopsdays-theme/issues/230)

**Fixed bugs:**

- List of other events should not say "past" [\#568](https://github.com/devopsdays/devopsdays-theme/issues/568)