### PR TITLE
[AMS 2018] Fix max sponsor spots

### DIFF
--- a/data/events/2018-amsterdam.yml
+++ b/data/events/2018-amsterdam.yml
@@ -104,8 +104,10 @@ sponsor_levels:
     max: "1"
   - id: preevent
     label: "Pre Event Social"
+    max: 1
   - id: beer
     label: Beer
+    max: 1
   - id: gold
     label: Gold
     max: 8


### PR DESCRIPTION
Set the max sponsor spots for the pre event and beer options.