### PR TITLE
[DC-2108] Sponsors get logo on DC site, not Baltimore

### DIFF
--- a/content/events/2018-washington-dc/sponsor.md
+++ b/content/events/2018-washington-dc/sponsor.md
@@ -162,7 +162,7 @@ Hour sponsorship includes some special perks not listed in the table above.
 * 1 included ticket
 * 10% discount code to share with your community
 * Logo on shared slide, rotating during breaks
-* Logo on DevOpsDays Baltimore 2018 event website
+* Logo on DevOpsDays DC 2018 event website
 
 ### Gold - $3,000
 


### PR DESCRIPTION
Signed-off-by: Nathen Harvey <nharvey@chef.io>
