### PR TITLE
[AMS-2018] sponsors spots should be string not int

### DIFF
--- a/data/events/2018-amsterdam.yml
+++ b/data/events/2018-amsterdam.yml
@@ -104,10 +104,10 @@ sponsor_levels:
     max: "1"
   - id: preevent
     label: "Pre Event Social"
-    max: 1
+    max: "1"
   - id: beer
     label: Beer
-    max: 1
+    max: "1"
   - id: gold
     label: Gold
     max: 8


### PR DESCRIPTION
The tekst sponsorS should be sponsor for evening/beer and coffee.
This PR changes the max setting from INT to string.