### PR TITLE
Upgrade builds to hugo 0.30.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ If you'd like to edit a specific devopsdays event site (and/or contribute code),
 
 ### Quick Overview
 
-1. Install [Hugo v0.22+](http://gohugo.io).
+1. Install [Hugo v0.30.2+](http://gohugo.io).
 1. Fork this repo.
 
 ### View site locally

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,10 +15,10 @@
   publish = "public/"
   command = "bin/netlify.sh"
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.23"
+  HUGO_VERSION = "0.30.2"
   
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.23"
+  HUGO_VERSION = "0.30.2"
 
 [context.test]
  command = "bin/netlify-production.sh"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
  publish = "dist/"
  
 [context.production.environment]
-   HUGO_VERSION = "0.23"
+   HUGO_VERSION = "0.30.2"
 
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.


### PR DESCRIPTION
This updates the version of hugo being used in preview builds to 0.30.2.

If this passes, we will update it for the production configuration.