### PR TITLE
[New York City 2018] Turning on speakers_verbose

### DIFF
--- a/data/events/2018-new-york-city.yml
+++ b/data/events/2018-new-york-city.yml
@@ -5,6 +5,7 @@ event_twitter: "devopsdaysNYC" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to New York City!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: "New York City"
+speakers_verbose: "true"
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate:  "2018-01-18" # The start date of your event. Leave blank if you don't have a venue reserved yet.


### PR DESCRIPTION
For @TomOnTime to review after it builds - turning on the new "verbose speaker info" flag for New York City 2018.