### PR TITLE
[PDX-2017] added DK speaker info to content folder

### DIFF
--- a/content/events/2017-portland/speakers/dustin-kirkland.md
+++ b/content/events/2017-portland/speakers/dustin-kirkland.md
@@ -1,0 +1,16 @@
++++
+Title = "Dustin Kirkland"
+Twitter = "dustinkirkland"
+image = ""
+type = "speaker"
+linktitle = "dustin-kirkland"
+
++++
+
+Dustin Kirkland leads the Product Management Team at Canonical for Ubuntu,
+from servers in the cloud to connected devices and Internet things.
+
+When he's not hacking on open source software in Ubuntu,
+he's home brewing beer or chasing his daughters around.
+
+


### PR DESCRIPTION
I have Dustin Kirkland speaker info in the data folder, but forgot to add his speaker information to the content folder