### PR TITLE
[NYC 2018] Single venue sponsor

### DIFF
--- a/data/events/2018-new-york-city.yml
+++ b/data/events/2018-new-york-city.yml
@@ -105,6 +105,7 @@ sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: venue
     label: Venue
+    max: 1
   - id: gold
     label: Gold
 #    max: 10


### PR DESCRIPTION
Hi, @coffinnailvgd - I noticed that in https://github.com/devopsdays/devopsdays-web/pull/3595 you aren't limiting the number of venue sponsors. It's possible that's intentional, but I think it's more likely that you didn't realize you can remove the possibly misleading "become a venue sponsor":

<img width="527" alt="screen shot 2017-11-11 at 8 25 37 am" src="https://user-images.githubusercontent.com/2104453/32690305-486ce870-c6ba-11e7-8776-b7527c066f89.png">

If merged, this is the effect:

<img width="525" alt="screen shot 2017-11-11 at 8 25 24 am" src="https://user-images.githubusercontent.com/2104453/32690306-522945b6-c6ba-11e7-8a9c-f96828c63e10.png">

I'll mark this "do not merge" until we hear from you regarding your wishes - thanks!