### PR TITLE
[Den 2018] Removing propose link

### DIFF
--- a/data/events/2018-denver.yml
+++ b/data/events/2018-denver.yml
@@ -19,7 +19,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
 
   - name: sponsor
   - name: registration
-  - name: propose
+#  - name: propose
   - name: contact
   - name: conduct
   - name: location


### PR DESCRIPTION
Since the Denver CFP is closed, you probably don't want this link anymore. Looking for a 👍 from @tavisto or other Denver organizer.