### PR TITLE
[DSM-2018] Remove map from bio to avoid duplicate/overlap

### DIFF
--- a/content/events/2018-des-moines/speakers/barattas-forte.md
+++ b/content/events/2018-des-moines/speakers/barattas-forte.md
@@ -3,12 +3,9 @@ Title = "Baratta’s at Forté"
 Website = "https://barattas.com/restaurants-venues/forte/"
 type = "speaker"
 linktitle = "barattas-forte"
+image = ""
 
 +++
-
-Party Details:
-
-Location: 
 
 ```
 Forte Banquet and Conference Center
@@ -23,7 +20,3 @@ Events:
     7:00 - 9:00 pm    Networking
 
 * Foods and Drinks provided by Source Allies
-
-Map: 
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d47713.7337276544!2d-93.71950317600069!3d41.631789203843134!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x87ee99a9eefaa1c3%3A0x942335eeefb67c7a!2sForte+Banquet+%26+Conference+Center!5e0!3m2!1sen!2sus!4v1523384605028" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>


### PR DESCRIPTION
Apparently on some devices the map being both places was causing display issues.