### PR TITLE
Make hugo stop if you send Ctrl+C

### DIFF
--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -9,4 +9,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tp 1313:1313 -v $(pwd):/site:cached -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.23
+docker run -tip 1313:1313 -v $(pwd):/site:cached -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.23


### PR DESCRIPTION
While running hugo under Docker, sending a Ctrl+C doesn't make it stop,
only the shell script stops.

(even thought Hugo says "Press Ctrl+C to stop")

Adding the `-i` to Docker changes this behaviour. Hitting Ctrl+C now
causes Hugo to stop, and the shell script to exit.