### PR TITLE
Fixing broken link

### DIFF
--- a/data/events/2017-raleigh.yml
+++ b/data/events/2017-raleigh.yml
@@ -38,7 +38,6 @@ team_members: # Name is the only required field for team members.
     twitter: "DukeAMO"
     image: "ann-marie-fred.jpg"
   - name: "Chris Knotts"
-    image: "chris-knotts.jpg"
   - name: "Josh Atwell"
     twitter: "Josh_Atwell"
     image: "josh-atwell.jpg"


### PR DESCRIPTION
Hey, @chris-short - I'm removing this line because it's causing this broken link:

<img width="975" alt="screen shot 2017-08-15 at 9 15 06 pm" src="https://user-images.githubusercontent.com/2104453/29344647-f00b51a8-81fe-11e7-9938-61605548777e.png">

You can restore it if you upload that missing file - thanks!

(The other change is because my editor restores the missing newline at the end of the file.)