### PR TITLE
[ZRH-2018] Enable DoD 2018 ZRH registration

### DIFF
--- a/content/events/2018-zurich/registration.md
+++ b/content/events/2018-zurich/registration.md
@@ -1,16 +1,16 @@
 +++
-date = "2016-07-20T13:45:44+02:00"
 title = "registration"
 type = "event"
-
-
+description = "Registration for devopsdays Zurich 2018"
 +++
-Registration for DevOpsDays Zürich is now open.<br> 
-<a href="https://user.ticketpark.ch/en/embed/ticketing/show/9FBB6FB2-4F52-4819-8CFC-174D39322177?customCssFiles=&language=en&bookingData=%7B%22booking%22%3A%7B%22origin%22%3A%22www.devopsdays.org%22%7D%7D&embedId=singleEmbed&entryPoint=https%3A%2F%2Fuser.ticketpark.ch%2Fen%2Fembed%2Fticketing%2Fshow%2F9FBB6FB2-4F52-4819-8CFC-174D39322177" target="_blank">Please click here if you don't see the payment page</a><br>
 
-<script type="text/javascript">
-  var _tp_customCssFiles = "";
-  var _tp_language = "en";
-</script>
-<script src="https://user.ticketpark.ch/embed/js/ticketing/show/9FBB6FB2-4F52-4819-8CFC-174D39322177" type="text/javascript"></script>
+Registration for DevOpsDays Zürich 2018, May 2 - May 3. If you have any questions please contact us at {{< email_organizers >}}.
 
+<div style="width:100%; text-align:left;">
+<link rel="stylesheet" type="text/css" href='https://css.tito.io/v1.1' />
+<script src='https://js.tito.io/v1' async></script>
+<tito-widget event="dod/dodzh2018"></tito-widget>
+</div>
+<br />
+
+If this doesn't work for you, registration can also be done here: [ti.to/dod/dodzh18](https://ti.to/dod/dodzh2018)

--- a/data/events/2018-zurich.yml
+++ b/data/events/2018-zurich.yml
@@ -10,7 +10,7 @@ enddate: 2018-05-03
 # cfp_date_start: 2016-11-01 # start accepting talk proposals.
 # cfp_date_end: 2017-02-01 # close your call for proposals.
 # cfp_date_announce: 2017-04-01 # inform proposers of status
-registration_open: "false"
+registration_open: "true"
 
 # Location
 #
@@ -25,7 +25,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
 # - name: propose
 #   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
   - name: location
-#  - name: registration
+  - name: registration
 #  - name: sponsor
   - name: contact
   - name: conduct


### PR DESCRIPTION
We now start selling tickets over Tito for devopsdays Zurich-Winterthur 2018. This PR adds the menu and includes the selling form.