### PR TITLE
[GAL-2017] Replace use of secret urls for slideshare

### DIFF
--- a/content/events/2017-galway/program/alan-duggan.md
+++ b/content/events/2017-galway/program/alan-duggan.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Culture Shift - The journey to the promised land is never complete"
 Type = "talk"
 Speakers = ["alan-duggan"]
-Slideshare = "https://www.slideshare.net/secret/vqIkjve8UbE4Ja"
+Slideshare = "https://www.slideshare.net/AlanDuggan8/alan-duggan-culture-shift/"
 +++
 
 <p>Adopting tools and processes is a simple task, just choose from the menu and buy the book. Getting this into the minds of every team and every member of an enterprise scale organisation is another matter.

--- a/content/events/2017-galway/program/eoin-connaughton.md
+++ b/content/events/2017-galway/program/eoin-connaughton.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Operations driven Continuous Delivery Pipeline"
 Type = "talk"
 Speakers = ["eoin-connaughton"]
-Slideshare = "https://www.slideshare.net/secret/pg0etQu7E9tbqp"
+Slides = "https://www.slideshare.net/secret/pg0etQu7E9tbqp"
 +++
 
 <p>One of my first memories from my DevOps journey, was hearing the statement ""DevOps is primarily a mind-set"". Coming from an Operations focused background, at the time I didn't fully understand the significance of this statement. </p>


### PR DESCRIPTION
Where a public version is available, replace the secret url shared by
the speaker with the correct public url to allow embedded to work.

Revert back to the simple link where the author forgot to make the
slides public.
