### PR TITLE
change display interactive to event tracking URL

### DIFF
--- a/data/events/2017-paris.yml
+++ b/data/events/2017-paris.yml
@@ -113,6 +113,7 @@ sponsors:
     level: silver
   - id: display-interactive
     level: silver
+    url: https://bit.ly/2vo1GvE
   - id: matters
     level: silver
   - id: objectif-libre


### PR DESCRIPTION
Display Interactive is using a specific URL for sponsoring this event.

cc @jooooooon