### PR TITLE
[LA 2018] remove sponsors

### DIFF
--- a/data/events/2018-los-angeles.yml
+++ b/data/events/2018-los-angeles.yml
@@ -37,26 +37,8 @@ proposal_email: "organizers-los-angeles-2018@devopsdays.org"
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
-  - id: 2017-vdms
-    level: sponsor
   - id: datadog
     level: sponsor
-  - id: 2016-carsdotcom
-    level: sponsor
-  - id: thoughtworks-gocd
-    level: sponsor
-  - id: opsgenie
-    level: sponsor
-  - id: collabnet
-    level: sponsor
-  - id: threatstack
-    level: sponsor
-  - id: versionone
-    level: sponsor
-  - id: cyberark
-    level: sponsor
-  - id: 2017-openx
-    level: lanyard
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
LA 2017 sponsors look to have been added on LA 2018 by mistake. I'm removing for now. we'll add new ones back in as they sign up.