### PR TITLE
[NYC-2018] add a local tagline to speaker bio

### DIFF
--- a/content/events/2018-new-york-city/speakers/mike-fiedler.md
+++ b/content/events/2018-new-york-city/speakers/mike-fiedler.md
@@ -14,3 +14,5 @@ grown. He’s also taught a few people some things here and there. Currently
 Director of Engineering at Paribus, a Capital One flagship product. Alum of
 Datadog, Magnetic, MongoDB, to name a few. He’s been a roller derby referee for
 almost 10 years.
+
+A New York local, talk to him about where to get some of the best pastries in the city.


### PR DESCRIPTION
The organizer recommends that if speakers are local, to have a callout in their bio.
