### PR TITLE
[AMS-2018] Adjust one speaker to not speak the same day

### DIFF
--- a/data/events/2018-amsterdam.yml
+++ b/data/events/2018-amsterdam.yml
@@ -483,8 +483,6 @@ program:
 ignites:
   - title: "jason-yee"
     date: 2018-06-28
-  - title: "serhat-can-ig"
-    date: 2018-06-28
   - title: "joep-weijers"
     date: 2018-06-28
   - title: "matt-stratton-ig"
@@ -492,6 +490,8 @@ ignites:
   - title: "jonah-meijers"
     date: 2018-06-29
   - title: "aditya-vadaganadam"
+    date: 2018-06-29
+  - title: "serhat-can-ig"
     date: 2018-06-29
   - title: "aernout-van-den-burg"
     date: 2018-06-29


### PR DESCRIPTION
* One of our speakers is igniting and speaking the same day. Submitting an adjustment. 