### PR TITLE
[Philly 2017] Adding video links to Philly 2017

### DIFF
--- a/content/events/2017-philadelphia/program/andre-d-henry.md
+++ b/content/events/2017-philadelphia/program/andre-d-henry.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Why Why Why"
 Type = "talk"
 Speakers = ["andre-d-henry"]
+youtube = "oEcd3kQDPjk"
 +++
 
 We do a lot of things in the name of progress. We have Agile, Scrum and as they are applied to Systems Administration we now have DevOps. But why do we do it all, why have we invented and described all new methodologies and processes? Is it to find a perfect budgeting method? Is to to find a perfect plan? Is it to make an on time schedule? Is it to have defect free systems? Those could all be potential side effects, but not the ultimate goal of why we do it all. We don't have time for the five whys, but lets shorten the process and see if we can get to the root of it all.

--- a/content/events/2017-philadelphia/program/andreas-grabner.md
+++ b/content/events/2017-philadelphia/program/andreas-grabner.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "From 6 Month Waterfall To 1h Code Deploys"
 Type = "talk"
 Speakers = ["andreas-grabner"]
+youtube = "2zm6x4htPqg"
 +++
 
 In 2011 we delivered 2 major releases of our on premise enterprise software. Market, technology and customer requirements forced us to change that in order to remain competitive.

--- a/content/events/2017-philadelphia/program/brian-cole.md
+++ b/content/events/2017-philadelphia/program/brian-cole.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Reproducible Genome-wide Analysis with Cloud Computing"
 Type = "talk"
 Speakers = ["brian-cole"]
+youtube = "UwXMHYBYV1c"
 +++
 
 Genome-wide association studies (GWAS) have revealed associations between human genetic variants and hundreds of human traits, including disease susceptibility.  We found that differences in quality control (QC) upstream of GWAS critically affect the results.  Despite this, no clear mechanism for reproducibility of GWAS QC pipelines exists to our knowledge.  We developed CLINK, a cloud-based interactive GWAS QC tool focused on reproducibility.  We use Amazon Web Services (AWS) machine images, adopting a dev/ops model to develop a version-controlled virtual appliance geared around the Jupyter Notebook.  We demonstrate the reproducibility of CLINK using a large case/control study of primary open-angle glaucoma, a leading cause of irreversible blindness.

--- a/content/events/2017-philadelphia/program/bridget-kromhout.md
+++ b/content/events/2017-philadelphia/program/bridget-kromhout.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Choose Your Own Adventure"
 Type = "talk"
 Speakers = ["bridget-kromhout"]
+youtube = "Y-KCBVo71zA"
 +++
 
 Which cloud do we want: public, private, hybrid? How are we going to orchestrate containers? How many pizzas should our teams eat? Should everyone be on call, even front-end? Maybe we should only hire full-stack ninjas? Do we even want to dev some ops, or do we need site reliability instead? Technical decision-making is a sea of bad and worse choices waiting to happen; let's talk about it.

--- a/content/events/2017-philadelphia/program/daniel-olson.md
+++ b/content/events/2017-philadelphia/program/daniel-olson.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "WordPress Goes Serverless"
 Type = "talk"
 Speakers = ["daniel-olson"]
+youtube = "04dDdvLkDEE"
 +++
 
 What can WordPress gain from Serverless Architecture?

--- a/content/events/2017-philadelphia/program/darwin-sanoy.md
+++ b/content/events/2017-philadelphia/program/darwin-sanoy.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "OpenSource PowerShell - How Could It Possibly Matter?"
 Type = "talk"
 Speakers = ["darwin-sanoy"]
+youtube = "nUxEtxDK90k"
 +++
 
 In DevOps it is common to have Ruby, Python and Bash on all Windows machines - will you install PowerShell on your Mac workstation and Linux servers?

--- a/content/events/2017-philadelphia/program/david-grizzanti.md
+++ b/content/events/2017-philadelphia/program/david-grizzanti.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "From VMs to containers: A DevOps journey"
 Type = "talk"
 Speakers = ["david-grizzanti"]
+youtube = "hClNFwRBsHM"
 +++
 
 Are the benefits of containerization limited to ease of integration, testing, deployment and operations? David Grizzanti explains how his team at Comcast -- which develops a highly performant, distributed software system supporting millions of customers and deployed across multiple data centers -- moved large-scale, multi-data-center services from an architecture deployed on virtual machines supported by separate development and operations teams to one based on containers with Apache Mesos operated by a single DevOps team, sharing how Comcast overcame multiple challenges -- some that were anticipated and many that were not.

--- a/content/events/2017-philadelphia/program/erica-windisch.md
+++ b/content/events/2017-philadelphia/program/erica-windisch.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Embracing Serverless Ops"
 Type = "talk"
 Speakers = ["erica-windisch"]
+youtube = "oalZgSV-UhQ"
 +++
 
 We will explore the value of bringing Serverless development to your operations and developer teams, and how it fits with DevOps culture. This talk will offer an introduction to Serverless applications, practical options for replacing infrastructure with Serverless, and will explore developer culture.

--- a/content/events/2017-philadelphia/program/jason-m-salberblack.md
+++ b/content/events/2017-philadelphia/program/jason-m-salberblack.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Provisioning is Magic - A Declarative Approach to AWS Infrastructure"
 Type = "talk"
 Speakers = ["jason-m-salberblack"]
+youtube = "4JB1A6Pn4dY"
 +++
 
 Choosing appropriate tooling for the provisioning of virtual infrastructure such as servers, storage, and networking components is a challenge due to the variety of available tools. These tools range from provider-native services such as AWS CloudFormation to multi-provider technologies such as Hashicorp's Terraform. Between the native and non-native solutions is a family of light-weight tools that operate directly on provider-native template files. I will briefly review the trade-offs between the different types of tooling, discuss why we chose the CloudFormation template-generating library SparkleFormation to meet our specific goals, and conclude with a tour of our SparkleFormation implementation.

--- a/content/events/2017-philadelphia/program/kim-crayton.md
+++ b/content/events/2017-philadelphia/program/kim-crayton.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Overcoming the Challenges of Mentoring"
 Type = "talk"
 Speakers = ["kim-crayton"]
+youtube = "q6RGkgFNhqs"
 +++
 
 Successful mentoring doesn't just happen, it's planned. We will discuss what mentoring is not, what mentoring is, factors for effective mentorship, and why it's important to the developer community.

--- a/content/events/2017-philadelphia/program/logan-daigle.md
+++ b/content/events/2017-philadelphia/program/logan-daigle.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Branching Strategies Ultimately Determine Product Complexity"
 Type = "talk"
 Speakers = ["logan-daigle"]
+youtube = "5KmyTE-UlgE"
 +++
 
 The ideal DevOps project starts with everything stored in source control. As a coach I often find that too little thought is given to how a team will handle their source control branching strategy. Time and time again I have seen how this lone decision determines much of the complexity of both product and process. The ease of your journey to continuous delivery is largely dependent on this decision. I'd like to discuss this idea and talk about teams seeing success when they take time to make this decision and don't just buy into master-only development or a model such as git flow. Instead, they think about how they want to manage complexity, and it starts with source control and branching strategy.

--- a/content/events/2017-philadelphia/program/michael-winslow.md
+++ b/content/events/2017-philadelphia/program/michael-winslow.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Release Notes Automation"
 Type = "talk"
 Speakers = ["michael-winslow"]
+youtube = "L6JmegkMov4"
 +++
 
 As a team practicing DevOps for Xfinity Mobile, we are always looking for opportunities to increase the velocity in which we move software through the deployment pipeline. This becomes increasingly important as we begin to discover production issues which are impacting our customers and require immediate attention.

--- a/content/events/2017-philadelphia/program/nicole-forsgren.md
+++ b/content/events/2017-philadelphia/program/nicole-forsgren.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Are we there yet? Signposts on your journey to awesome"
 Type = "talk"
 Speakers = ["nicole-forsgren"]
+youtube = "IdZaFzuOPUQ"
 +++
 
 When embarking on a journey of transformation, you want to measure your current status and subsequent progress while keeping tabs on factors that drive improvement in technology performance. Nicole Forsgren explains the importance of knowing how (and what) to measure—ensuring you catch successes and failures when they first show up, not just when they’re epic.

--- a/content/events/2017-philadelphia/program/sam-jones.md
+++ b/content/events/2017-philadelphia/program/sam-jones.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "A Better Technical Interview"
 Type = "talk"
 Speakers = ["sam-jones"]
+youtube = "t06BfYL-LAw"
 +++
 
 Let's make a valuable interview by setting better expectations and creating better evaluation techniques.

--- a/content/events/2017-philadelphia/program/sonia-sarda.md
+++ b/content/events/2017-philadelphia/program/sonia-sarda.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "The case for longer hackathons"
 Type = "talk"
 Speakers = ["sonia-sarda"]
+youtube = "wmvkSk834Oo"
 +++
 
 How hackathons should be built around helping the community- so longer hackathons judged based on the number of lives they positively impact and not just how cool they are

--- a/content/events/2017-philadelphia/program/stephanie-herr.md
+++ b/content/events/2017-philadelphia/program/stephanie-herr.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Help!  My database is the bottleneck"
 Type = "talk"
 Speakers = ["stephanie-herr"]
+youtube = "amQBSebnTSw"
 +++
 
 Data is an integral part of every application, so why aren’t we talking about it more when it comes to DevOps and including the DBAs in this important conversation. In this session, we'll talk about why the database has been left behind and the special challenges it presents.  We'll also explore the similarities to application development and show that even though there are challenges, it is possible to include your database in DevOps processes. It’s time to start thinking about incorporating your databases into your best practices so it's no longer the bottleneck.

--- a/content/events/2017-philadelphia/program/steve-desmond.md
+++ b/content/events/2017-philadelphia/program/steve-desmond.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Adventures in Enterprise: Lessons Learned Promoting DevOps in a Legacy Organization"
 Type = "talk"
 Speakers = ["steve-desmond"]
+youtube = "Zos0xDAbne4"
 +++
 
 After many years doing DevOps-y things before learning the term "DevOps", I moved to a larger, more traditional IT organization, with a goal of helping modernize their outdated technologies and practices. The next several years brought many challenges -- technical, political, and interpersonal -- some of which were more easily overcome, and some of which, well, not so much.

--- a/content/events/2017-philadelphia/program/tim-gross.md
+++ b/content/events/2017-philadelphia/program/tim-gross.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Like Software, Buildings are Made of People"
 Type = "talk"
 Speakers = ["tim-gross"]
+youtube = "Db4jOAF0MfU"
 +++
 
 Software architecture. Software engineering. Software construction. Practitioners of the architecture, engineering, and construction of buildings might consider these terms to be overly lofty for the craft of software development. One of these industries is plagued by cost overruns, failed projects, religious battles over methodologies, dysfunctional teams, and unhappy clients, but is also innovative, socially conscious, and applying technology to solve real-world problems. And the other is software development.

--- a/content/events/2017-philadelphia/program/tony-burns.md
+++ b/content/events/2017-philadelphia/program/tony-burns.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Continuous Delivery on ECS"
 Type = "talk"
 Speakers = ["tony-burns"]
+youtube = "yZ9_A7KlZqM"
 +++
 
 Amazon Elastic Container Service is an orchestration service for Docker containers in clusters of EC2 instances. We’ll dive into the details of how Capital One deployed its first ECS cluster, with full 


### PR DESCRIPTION
In looking at my talks from 2017, I noticed that Philly has videos posted but not linked on the website. Adding - approval needed from @peterjshan to merge.

(Side note, @peterjshan - the title/description for https://www.devopsdays.org/events/2017-philadelphia/program/michael-winslow/ is wrong on youtube.)