### PR TITLE
[VAN-2018] Fix Open Space 4 copy mistake

### DIFF
--- a/data/events/2018-vancouver.yml
+++ b/data/events/2018-vancouver.yml
@@ -414,13 +414,13 @@ program:
     start_time: "14:30"
     end_time: "15:00"
     background_color: "#ABEBFF"
-  - title: "Open Space - Slot 5"
+  - title: "Open Space - Slot 4"
     type: custom
     date: 2018-04-21
     start_time: "15:00"
     end_time: "16:00"
     background_color: "#FFB566"
-  - title: "Open Space - Slot 6"
+  - title: "Open Space - Slot 5"
     type: custom
     date: 2018-04-21
     start_time: "16:00"


### PR DESCRIPTION
There was a copy mistake in our excel sheet where the schedule was built, I didn't catch in the previous PR. This fixes the naming.