### PR TITLE
[Kansas City-2017]: Add program as link

### DIFF
--- a/content/events/2017-kansascity/welcome.md
+++ b/content/events/2017-kansascity/welcome.md
@@ -62,14 +62,14 @@ Where large enterprise software companies and a growing startup community are fu
   </div>
 </div>
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
     <strong>Program</strong>
   </div>
   <div class = "col-md-8">
     View the {{< event_link page="program" text="program." >}}
   </div>
-</div> -->
+</div>
 
 <!-- <div class = "row">
   <div class = "col-md-2">

--- a/data/events/2017-kansascity.yml
+++ b/data/events/2017-kansascity.yml
@@ -29,7 +29,7 @@ registration_open: "true"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
 
-#  - name: program
+
 #  - name: speakers
   - name: location
   - name: registration
@@ -38,8 +38,10 @@ nav_elements: # List of pages you want to show up in the navigation of your page
     icon: smile-o
     url: https://drive.google.com/file/d/0Bz33o_Xkz6GYQTF3Z1BFQmthdFU/view?usp=sharing
   - name: sponsor
+  - name: program
   - name: contact
   - name: conduct
+
 
 # These are the same people you have on the mailing list and Slack channel.
 team_members: # Name is the only required field for team members.


### PR DESCRIPTION
Add in links from KC to program.

We understand the program is empty at this point, this is just so that the link will be there for speaker communications.
