### PR TITLE
[VAN-2018] Add links for registration and CFP

### DIFF
--- a/content/events/2018-vancouver/index.md
+++ b/content/events/2018-vancouver/index.md
@@ -28,23 +28,32 @@ aliases = ["/events/2018-vancouver/welcome"]
   </div>
 </div>
 
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Register</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="registration" text="Register to attend the conference!" >}}
-  </div>
-</div>
-
 <div class = "row">
   <div class = "col-md-2">
     <strong>Propose</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_link page="propose" text="Propose a talk!" >}}
+    <a href = "https://www.papercall.io/devopsdays-vancouver-2018">Propose a talk!</a>
   </div>
-</div> -->
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Register</strong>
+  </div>
+  <div class = "col-md-8">
+    <a href = "https://www.eventbrite.ca/e/devops-days-vancouver-2018-apr-20th-21st-tickets-41596196343?aff=es2">Register to attend the conference!</a>
+  </div>
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Sponsors</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="sponsor" text="Sponsor devopsdays Vancouver!" >}}
+  </div>
+</div>
 
 <!-- <div class = "row">
   <div class = "col-md-2">
@@ -63,15 +72,6 @@ aliases = ["/events/2018-vancouver/welcome"]
     Check out the {{< event_link page="speakers" text="speakers!" >}}
   </div>
 </div> -->
-
-<div class = "row">
-  <div class = "col-md-2">
-    <strong>Sponsors</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="sponsor" text="Sponsor devopsdays Vancouver!" >}}
-  </div>
-</div>
 
 <div class = "row">
   <div class = "col-md-2">

--- a/data/events/2018-vancouver.yml
+++ b/data/events/2018-vancouver.yml
@@ -9,27 +9,24 @@ description: "devopsdays is an inclusive, self-organizing conference for anyone 
 startdate:  2018-04-20 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  2018-04-21 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-02-26 # start accepting talk proposals.
+cfp_date_start: 2018-01-03 # start accepting talk proposals.
 cfp_date_end:  2018-02-26 # close your call for proposals.
 cfp_date_announce: 2018-03-05 # inform proposers of status
-registration_open: "false"
-registration_link: https://www.eventbrite.ca/e/devops-days-vancouver-2018-apr-20th-21st-tickets-41596196343?aff=es2
+cfp_link: "https://www.papercall.io/devopsdays-vancouver-2018"
+registration_open: "true"
+registration_link: "https://www.eventbrite.ca/e/devops-days-vancouver-2018-apr-20th-21st-tickets-41596196343?aff=es2"
 
 # Location
-#
 coordinates: "49.282732, -123.121096" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "UBC Robson Square" # Defaults to city, but you can make it the venue name.
-#
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
     # - name: program
-    # - name: propose
-    #   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
-    # - name: location
     # - name: livestream
-    # - name: registration
-    #   url: "https://www.eventbrite.ca/e/devops-days-vancouver-2018-mar-31st-apr-1st-tickets-29634403298"
+    - name: propose
     - name: sponsor
+    - name: registration
+    - name: location
     - name: contact
     - name: conduct
     - name: policies


### PR DESCRIPTION
I also opened devopsdays/devopsdays-theme#617, so that I can use `cfp_link` and `registration_link` from my YAML file in my event instead of duplicating the strings. I will open another PR to make use of that, when and if I can get it merged!