### PR TITLE
[CHI-2018] Update proposal links to papercall

### DIFF
--- a/content/events/2018-chicago/welcome.md
+++ b/content/events/2018-chicago/welcome.md
@@ -62,7 +62,7 @@ The format of DevOpsDays Chicago includes a single track of 30 minute talks in t
       <div class = "col-md-12">
       <div class = "row justify-content-center">
         <div class = "d-flex p-2">
-          <a class="btn btn-primary btn-block"  style = "margin-top: 10px; margin-bottom: 10px; background-color: #96bfe6; border-color: #96bfe6;" href="/events/2018-chicago/propose">
+          <a class="btn btn-primary btn-block"  style = "margin-top: 10px; margin-bottom: 10px; background-color: #96bfe6; border-color: #96bfe6;" href="https://www.papercall.io/devopsdays-chicago-2018">
             <i class="fa fa-microphone fa-lg"></i>&nbsp;&nbsp;&nbsp;Propose a Talk
           </a>
         </div>

--- a/data/events/2018-chicago.yml
+++ b/data/events/2018-chicago.yml
@@ -14,7 +14,7 @@ cfp_date_start: 2018-03-19 # start accepting talk proposals.
 cfp_date_end: 2018-06-01  # close your call for proposals.
 cfp_date_announce: 2018-06-15  # inform proposers of status
 
-cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_link: "https://www.papercall.io/devopsdays-chicago-2018" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2018-03-19  # start accepting registration. Leave blank if registration is not open yet
 registration_date_end: 2018-08-28 # close registration. Leave blank if registration is not open yet.


### PR DESCRIPTION
No reason to send people to `/propose` and make them click again.