### PR TITLE
Add twitter handles for some sponsors

### DIFF
--- a/data/sponsors/aging-2-0-baltimore.yml
+++ b/data/sponsors/aging-2-0-baltimore.yml
@@ -1,2 +1,3 @@
 name: "Aging 2.0 Baltimore"
 url: "https://www.aging2.com/baltimore/"
+twitter: aging20

--- a/data/sponsors/datadog.yml
+++ b/data/sponsors/datadog.yml
@@ -1,3 +1,3 @@
-
 name: "Datadog"
 url: "https://www.datadoghq.com"
+twitter:  datadoghq

--- a/data/sponsors/gitlab.yml
+++ b/data/sponsors/gitlab.yml
@@ -1,3 +1,3 @@
-
 name: "GitLab"
 url: "https://gitlab.com"
+twitter: gitlab

--- a/data/sponsors/nutanix.yml
+++ b/data/sponsors/nutanix.yml
@@ -1,2 +1,3 @@
 name: nutanix
 url: http://www.nutanix.com
+twitter: nutanix

--- a/data/sponsors/onyx-point.yml
+++ b/data/sponsors/onyx-point.yml
@@ -1,3 +1,3 @@
 name: "Onyx Point"
 url: "http://www.onyxpoint.com/"
-twitter:
+twitter: onyxpoint

--- a/data/sponsors/perfbytes.yml
+++ b/data/sponsors/perfbytes.yml
@@ -1,2 +1,3 @@
 name: "PerfBytes"
 url: "http://www.perfbytes.com"
+twitter: perfbytes


### PR DESCRIPTION
NOTE:  this is not used by the site but is handy for organizers wishing
to include the twitter handle of sponsors in various things like slides
and twitter lists.

Signed-off-by: Nathen Harvey <nharvey@chef.io>
