### PR TITLE
[GAL-2017] Use slideshare/speakerdeck widgets

### DIFF
--- a/content/events/2017-galway/program/alan-duggan.md
+++ b/content/events/2017-galway/program/alan-duggan.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Culture Shift - The journey to the promised land is never complete"
 Type = "talk"
 Speakers = ["alan-duggan"]
-Slides = "https://www.slideshare.net/secret/vqIkjve8UbE4Ja"
+Slideshare = "https://www.slideshare.net/secret/vqIkjve8UbE4Ja"
 +++
 
 <p>Adopting tools and processes is a simple task, just choose from the menu and buy the book. Getting this into the minds of every team and every member of an enterprise scale organisation is another matter.

--- a/content/events/2017-galway/program/antoine-voiry.md
+++ b/content/events/2017-galway/program/antoine-voiry.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "I cannot do DEVOPS because ..."
 Type = "talk"
 Speakers = ["antoine-voiry"]
-Slides = "https://www.slideshare.net/AntoineVoiry/dxc-antoine-voiry-ignite-i-cannot-do-devops/AntoineVoiry/dxc-antoine-voiry-ignite-i-cannot-do-devops"
+Slideshare = "https://www.slideshare.net/AntoineVoiry/dxc-antoine-voiry-ignite-i-cannot-do-devops/AntoineVoiry/dxc-antoine-voiry-ignite-i-cannot-do-devops"
 +++
 
 <p>In the past 3 years, my team assisted many teams in their DEVOPS transformation internally and externally.</p>

--- a/content/events/2017-galway/program/eoin-connaughton.md
+++ b/content/events/2017-galway/program/eoin-connaughton.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Operations driven Continuous Delivery Pipeline"
 Type = "talk"
 Speakers = ["eoin-connaughton"]
-Slides = "https://www.slideshare.net/secret/pg0etQu7E9tbqp"
+Slideshare = "https://www.slideshare.net/secret/pg0etQu7E9tbqp"
 +++
 
 <p>One of my first memories from my DevOps journey, was hearing the statement ""DevOps is primarily a mind-set"". Coming from an Operations focused background, at the time I didn't fully understand the significance of this statement. </p>

--- a/content/events/2017-galway/program/garima-sharma.md
+++ b/content/events/2017-galway/program/garima-sharma.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Deploy: Train, Driver and Tracks"
 Type = "talk"
 Speakers = ["garima-sharma"]
-Slides = "https://speakerdeck.com/gasharma/deploy-train-driver-and-tracks"
+Speakerdeck = "https://speakerdeck.com/gasharma/deploy-train-driver-and-tracks"
 +++
 
 <p>Platform as a Service (PaaS) allows customers to develop, run, and manage applications without the complexity of building and maintaining the infrastructure typically associated with developing and launching an app. Operating a service which holds these complexities in itself can become challenging.  We need to answer a lot of questions beforehand like, how we decide when to deploy what? How and what to monitor for these huge and complex components? When shall we get paged? Why not  staging environments? and many more.</p>

--- a/content/events/2017-galway/program/mark-walsh.md
+++ b/content/events/2017-galway/program/mark-walsh.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Zero to DevOps: The beginning of a journey"
 Type = "talk"
 Speakers = ["mark-walsh"]
-Slides = "https://www.slideshare.net/MarkWalsh59/markwalshzerotodevopsdistributed"
+Slideshare = "https://www.slideshare.net/MarkWalsh59/markwalshzerotodevopsdistributed"
 +++
 
 <p>An introduction to MetLife's current technical landscape and the roadmap for the Global Technology Campus in Galway to adopt DevOps principles and practices from Continuous Integration to Continuous Delivery and Containerization to Orchestration.</p>

--- a/content/events/2017-galway/program/owen-byrne.md
+++ b/content/events/2017-galway/program/owen-byrne.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Vulnerability Testing in the Cloud by dint of DevSecOps"
 Type = "talk"
 Speakers = ["owen-byrne"]
-Slides = "https://www.slideshare.net/OwenByrne1/vulnerability-testing-in-the-cloud-by-dint-of-devsecops-82504056"
+Slideshare = "https://www.slideshare.net/OwenByrne1/vulnerability-testing-in-the-cloud-by-dint-of-devsecops-82504056"
 +++
 
 <p>Developers want speed. Customers want features. Security teams want time.</p>

--- a/content/events/2017-galway/program/paul-oconnor.md
+++ b/content/events/2017-galway/program/paul-oconnor.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "On Call Engineer Happiness"
 Type = "talk"
 Speakers = ["paul-oconnor"]
-Slides = "https://www.slideshare.net/PaulOConnor21/on-call-engineer-happiness-devops-days-galway-2017/PaulOConnor21/on-call-engineer-happiness-devops-days-galway-2017"
+Slideshare = "https://www.slideshare.net/PaulOConnor21/on-call-engineer-happiness-devops-days-galway-2017/PaulOConnor21/on-call-engineer-happiness-devops-days-galway-2017"
 +++
 
 <p>On call is an unfortunate side effect of the technology industry. Outages happen outside business hours, frequently when engineers are sleeping. Using existing tools, and reexamining alerting healthchecks, it is possible to make on call a much happier experience.</p>

--- a/content/events/2017-galway/program/tony-chapman.md
+++ b/content/events/2017-galway/program/tony-chapman.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "The elephant in the room. How to attract and retain great DevOps talent."
 Type = "talk"
 Speakers = ["tony-chapman"]
-Slides = "https://www.slideshare.net/TonyChapman9/devops-days-galway-talk"
+Slideshare = "https://www.slideshare.net/TonyChapman9/devops-days-galway-talk"
 +++
 
 <p>People, Process, Technology, 3 of the key things to consider if you’re looking to implement DevOps principles.<p>


### PR DESCRIPTION
Update ignites to make use of the slideshare/speakerdeck widgets for
including the slides directly into the talk pages instead of just links.

