### PR TITLE
Make Docker for Mac cache filesystem calls

### DIFF
--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -7,4 +7,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tp 1313:1313 -v $(pwd):/site -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.23
+docker run -tp 1313:1313 -v $(pwd):/site:cached -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.23

--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -4,6 +4,8 @@
 #
 # Purpose: Run the Hugo container as a local server
 #
+# This requires Docker 17.06.0-ce or above.
+
 
 docker stop hugo-server
 docker rm   hugo-server


### PR DESCRIPTION
https://blog.docker.com/2017/05/user-guided-caching-in-docker-for-mac/

Hugo takes a while to render the website in Docker on macOS due to slow
filesystem calls. This should speed it up.

I tested a rebuild of the site before and after the change, and got
this:
Before - 103508ms
After - 25891ms

This requires Docker 17.06.0-ce or above.

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2017] Add Bluth Company as a sponsor`*
