### PR TITLE
[Nashville-2017] Remove Jurnell from list of organizers

### DIFF
--- a/data/events/2017-nashville.yml
+++ b/data/events/2017-nashville.yml
@@ -51,7 +51,6 @@ team_members: # Name is the only required field for team members.
   - name: "Steve Stewart"
   - name: "Joel Parks"
   - name: "Alicia Sepanik"
-  - name: "Jurnell Cockhren"
   - name: "Brian Pitts"
 organizer_email: "organizers-nashville-2017@devopsdays.org" # Put your organizer email address here
 proposal_email: "proposals-nashville-2017@devopsdays.org" # Put your proposal email address here


### PR DESCRIPTION
Jurnell is not active as an organizer any more this year.
