### PR TITLE
[Columbus 2017] Adding links for talks and speakers

### DIFF
--- a/content/events/2017-ohio/program/aaron-kalin.md
+++ b/content/events/2017-ohio/program/aaron-kalin.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Where are all the Chefs?"
 Type = "talk"
 Speakers = ["aaron-kalin"]
+youtube = "PYF1A2I3KRM"
 +++
 
 We live in this world of DevOps with new and exciting things happening around every corner. How are we advancing ourselves in our trade and craft? Can DevOps culture support us while welcoming new people into the fold? We’ll dive into a little DevOps history and look towards the future.

--- a/content/events/2017-ohio/program/adarsh-shah.md
+++ b/content/events/2017-ohio/program/adarsh-shah.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Role of Team structures in DevOps Transformation Journey"
 Type = "talk"
 Speakers = ["adarsh-shah"]
+youtube = "RIEJe2eqN4I"
 +++
 
 Conway’s Law says that "Organizations which design systems, are constrained to produce designs which are copies of the communication structures of these organizations". The communication structures are heavily influenced by how the teams are structured and whether they can create a culture of shared responsibility.

--- a/content/events/2017-ohio/program/barbara-bouldin.md
+++ b/content/events/2017-ohio/program/barbara-bouldin.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "One Woman's Experiences as the Software Industry Evolved"
 Type = "talk"
 Speakers = ["barbara-bouldin"]
+youtube = "3rzrbmzJAMY"
 +++
 
 I will talk about the early days of Unix at Bell Labs, AT&T Divestiture, the Silicon Valley, a Start-up company, and my current position working in DevOps with John Willis. I will discuss implementing automated technology and bringing about a cultural change in a large organization at AT&T.

--- a/content/events/2017-ohio/program/barry-tarlton.md
+++ b/content/events/2017-ohio/program/barry-tarlton.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "The MacGyver Mindset for Mastering Problem Solving"
 Type = "talk"
 Speakers = ["barry-tarlton"]
+youtube = "WvAjofQgV3o"
 +++
 
 A humorous look at how to become more than an average geek and how to be a MacGyver in your field. As tools and technologies constantly change around us, what are the qualities that will make you excel? Come discover the attitude, skills, and mindset required to become an expert problem solver. Join us for this entertaining and informative talk to better hone your problem solving skills that will allow you tackle the technical challenges we face day to day.

--- a/content/events/2017-ohio/program/chris-mcfee.md
+++ b/content/events/2017-ohio/program/chris-mcfee.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "The DevOps Abides"
 Type = "talk"
 Speakers = ["chris-mcfee"]
+youtube = "ZU033WskOSo"
 +++
 
 This year two of our Enterprise DevOps journey. The big question we came back to was "how do we scale this"? This led to a bit of a history lesson on how we got here. As a bank that has roots that go back over 190 years and has been thru many acquisitions, we have compiled a lot of complexity. This drove us to distributed organizational model to support the systems and not the business or customers. In a sense, Conway’s Law told us we made it extremely complex by building point to point solutions vs. solutions to enable our business and customers. So now that we had a lot of executive support, we worked very closely with our CTO on defining a new organizational structure that aligned us to a better deliver model. Rather than have technology specific organizations only focused on protecting their world, we needed to break that down. This started with value stream mapping our process for how work actually gets done.

--- a/content/events/2017-ohio/program/jason-hand.md
+++ b/content/events/2017-ohio/program/jason-hand.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Scrutinizing the Scrutiny"
 Type = "talk"
 Speakers = ["jason-hand"]
+youtube = "OQzpMKdQLjo"
 +++
 
 Common approaches to post-incident reviews are often short-sighted in their focus and rarely bring about any real improvements to our overall systems.

--- a/content/events/2017-ohio/program/jerry-cattell.md
+++ b/content/events/2017-ohio/program/jerry-cattell.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "How to Make Remote Work Work"
 Type = "talk"
 Speakers = ["jerry-cattell"]
+youtube = "lBl-YDUbe94"
 +++
 
 Whether it is to hire quality talent outside of their area or to save money on office space, more companies are considering remote workers. However, you can't just hire a remote employee, plug them into a team, and expect them to be successful. This ignite will provide some tips on how to navigate some of the issues you may experience when adding remote workers to your company.

--- a/content/events/2017-ohio/program/michael-butler.md
+++ b/content/events/2017-ohio/program/michael-butler.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "DevOps for Tweens"
 Type = "talk"
 Speakers = ["michael-butler"]
+youtube = "U2-PzeiQEaE"
 +++
 
 What’s better than teaching people DevOps Practices? Teaching TWEENS. Come here how my experience with taking a small group of 5th - 7th graders in their First Lego League club is going!

--- a/content/events/2017-ohio/program/michael-pinnegar.md
+++ b/content/events/2017-ohio/program/michael-pinnegar.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Dockerize Your Build Toolchain"
 Type = "talk"
 Speakers = ["michael-pinnegar"]
+youtube = "FI1JcD340B0"
 +++
 
 Take your build toolchain to the next level by putting all your build tools (gulp, maven, gradle, grunt, make, rake) into a Docker container. In this talk we'll go over the basics of getting started putting your toolchain into Docker, explore a few examples, and talk about common problems you might encounter.

--- a/content/events/2017-ohio/program/neil-primmer.md
+++ b/content/events/2017-ohio/program/neil-primmer.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "The Most Productive Meeting in the World"
 Type = "talk"
 Speakers = ["neil-primmer"]
+youtube = "pAxGDqH_J_s"
 +++
 
 How one operations team addressed trust issues, reduced the amount of time they spent in slack, and got more of the things they wanted to do done, just by adding one meeting a week to their schedules.

--- a/content/events/2017-ohio/program/preston-waller.md
+++ b/content/events/2017-ohio/program/preston-waller.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Nationwide's DevOps Journey to Accelerated Delivery"
 Type = "talk"
 Speakers = ["preston-waller"]
+youtube = "AgfXDbhsqVI"
 +++
 
 Using “The DevOps Handbook” as a guide, Nationwide is transforming its enterprise delivery strategy. The goal is to maintain high quality while gaining efficiency and speed. Nationwide is starting small by running experiments with two of the two hundred development lines. These experiments focus on the specific timeframe of when a story enters the backlog up until it is deployed. This session will cover the various practices, culture changes and technologies that Nationwide is evaluating. This session will not be an overview of DevOps, but a collective examination of the actions that Nationwide is taking. This discussion will explain why some experiments have been successful as well as why some experiments have not. The benefits Nationwide gained from experimentation and the challenges that Nationwide still faces will also be covered.

--- a/content/events/2017-ohio/program/ryan-lockard.md
+++ b/content/events/2017-ohio/program/ryan-lockard.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Business Agility requires DevOps"
 Type = "talk"
 Speakers = ["ryan-lockard"]
+youtube = "_8b9x44G2p8"
 +++
 
 To win in business, you require the ability to sense market problems and respond with valuable technical solutions. Both disruptive innovation and sustainable growth are underpinned with the ability to deploy software nimbly, and with high confidence. It is important for the business team to understand the critical importance of DevOps, the mindset and to prepare for the speed that is acquired when teams adopt this culture. This talk introduces the topics of delivery orchestration, containerization and the DevOps mindset through the business lens to demystify the mindset and present the unique value proposition of organizations that successfully employ this mindset.

--- a/content/events/2017-ohio/program/tiffany-longworth.md
+++ b/content/events/2017-ohio/program/tiffany-longworth.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "Change Management for Humans"
 Type = "talk"
 Speakers = ["tiffany-longworth"]
+youtube = "ErXaBoaK8Ok"
 +++
 
 Unfortunately, rolling out changes for humans is not as easy as merging a pull request. How many times have you seen a new project management tool get rolled out, sometimes with much fanfare and polish, and just not get adopted? Have you ever seen your company announce a new business unit which led to a minor revolt? How scary is the word “reorganization”? If you have ideas on how your group’s processes could be better, want to launch a new tool that will work better as your company grows, or have to adjust the way you do things to meet new regulations, learning the basics of change management will help you to get your plans going, launch them effectively, and ensure they stick around.

--- a/content/events/2017-ohio/program/tom-larrow.md
+++ b/content/events/2017-ohio/program/tom-larrow.md
@@ -5,6 +5,7 @@ Talk_end_time = ""
 Title = "The Importance of Now"
 Type = "talk"
 Speakers = ["tom-larrow"]
+youtube = "nOn_tJyG5RE"
 +++
 
 In your CI/CD pipeline, every second counts. The faster you can get accurate results to back to your developers, the more productive you can make them.

--- a/data/events/2017-ohio.yml
+++ b/data/events/2017-ohio.yml
@@ -14,6 +14,7 @@ location: "The Bluestone" # The name of your location
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: contact
   - name: program
+  - name: speakers
   - name: conduct
   - name: sponsor
   - name: "location/parking"


### PR DESCRIPTION
Hi, @kjenkins19 @mfdii etc - I noticed that your talks are posted but weren't linked on each speaker's page. I've added those links because that's usually nice to have. I also added the "speakers" link so all your speakers from 2017 are visible on one page. (I apparently also added newlines, which made it look like there are more changes than there are.)

I'll mark this "do not merge" until we hear from a Columbus organizer as to whether you want this. Thanks. 