### PR TITLE
[Auckland-2017] Adding RedHat and OSS as gold sponsors

### DIFF
--- a/data/events/2017-auckland.yml
+++ b/data/events/2017-auckland.yml
@@ -80,6 +80,10 @@ sponsors:
     level: gold
   - id: SECTION6
     level: gold
+  - id: redhat
+    level: gold
+  - id: 2016-oss
+    level: gold  
   - id: k2
     level: silver
   - id: 2016-xero


### PR DESCRIPTION
 Adding RedHat and OSS as gold sponsors for event.