### PR TITLE
Fix sed commands to use correct placeholder for file

### DIFF
--- a/utilities/add_sponsors.sh
+++ b/utilities/add_sponsors.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# Detect OS for correct 'sed' syntax
+OSNAME=`uname`
+SEDCMD(){
+  if [[ $OSNAME == 'Linux' ]]; then
+    sed -i "$@"
+  elif [[ $OSNAME == 'Darwin' ]]; then
+    sed -i '' "$@"
+  fi
+}
+
 # Get year
 read -p "Enter your event year (default: $(date +"%Y")): " year
 [ -z "${year}" ] && year='2017'
@@ -48,9 +58,9 @@ read -p "Enter path to 200x200 PNG logo: " logo
 # Populate data file
 cp examples/data/sponsors/sponsorname.yml $sponsorfile
 
-sed -i '' "s/SPONSORNAME/$sponsorname/" $sponsorfile
-sed -i '' "s%URL%$url%" $sponsorfile
-sed -i '' "s/TWITTER/$twitter/" $sponsorfile
+SEDCMD "s/SPONSORNAME/$sponsorname/" $sponsorfile
+SEDCMD "s%URL%$url%" $sponsorfile
+SEDCMD "s/TWITTER/$twitter/" $sponsorfile
 
 # Set logo
 


### PR DESCRIPTION
Remove argument after '-i' as it is being recognized as the sed script to execute
rather than as an argument to the option flag.