### PR TITLE
[Cape Town 2017] Change to a event specific URL

### DIFF
--- a/data/events/2017-cape-town.yml
+++ b/data/events/2017-cape-town.yml
@@ -94,6 +94,7 @@ sponsors:
    url: https://sites.elasticgrid.com/atlassian/devops-aw/obsidianza/
  - id: offerzen
    level: gold
+   url: http://bit.ly/2xBHNm9
  - id: thoughtworks-gocd
    level: gold
  - id: zappistore


### PR DESCRIPTION
OfferZen want to track traffic to their site, and have requested this URL change.
