### PR TITLE
[CHI-2017] Remove propose link from Chicago 2017

### DIFF
--- a/data/events/2017-chicago.yml
+++ b/data/events/2017-chicago.yml
@@ -30,8 +30,6 @@ location_address: "350 West Mart Center Drive, Chicago, IL 60654"
 nav_elements: # List of pages you want to show up in the navigation of your page.
 
 #  - name: program
-  - name: propose
-    url: https://www.papercall.io/devopsdays-chicago-2017 # The url setting is optional, and only if you want the navigation to link off-site
   - name: location
   - name: registration
   - name: volunteer


### PR DESCRIPTION
Whoops. Our CFP closed, and we forgot to remove the propose link from the menu.