### PR TITLE
[ATL-2018] Fix time listing for opening keynote

### DIFF
--- a/data/events/2018-atlanta.yml
+++ b/data/events/2018-atlanta.yml
@@ -154,8 +154,6 @@ program:
     date: "2018-04-17"
     start_time: "9:15"
     end_time: "9:45"
-    start_time: "09:00"
-    end_time: "09:15"
 
   - title: "Sponsors - Microsoft, Rigor, Instana"
     type: custom


### PR DESCRIPTION
The `.yml` file had two start and end times listed.  The second set of
them were winning and showing the time of the talk as `09:00 - -9:15`.

This fix removes the duplicate start and end times and updates the time
on the program page to `09:15 - 09:45`.

/cc @cacorriere

Signed-off-by: Nathen Harvey <nharvey@chef.io>

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2018] Add Bluth Company as a sponsor`*
