### PR TITLE
Text changes to clarify open spaces vs curated content.

### DIFF
--- a/content/page/about.md
+++ b/content/page/about.md
@@ -8,11 +8,13 @@ aliases = ["/contact/"]
 
 +++
 
-Devopsdays is a worldwide series of technical conferences covering topics of software development, IT infrastructure operations, and the intersection between them. Topics often include automation, testing, security, and organizational culture.
+Devopsdays is a worldwide series of technical conferences covering topics of software development, IT infrastructure operations, and the intersection between them. Each event is run by volunteers from the local area. 
+
+Most devopsdays events feature a combination of curated talks (see open [Calls for Proposals](/speaking/)) and self organized [open space](/open-space-format/) content. Topics often include automation, testing, security, and organizational culture.
 
 ### History
 
-The first devopsdays was held in Ghent, Belgium in 2009. Since then, devopsdays events have multiplied, and if there isn't one in your city, contact us about organizing one yourself!
+The first devopsdays was held in Ghent, Belgium in 2009. Since then, devopsdays events have multiplied, and if there isn't one in your city, [check out the information](/organizing/) for organizing one yourself!
 
 
 ### About the organization

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -14,7 +14,7 @@ Most devopsdays events feature a combination of curated talks (see open [Calls f
 
 ### History
 
-The first devopsdays was held in Ghent, Belgium in 2009. Since then, devopsdays events have multiplied, and if there isn't one in your city, [check out the information](/organizing/) for organizing one yourself!
+The first devopsdays was held in Ghent, Belgium in 2009. Since then, devopsdays events have multiplied, and if there isn't one in your city, [check out the information](/organizing/) about organizing one yourself!
 
 
 ### About the organization

--- a/content/page/open-space-format.md
+++ b/content/page/open-space-format.md
@@ -6,8 +6,9 @@ date = "2016-04-14T11:28:51-05:00"
 title = "Devopsdays - openspace concept"
 aliases = ["/pages/open-space-format/"]
 
-
 +++
+
+Most devopsdays events are a combination of curated talks and self organized conversations. The self organized content is known as "open spaces". Open Spaces give attendees the opportunity to talk about anything they'd like. A person might suggest a topic they want to learn about, or one they feel like they can help others with. The topics range widely, from highly technical, to pure culture, to board games for networking.
 
 <div><em>Open space is the simplest meeting format that could possibly work.</em>
 <em> </em></div>


### PR DESCRIPTION
Attempting to clarify open spaces vs curated talks. The current open-space-format page doesn't set any context. 