### PR TITLE
[PHILLY-2017] Fix 'SPEAKERBIO' anomaly in Erica's bio

### DIFF
--- a/content/events/2017-philadelphia/speakers/erica-windisch.md
+++ b/content/events/2017-philadelphia/speakers/erica-windisch.md
@@ -7,4 +7,4 @@ linktitle = "erica-windisch"
 
 +++
 
-Erica is CTO SPEAKERBIO Founder at IOpipe where she is building developer tools for serverless applications. She is a former maintainer of Docker and OpenStack and has been building cloud, ops, and infrastructure tooling for over 15 years.
+Erica is CTO/Founder at IOpipe where she is building developer tools for serverless applications. She is a former maintainer of Docker and OpenStack and has been building cloud, ops, and infrastructure tooling for over 15 years.


### PR DESCRIPTION
Erica Windisch's bio contained 

```
CTO SPEAKERBIO Founder
```

Which looks like copypasta or similar.  I'm replacing it with a slash.