### PR TITLE
Fix sponsor example

### DIFF
--- a/utilities/examples/data/sponsors/sponsorname.yml
+++ b/utilities/examples/data/sponsors/sponsorname.yml
@@ -1,3 +1,3 @@
 name: "SPONSORNAME"
 url: "URL"
-twitter:
+twitter: "TWITTER"


### PR DESCRIPTION
`add_sponsors.sh` expects this string to exist, because it replaces it
with the correct twitter account.
See
https://github.com/devopsdays/devopsdays-web/blob/9e96ad2f7990150a5b14f91975312aaa0d1cb0c3/utilities/add_sponsors.sh#L64
