### PR TITLE
Make appveyor stuck to hugo 0.31.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 install:
 #  Install Hugo from chocolatey and display the version number
 - cmd: >-
-    choco install hugo -y
+    choco install hugo -y --version 0.31.1
 
     hugo version
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,29 +1,18 @@
 # Production context: All deploys to the main
 # repository branch will inherit these settings.
 [context.production]
- #command = "bin/netlify.sh"
- #publish = "public/"
  command = "bin/netlify-production.sh"
  publish = "dist/"
  
-[context.production.environment]
-   HUGO_VERSION = "0.30.2"
-
-# Deploy Preview context: All Deploy Previews
-# will inherit these settings.
-[context.deploy-preview]
-  publish = "public/"
+ [context.deploy-preview]
   command = "bin/netlify.sh"
+  publish = "public/"
+ 
+[context.production.environment]
+   HUGO_VERSION = "0.31.1"
+   
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.30.2"
+  HUGO_VERSION = "0.31.1"
   
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.30.2"
-
-[context.test]
- command = "bin/netlify-production.sh"
- publish = "dist/"
-
-[context.updates-for-new-theme]
-  command = "bin/netlify-production.sh"
-  publish = "dist/"
+  HUGO_VERSION = "0.31.1"


### PR DESCRIPTION
This, in theory, will keep appveyor using the last known compatible version of hugo.