### PR TITLE
[ATX-2018] Update twitter handle for NS1

### DIFF
--- a/data/sponsors/ns1.yml
+++ b/data/sponsors/ns1.yml
@@ -1,3 +1,3 @@
 name: "ns1"
 url: "https://ns1.com"
-twitter: "nsoneinc"
+twitter: "NS1"


### PR DESCRIPTION
NS1 has moved twitter account from @nsoneinc to @NS1. See
https://twitter.com/nsoneinc/status/958356082627313664.