### PR TITLE
Allow gitlab to be added to team members profiles

### DIFF
--- a/data/events/2017-cape-town.yml
+++ b/data/events/2017-cape-town.yml
@@ -30,6 +30,7 @@ team_members:
     employer: "SweepSouth"
     twitter: "adrianmoisey"
     github: "adrianmoisey"
+    gitlab: "adrianmoisey"
     linkedin: "https://www.linkedin.com/in/adrian-moisey-b6705744"
     facebook: "https://www.facebook.com/adrianbmoisey"
     website: "https://adrianmoisey.github.io/"

--- a/themes/devopsdays-theme/layouts/shortcodes/list_organizers.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/list_organizers.html
@@ -40,6 +40,9 @@
                 {{- if .github -}}
                     <a href = "http://github.com/{{ .github }}"><i class="fa fa-github fa-2x" aria-hidden="true"></i></a>&nbsp;
                 {{- end -}}
+                {{- if .gitlab -}}
+                    <a href = "http://gitlab.com/{{ .gitlab}}"><i class="fa fa-gitlab fa-2x" aria-hidden="true"></i></a>&nbsp;
+                {{- end -}}
             </div>
           </div>
         </div>


### PR DESCRIPTION
I'm ❤️ ing Gitlab these days and would like to list it on my profile.