### PR TITLE
Use existing docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 before_install:
-  - docker run --rm -e SITE_URL="https://wwww.devopsdays.org" -v $(pwd):/site devopsdays/docker-hugo-compiler
+  - docker run --name "hugo-server" -P -v $(pwd):/src -v $(pwd)/public:/output jojomi/hugo:0.30.2
 
 before_script:
 - npm install -g gulp

--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -9,4 +9,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tip 1313:1313 -v $(pwd):/site:cached -e VIRTUAL_HOST="${1}" --name hugo-server devopsdays/docker-hugo-server:v0.30.2
+docker run -tip 1313:1313 -v $(pwd):/src:cached -e HUGO_WATCH=1 --name hugo-server jojomi/hugo:0.30.2


### PR DESCRIPTION
Fixes #4127

Replaces https://github.com/devopsdays/devopsdays-web/pull/4401

(I deleted an re-created my fork, cause my upload bandwidth is slow, and then killed my previous branch)