### PR TITLE
[PDX-2018] Open the CFP, add sponsor info, adjust team membership

### DIFF
--- a/content/events/2018-portland/conduct.md
+++ b/content/events/2018-portland/conduct.md
@@ -1,7 +1,7 @@
 +++
 Title = "Conduct"
 Type = "event"
-Description = "Code of conduct for devopsdays Portland 2018"
+Description = "Code of conduct for DevOpsDays Portland 2018"
 +++
 
 ## ANTI-HARASSMENT POLICY

--- a/content/events/2018-portland/contact.md
+++ b/content/events/2018-portland/contact.md
@@ -1,7 +1,7 @@
 +++
 Title = "Contact"
 Type = "event"
-Description = "Contact information for devopsdays Portland 2018"
+Description = "Contact information for DevOpsDays Portland 2018"
 +++
 
 If you'd like to contact us by email: {{< email_organizers >}}
@@ -9,6 +9,13 @@ If you'd like to contact us by email: {{< email_organizers >}}
 **Our local team**
 
 {{< list_organizers >}}
+
+**Organizers emeritus**
+
+* <a href="https://twitter.com/nibalizer">Spencer Krum</a>
+* <a href="https://twitter.com/alicegoldfuss">Alice Goldfuss</a>
+* <a href="https://twitter.com/gitbisect">Jason Yee</a>
+* <a href="https://twitter.com/daniel_dreier">Daniel Dreier</a>
 
 **The core devopsdays organizer group**
 

--- a/content/events/2018-portland/location.md
+++ b/content/events/2018-portland/location.md
@@ -1,7 +1,7 @@
 +++
 Title = "Location"
 Type = "event"
-Description = "Location for devopsdays Portland 2018"
+Description = "Location for DevOpsDays Portland 2018"
 +++
 
 Watch this space for information about the venue including address, map/direction, parking/transit, and any hotel details.

--- a/content/events/2018-portland/propose.md
+++ b/content/events/2018-portland/propose.md
@@ -1,7 +1,7 @@
 +++
 Title = "Propose"
 Type = "event"
-Description = "Propose a talk for devopsdays Portland 2018"
+Description = "Propose a talk for DevOpsDays Portland 2018"
 +++
   {{< cfp_dates >}}
 
@@ -24,12 +24,3 @@ Choosing talks is part art, part science; here are some factors we consider when
 - _original content_: We will consider talks that have already been presented elsewhere, but we prefer talks that the local area isn't likely to have already seen.
 - _no third-party submissions_: This is a small community-driven event, and speakers need to be directly engaged with the organizers and attendees. If a PR firm or your marketing department is proposing the talk, you've already shown that as a speaker you're distant from the process.
 - _no vendor pitches_: As much as we value vendors and sponsors, we are not going to accept a talk that appears to be a pitch for your product.
-
-<hr>
-
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>

--- a/content/events/2018-portland/registration.md
+++ b/content/events/2018-portland/registration.md
@@ -1,7 +1,7 @@
 +++
 Title = "Registration"
 Type = "event"
-Description = "Registration for devopsdays Portland 2018"
+Description = "Registration for DevOpsDays Portland 2018"
 +++
 
 <div style="width:100%; text-align:left;">

--- a/content/events/2018-portland/sponsor.md
+++ b/content/events/2018-portland/sponsor.md
@@ -1,66 +1,13 @@
 +++
 Title = "Sponsor"
 Type = "event"
-Description = "Sponsor devopsdays Portland 2018"
+Description = "Sponsor DevOpsDays Portland 2018"
 +++
-
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
-
 <hr>
+We greatly value sponsors for this open event! We could, quite literally, not do this without you.
 
-devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
-<p>
-Sponsorship levels are still being worked out. If you're interested, contact us!
-<p>
-The best thing to do is send engineers to interact with the experts at devopsdays on their own terms.
-<p>
+Please review our <a target="_blank" href="https://docs.google.com/document/d/1LM6WZlvGiPNWhP2tApZHPW7vBEEHDeq4TJWIaCPOhaY">Sponsor Prospectus</a> for an overview of sponsorship tiers and notes.
 
-<!--
-<hr/>
+If you are interested in sponsoring or have any questions, please drop us an email at {{< email_organizers >}}
 
-<div style="width:590px">
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>packages</i></th>
-    <th><center><b><u>Bronze<br />1000 usd</u></center></b></th>
-    <th><center><b><u>Silver<br />3000 usd</u></center></b></th>
-    <th><center><b><u>Gold<br />5000 usd</u></center></b></th>
-    <th></th>
-  </tr>
-<tr><td>2 included tickets</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on event website</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on shared slide, rotating during breaks</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on all email communication</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on its own slide, rotating during breaks</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>1 minute pitch to full audience (including streaming audience)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr></tr>
-<tr><td>2 additional tickets (4 in total)</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>4 additional tickets (6 in total)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>shared table for swag</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>booth/table space</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-</table>
-<hr/>
-There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
-<br/>
-<br/>
-
-<br>
-<br>
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>Sponsor FAQ</i></th>
-    <th><center><b>Answers to questions frequently asked by sponsors&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</center></b></th>
-    <th></th>
-  </tr>
-<tr><td>What dates/times can we set up and tear down?</td><td></td></tr>
-<tr><td>How do we ship to the venue?</td><td></td></tr>
-<tr><td>How do we ship from the venue?</td><td></td></tr>
-<tr><td>Whom should we send?</td><td></td></tr>
-<tr><td>What should we expect regarding electricity? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>What should we expect regarding WiFi? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>How do we order additional A/V equipment?</td><td></td></tr>
-<tr><td>Additional important details</td><td></td></tr>
-</table>
-</div>
-
--->
-<hr/>
+We'll also have space and time available for local non-profit community groups -- if that's you, please talk to us!

--- a/content/events/2018-portland/welcome.md
+++ b/content/events/2018-portland/welcome.md
@@ -1,8 +1,8 @@
 +++
-Title = "devopsdays Portland 2018"
+Title = "DevOpsDays Portland 2018"
 Type = "welcome"
 aliases = ["/events/2018-portland"]
-Description = "devopsdays Portland 2018"
+Description = "DevOpsDays Portland 2018"
 +++
 
 <!-- <div style="text-align:center;">
@@ -82,6 +82,5 @@ Description = "devopsdays Portland 2018"
 </div>
 
 <!-- Uncomment if you added your city twitter name -->
-<!--
+
 {{< event_twitter >}}
--->

--- a/data/events/2018-portland.yml
+++ b/data/events/2018-portland.yml
@@ -2,20 +2,20 @@ name: "2018-portland" # The name of the event. Four digit year with the city nam
 year: "2018" # The year of the event. Make sure it is in quotes.
 city: "Portland" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdayspdx" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
-description: "Devopsdays is coming to Portland!" # Edit this to suit your preferences
+description: "DevOpsDays is coming to Portland!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: '2018-09-11' # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: '2018-09-12' # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-09-11 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-09-13 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:  # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_start: 2018-02-15 # start accepting talk proposals.
+cfp_date_end: 2018-04-14 # close your call for proposals.
+cfp_date_announce: 2018-05-14 # inform proposers of status
 
-cfp_open: "false"
-cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_open: "true"
+cfp_link: "https://devopsdayspdx2018.busyconf.com/proposals/new" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet
 registration_date_end: # close registration. Leave blank if registration is not open yet.
@@ -31,7 +31,7 @@ location: "Oregon Convention Center" # Defaults to city, but you can make it the
 location_address: "777 NE Martin Luther King Jr Blvd, Portland, OR 97232" #Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- # - name: propose
+  - name: propose
  # - name: location
  # - name: registration
  # - name: program
@@ -48,17 +48,8 @@ nav_elements: # List of pages you want to show up in the navigation of your page
 team_members: # Name is the only required field for team members.
   - name: "Bill Weiss"
     twitter: "billweiss"
-  - name: "Alice Goldfuss"
-    twitter: "alicegoldfuss"
-    employer: "Github"
   - name: "Alastair Drong"
     twitter: "dev_dull"
-  - name: "Daniel Dreier"
-    twitter: "daniel_dreier"
-    employer: "Puppet"
-  - name: "Jason Yee"
-    twitter: "gitbisect"
-    employer: "Datadog"
   - name: "Joe Nuspl"
     twitter: "joenuspl"
     employer: "Workday"
@@ -77,18 +68,22 @@ team_members: # Name is the only required field for team members.
   - name: "Megan Guiney"
     employer: "OpenStack Foundation"
     twitter: "meganguiney"
-  - name: "Ted Waggoner"
-    employer: "Columbia Sportswear"
   - name: "Tiffany Longworth"
     employer: "Puppet"
+  - name: "Will Ellett"
+    employer: "Cozy"
 
 
 organizer_email: "organizers-portland-2018@devopsdays.org" # Put your organizer email address here
-proposal_email: "proposals-portland-2018@devopsdays.org" # Put your proposal email address here
+proposal_email: "" # Put your proposal email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
+  - id: columbia
+    level: gold
+  - id: scalyr
+    level: gold
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 
@@ -105,5 +100,7 @@ sponsor_levels:
     label: Silver
   - id: bronze
     label: Bronze
+  - id: specialty
+    label: Specialty
   - id: community
     label: Community


### PR DESCRIPTION
- Opens the 2018 Portland CFP!
- Adds sponsorship prospectus link and details
- Adds first two sponsors
- Adjusts the team membership to reflect this year's crew (I'll email info@devopsdays.org with this too)
- Standardizes on camelcase DevOpsDays for this event