### PR TITLE
2017 is over; point to 2018

### DIFF
--- a/content/events/2017-minneapolis/sponsor.md
+++ b/content/events/2017-minneapolis/sponsor.md
@@ -5,6 +5,10 @@ type = "event"
 
 +++
 
+<h1><mark>You're looking at a past event. <br><br>
+Go to <a href="/events/2018-minneapolis/sponsor/">devopsdays Minneapolis 2018</a> instead.</mark></h1><br><br>
+
+
 Platinum, Gold and Silver sponsorship packages are sold out. If you are interested in an à la carte sponsorship, please drop us an email at [{{< email_organizers >}}].
 
 Additional à la carte sponsorships that are still available:

--- a/content/events/2017-minneapolis/welcome.md
+++ b/content/events/2017-minneapolis/welcome.md
@@ -7,6 +7,11 @@ description = "devopsdays returns July 25 & 26 to downtown Minneapolis."
 
 +++
 
+
+<h1><mark>You're looking at a past event. <br><br>
+Go to <a href="/events/2018-minneapolis/welcome/">devopsdays Minneapolis 2018</a> instead.</mark></h1><br><br>
+
+
 **devopsdays is returning to {{< event_location >}} for a fourth year!**
 
 <div class = "row">


### PR DESCRIPTION
Sponsors find 2017 instead of 2018 because of search-engine rankings and links.