### PR TITLE
[LDN-2018] Updating content for CFP and Sponsorships

### DIFF
--- a/content/events/2018-london/propose.md
+++ b/content/events/2018-london/propose.md
@@ -6,30 +6,35 @@ Description = "Propose a talk for devopsdays London 2018"
   {{< cfp_dates >}}
 
 <hr>
+<h2><a href="https://docs.google.com/forms/d/e/1FAIpQLSdGb7ZUaUpUiH8ObK2OUBfeueGSU7pKLkZB4RqMh9aeKxjoeg/viewform#start=openform" target="_blank">Click here to propose a session</a></h2>
 
-There are three ways to propose a topic at devopsdays:
+<br/><strong>There are two ways to propose a topic:</strong>
 <ol>
-  <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
-  <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
-  <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
+  <li><strong><em>Main talk</em></strong>: 30 minute slots.</li>
+  <li><strong><em>Ignite talk</em></strong>: 5 minute slots (presented using the <a href="/pages/ignite-talks-format"> Ignite format</a>.)</li>
 </ol>
 
+<strong>Our main criteria:</strong>
+
+- _original content_: content not yet presented at other conferences, or a new angle to an existing problem
+- _new presenters_: people who are new to the space and have insightful stuff to say; we want to hear everybody's voice
+- _no vendor pitches_: as much as we value vendors and sponsors, we just don't think this is the right forum. You can demo at your table or during Open Space.
+- _diversity_: our review process will involve stripping any identifiable information from proposals including name, gender, geography and company.
+
+<strong>Tips:</strong>
+<ul>
+	<li>Be specific... we aren't mind readers (a description of about 20 lines is about right)</li>
+	<li>Detail is good... but not as important as explaining why your proposal would be interesting</li>
+	<li>Propose your own talk; don't have someone else do it for you.</li>
+	<li>Nominations welcome... if you know someone who has content/experience relevant to the DevOps conversation, please point us in their direction!</li>
+	<li>Multiple proposals welcome... just follow the other rules</li>
+</ul>
+
+<strong>What the organisers have been blogging about:</strong>
+
+- <a href="https://medium.com/@hannahfoxwell/should-tech-conferences-be-more-inclusive-5a05a09cd302">Should Tech Conferences Be More Inclusive?</a>
+- <a href="http://randomness.org.uk/2017/05/21/Anonymising-talk-submissions-for-DevOpsDays-London.html">Anonymising talk submissions for DevOpsDays London</a>
+
+
+<br/><h2><a href="https://docs.google.com/forms/d/e/1FAIpQLSdGb7ZUaUpUiH8ObK2OUBfeueGSU7pKLkZB4RqMh9aeKxjoeg/viewform#start=openform" target="_blank">Click here to propose a session</a></h2>
 <hr>
-
-Choosing talks is part art, part science; here are some factors we consider when trying to assemble the best possible program for our local audience:
-
-- _broad appeal_: How will your talk play out in a room of people with a variety of backgrounds? Technical deep dives need more levels to provide value for the whole room, some of whom might not use your specific tool.
-- _new local presenters_: You are the only one who can tell your story. We are very interested in the challenges and successes being experienced in our local area. We are happy to provide guidance/coaching for new speakers upon request.
-- _under-represented voices_: We want to hear all voices, including those that may speak less frequently at similar events. Whether you're in a field not typically thought of as a technology field, you're in a large, traditional organization, or you're the only person at your organization with your background, we are interested in your unique experience.
-- _original content_: We will consider talks that have already been presented elsewhere, but we prefer talks that the local area isn't likely to have already seen.
-- _no third-party submissions_: This is a small community-driven event, and speakers need to be directly engaged with the organizers and attendees. If a PR firm or your marketing department is proposing the talk, you've already shown that as a speaker you're distant from the process.
-- _no vendor pitches_: As much as we value vendors and sponsors, we are not going to accept a talk that appears to be a pitch for your product.
-
-<hr>
-
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>

--- a/data/events/2018-london.yml
+++ b/data/events/2018-london.yml
@@ -10,11 +10,11 @@ startdate: 2018-09-20  # The start date of your event. Leave blank if you don't 
 enddate:   2018-09-21  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:  # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_start:  2018-04-27 # start accepting talk proposals.
+cfp_date_end: 2018-06-13 # close your call for proposals.
+cfp_date_announce: 2018-07-01 # inform proposers of status
 
-cfp_open: "false"
+cfp_open: "true"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet
@@ -28,10 +28,10 @@ registration_link: "" # If you have a custom registration link, enter it here. T
 coordinates: "51.507351, -0.127758" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "London" # Defaults to city, but you can make it the venue name.
 #
-location_address: "" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+location_address: "QEII Centre, Broad Sanctuary, Westminster" #Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- # - name: propose
+  - name: propose
   - name: location
  # - name: registration
  # - name: program
@@ -78,7 +78,7 @@ proposal_email: "proposals-london-2018@devopsdays.org" # Put your proposal email
 sponsors:
   - id: samplesponsorname
     level: gold
- #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.   
+ #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
   - id: arresteddevops
     level: community
 
@@ -91,16 +91,18 @@ sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: platinum
     label: Platinum
-    max: 3
+    max: 1
+  - id: evening
+    label: Evening
   - id: gold
     label: Gold
-    max: 5
+    max: 7
   - id: silver
     label: Silver
-    max: 7
+    max: 12
   - id: bronze
     label: Bronze
-    max: 10
+    max: 5
   - id: charity
     label: Charity
-    max: 2
+    max: 20


### PR DESCRIPTION
The updated CFP (Purpose) page with relevant 2018 information
including the new link. Added location details and sponorship page
updates.

Signed-off-by: Chris M <chris.mills@hee.nhs.uk>

- Added form for propose and altered content so it fits in line with 2018
- Altered dates for CFP to they match start/end/announce dates.
- Altered sponsor levels to they match goals.