### PR TITLE
[Cape Town 2017] Open registration and add a button

### DIFF
--- a/content/events/2017-cape-town/index.md
+++ b/content/events/2017-cape-town/index.md
@@ -17,6 +17,13 @@ Description = "DevOpsDays is coming back to Cape Town! Tickets on sale now."
     </a>
   </div>
 </div>
+<div class="row">
+  <div class = "col-md-4 offset-md-4">
+    <a class="btn btn-primary btn-block" style="margin-top: 10px; margin-bottom: 10px; background-color: #96bfe6; border-color: #96bfe6;" href="/events/2017-cape-town/program">
+      <i class="fa fa-calendar fa-lg"></i>&nbsp;&nbsp;&nbsp;See the program for DevOpsDays Cape Town 2017
+    </a>
+  </div>
+</div>
 <br>
 
 <div class = "row">

--- a/data/events/2017-cape-town.yml
+++ b/data/events/2017-cape-town.yml
@@ -13,6 +13,8 @@ cfp_date_start: 2017-06-01  # start accepting talk proposals.
 cfp_date_end: 2017-07-31  # close your call for proposals.
 cfp_date_announce: 2017-08-08  # inform proposers of status
 
+registration_open: "true"
+
 coordinates: "-33.935600, 18.457423"
 location: "Hilton Doubletree, Woodstock, Cape Town"
 


### PR DESCRIPTION
- Turns on registration (turns out we should have done that a while back)
- Add a button pointing people at the schedule (seems like they want that, so make it clear where to find it)