### PR TITLE
[PHILLY-2017] Stop accepting Silver Sponsors

### DIFF
--- a/data/events/2017-philadelphia.yml
+++ b/data/events/2017-philadelphia.yml
@@ -98,7 +98,7 @@ sponsor_levels:
     max: 10
   - id: silver
     label: Silver
-    max: 0 # This is the same as omitting the max limit.
+    max: 1 # Actually will be 2 total, but we have one in-flight and need to stop accepting new requests
   - id: bronze
     label: Bronze
   - id: community


### PR DESCRIPTION
Temporarily sets max silver sponsors to 1, removing the Become a Sponsor message at that level.  We do in fact have one more, but it is in flight, and we don't want new proposals.