### PR TITLE
Fix extra space in yaml

### DIFF
--- a/utilities/add_sponsors.sh
+++ b/utilities/add_sponsors.sh
@@ -74,7 +74,7 @@ else
 fi
 
 echo "Add this to ../data/events/"$event_slug".yml under sponsors:"
-echo "  - id: " $sponsor_slug
+echo "  - id:" $sponsor_slug
 echo "    level: theirlevel"
 
 


### PR DESCRIPTION
Without this patch the add_sponsors.sh script will add an extra space to
the yaml output which can cause the sponsor logo to not appear.