### PR TITLE
Remove the hugo version incompatibility warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ If you'd like to edit a specific devopsdays event site (and/or contribute code),
 
 ### Quick Overview
 
-1. Install [Hugo v0.30.2+](http://gohugo.io).
+1. Install [Hugo v0.36.1+](http://gohugo.io). [(Quick Install)](https://gohugo.io/getting-started/installing#binary-cross-platform)
 1. Fork this repo.
 
 ### View site locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ If you'd like to edit a specific devopsdays event site (and/or contribute code),
 ### Quick Overview
 
 1. Install [Hugo v0.30.2+](http://gohugo.io).
-   * The theme is currently incompatible with `v0.32.x` and above; recommend `v0.31.1`.
 1. Fork this repo.
 
 ### View site locally


### PR DESCRIPTION
Pull request #3980 fixes the hugo incompatibility problem we were seeing
with version v0.32. Removing the warning as it is no longer necessary.

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2017] Add Bluth Company as a sponsor`*
