### PR TITLE
Removing blank images

### DIFF
--- a/content/events/2017-auckland/speakers/alison-polton-simon.md
+++ b/content/events/2017-auckland/speakers/alison-polton-simon.md
@@ -1,7 +1,6 @@
 +++
 Title = "Alison Polton-Simon"
 Twitter = ""
-image = ""
 type = "speaker"
 linktitle = "alison-polton-simon"
 

--- a/content/events/2017-auckland/speakers/anthony-angell.md
+++ b/content/events/2017-auckland/speakers/anthony-angell.md
@@ -1,7 +1,6 @@
 +++
 Title = "Anthony Angell"
 Twitter = ""
-image = ""
 type = "speaker"
 linktitle = "anthony-angell"
 


### PR DESCRIPTION
I'm noticing that when there's an image element that's blank, we aren't getting the default. Likely a bug. It manifests thusly.

<img width="1049" alt="screen shot 2017-08-31 at 9 18 04 pm" src="https://user-images.githubusercontent.com/2104453/29952903-f0939c4e-8e91-11e7-9e7c-fc98c465f287.png">
