### PR TITLE
[ZRH-2018] Adding Sponsors

### DIFF
--- a/content/events/2018-zurich/sponsor.md
+++ b/content/events/2018-zurich/sponsor.md
@@ -13,7 +13,7 @@ Please keep in mind, that you accept our Code of Conduct with sponsoring this ev
 <table border="1" width="100%" style="padding: 5px; border-collapse: collapse; border: 1px solid black;">
   <tr>
     <th><b>Packages</b></th>
-    <th><center><b><u>Evening<br />9'000.- CHF</u></center></b></th>
+    <th><center><b><u>Evening<br /><font color="red">SOLD OUT</font></center></b></th>
     <th><center><b><u>Gold<br />6'000.- CHF</u></center></b></th>
     <th><center><b><u>Silver<br />3'000.- CHF</u></center></b></th>
     <th><center><b><u>Bronze<br />1'500.- CHF</u></center></b></th>

--- a/data/events/2018-zurich.yml
+++ b/data/events/2018-zurich.yml
@@ -119,6 +119,8 @@ proposal_email: "organizer@devopsdays.ch" # Put your proposal email address here
 sponsors:
   - id: pontine
     level: Evening Event
+  - id: puzzle-itc
+    level: silver
 
 sponsors_accepted : "true" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels: # In this section, list the level of sponsorships and the label to use.

--- a/data/events/2018-zurich.yml
+++ b/data/events/2018-zurich.yml
@@ -120,5 +120,13 @@ sponsors:
 
 sponsors_accepted : "true" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels: # In this section, list the level of sponsorships and the label to use.
+  - id: Evening Event
+    label: Evening Event
+  - id: gold
+    label: Gold
+  - id: silver
+    label: Silver
+  - id: bronze
+    label: Bronze
 
 program:

--- a/data/events/2018-zurich.yml
+++ b/data/events/2018-zurich.yml
@@ -117,6 +117,8 @@ proposal_email: "organizer@devopsdays.ch" # Put your proposal email address here
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
+  - id: pontine
+    level: Evening Event
 
 sponsors_accepted : "true" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels: # In this section, list the level of sponsorships and the label to use.


### PR DESCRIPTION
Adding Pontine and Puzlle ITC as sponsors as well as the sponsor levels

There seems to be something off with the styling of the sponsor levels on our start page (Browser: Safari 10.1.2)
![devopsdays 2018 zurich sponsor display problem](https://user-images.githubusercontent.com/10051979/31558167-18105150-b04c-11e7-89ab-0b9fe2eedc30.png)

