### PR TITLE
[Boise 2018] Remove EarlyBird discount code

### DIFF
--- a/content/events/2018-boise/registration.md
+++ b/content/events/2018-boise/registration.md
@@ -8,8 +8,6 @@ type = "event"
 
 Registration is now available via EventBrite.  If you are a High School or College student, please <a href="mailto:{{< email_organizers >}}?subject=Discount Code for DevOpsDays Boise">contact the organizing team</a> for a discount code.
 
-Early Bird tickets are still available with promo code: <i>EarlyBird</i>
-
 <div style="width:100%; text-align:left;">
 
 <iframe src="https://www.eventbrite.com/tickets-external?eid=44858063676&ref=etckt" frameborder="0" height="1000" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe>


### PR DESCRIPTION
It's not longer active, early bird expired last friday (oops..)