### PR TITLE
[Boston 2018] Making sure we don't accidentally use past logos

### DIFF
--- a/data/events/2018-boston.yml
+++ b/data/events/2018-boston.yml
@@ -158,7 +158,7 @@ sponsors:
   #   level: gold
   # - id: threatstack
   #   level: platinum
-  # - id: cyberark-before-20180203
+  # - id: cyberark
   #   level: gold
   # - id: pivotal
   #   level: gold
@@ -168,9 +168,9 @@ sponsors:
   #   level: platinum
   # - id: victorops
   #   level: platinum
-  # - id: appdynamics-before-20180316
+  # - id: appdynamics
   #   level: gold
-  # - id: influxdata-before-20181218
+  # - id: influxdata
   #   level: gold
   # - id: pagerduty
   #   level: gold


### PR DESCRIPTION
Even though they're commented out, we probably want to avoid accidentally uncommenting and using outdated logos.