### PR TITLE
[CPH 2018] updating links

### DIFF
--- a/content/events/2018-copenhagen/welcome.md
+++ b/content/events/2018-copenhagen/welcome.md
@@ -18,14 +18,14 @@ Description = "devopsdays Copenhagen 2018"
   </div>
 </div>
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
     <strong>Location</strong>
   </div>
   <div class = "col-md-8">
     {{< event_location >}}
   </div>
-</div> -->
+</div>
 
 <!-- <div class = "row">
   <div class = "col-md-2">
@@ -45,23 +45,23 @@ Description = "devopsdays Copenhagen 2018"
   </div>
 </div> -->
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
     <strong>Program</strong>
   </div>
   <div class = "col-md-8">
     View the {{< event_link page="program" text="program." >}}
   </div>
-</div> -->
+</div>
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
     <strong>Speakers</strong>
   </div>
   <div class = "col-md-8">
     Check out the {{< event_link page="speakers" text="speakers!" >}}
   </div>
-</div> -->
+</div>
 
 <div class = "row">
   <div class = "col-md-2">
@@ -81,7 +81,4 @@ Description = "devopsdays Copenhagen 2018"
   </div>
 </div>
 
-<!-- Uncomment if you added your city twitter name -->
-<!--
 {{< event_twitter >}}
--->

--- a/data/events/2018-copenhagen.yml
+++ b/data/events/2018-copenhagen.yml
@@ -32,7 +32,7 @@ location_address: "Mogens Dahl Concert Hall, København" #Optional - use the str
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
 
-  - name: propose
+#  - name: propose
   - name: location
   - name: registration
   - name: program


### PR DESCRIPTION
Hi, @mariuszbury - please let us know if you'd like this update merged.

- removes the "propose" page from the top links since it's closed now
- shows speaker, program, and location pages in the main page links