### PR TITLE
[ZRH-2018] Change organizer profile list to link to contact page

### DIFF
--- a/content/events/2018-zurich/conduct.md
+++ b/content/events/2018-zurich/conduct.md
@@ -23,7 +23,7 @@ report violations:
 
 We will wear special crew shirts and we try to be always around, please reach us out even if we look busy.
 
-{{< list_organizers >}}
+<a href="https://www.devopsdays.org/events/2018-zurich/contact/">See the organizer profile pictures</a>
 
 ## Addressing Grievances
 


### PR DESCRIPTION
Updated the code of conduct to link to the contact page to see organizer profile pictures
