### PR TITLE
Fix alias for 2018 nyc

### DIFF
--- a/content/events/2018-new-york-city/welcome.md
+++ b/content/events/2018-new-york-city/welcome.md
@@ -1,7 +1,7 @@
 +++
 Title = "devopsdays New York City 2018"
 Type = "welcome"
-aliases = ["/events/2017-new-york-city"]
+aliases = ["/events/2018-new-york-city"]
 Description = "devopsdays New York City 2018"
 +++
 


### PR DESCRIPTION
The alias on the welcome page for NYC 2018 was wrong :)