### PR TITLE
Updating theme to 1.13.1

### DIFF
--- a/themes/devopsdays-theme/CHANGELOG.md
+++ b/themes/devopsdays-theme/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.13.1](https://github.com/devopsdays/devopsdays-theme/tree/1.13.1) (2017-08-29)
+[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.12.1...1.13.1)
+
+**Fixed bugs:**
+
+- Extra dash on program page if speaker is blank [\#586](https://github.com/devopsdays/devopsdays-theme/issues/586)
+- Talk page needs spacing below headshot and before speaker title [\#578](https://github.com/devopsdays/devopsdays-theme/issues/578)
+
 ## [1.12.1](https://github.com/devopsdays/devopsdays-theme/tree/1.12.1) (2017-08-06)
 [Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.12.0...1.12.1)
 

--- a/themes/devopsdays-theme/REFERENCE.md
+++ b/themes/devopsdays-theme/REFERENCE.md
@@ -271,6 +271,7 @@ Pages of the type `speaker` have a few additional frontmatter elements available
 | `facebook` | No       | Speaker's Facebook URL                                                                                                                                                                                     | "https://www.facebook.com/matt.stratton"    |
 | `linkedin` | No       | Speaker's LinkedIn URL                                                                                                                                                                                     | "https://www.linkedin.com/in/mattstratton/" |
 | `github`   | No       | Speakers' GitHub username.                                                                                                                                                                                 | "mattstratton"                              |
+| `gitlab`   | No       | Speakers' GitLab username.                                                                                                                                                                                 | "mattstratton"                              |
 | `image`    | No       | The image for the speaker. This image is relative to the `static/events/YYYY-CITY/speakers` directory. It can be either .png or .jpg. It must be square, and 300px square, 600px square, or 900px square.  | "matt-stratton.jpg"                         |
 
 ### Blog Post Fields

--- a/themes/devopsdays-theme/layouts/shortcodes/list_organizers.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/list_organizers.html
@@ -40,6 +40,9 @@
                 {{- if .github -}}
                     <a href = "http://github.com/{{ .github }}"><i class="fa fa-github fa-2x" aria-hidden="true"></i></a>&nbsp;
                 {{- end -}}
+                {{- if .gitlab -}}
+                    <a href = "https://gitlab.com/{{ .gitlab}}"><i class="fa fa-gitlab fa-2x" aria-hidden="true"></i></a>&nbsp;
+                {{- end -}}
             </div>
           </div>
         </div>

--- a/themes/devopsdays-theme/layouts/talk/single.html
+++ b/themes/devopsdays-theme/layouts/talk/single.html
@@ -118,10 +118,10 @@
         <a href = "{{ (printf "events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) | absURL}}">
         {{- if isset .Params "image" -}}
           {{- if ne .Params.image "" -}}
-            <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br />
+            <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
           {{- end -}}
           {{- else -}}
-            <img src = "{{"img/speaker-default.jpg" | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br />
+            <img src = "{{"img/speaker-default.jpg" | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
         {{- end -}}
           <h4 class="talk-page"><a href = "{{ (printf "events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) | absURL }}">
             {{ .Title }}

--- a/themes/devopsdays-theme/theme.toml
+++ b/themes/devopsdays-theme/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/devopsdays/devopsdays-theme/"
 tags = ["", ""]
 features = ["", ""]
 min_version = 0.18
-theme_version = 1.12.1
+theme_version = 1.13.1
 
 [author]
   name = "Matt Stratton"


### PR DESCRIPTION
## [1.13.1](https://github.com/devopsdays/devopsdays-theme/tree/1.13.1) (2017-08-29)
[Full Changelog](https://github.com/devopsdays/devopsdays-theme/compare/1.12.1...1.13.1)

**Fixed bugs:**

- Extra dash on program page if speaker is blank [\#586](https://github.com/devopsdays/devopsdays-theme/issues/586)
- Talk page needs spacing below headshot and before speaker title [\#578](https://github.com/devopsdays/devopsdays-theme/issues/578)

**Implemented enhancement**

- Speaker page now supports link to GitLab profile