### PR TITLE
[BOS-2018] added appd as platinum sponsor

### DIFF
--- a/data/events/2018-boston.yml
+++ b/data/events/2018-boston.yml
@@ -120,6 +120,10 @@ proposal_email: "proposals-boston-2018@devopsdays.org" # Put your proposal email
 sponsors:
   - id: klaviyo
     level: gold
+  - id: mesosphere
+    level: gold
+  - id: appdynamics
+    level: platinum
   # - id: samplesponsorname
   #   level: gold
   # - id: arresteddevops
@@ -158,8 +162,6 @@ sponsors:
   #   level: gold
   # - id: turbinelabs
   #   level: gold
-  - id: mesosphere
-    level: gold
   # - id: threatstack
   #   level: platinum
   # - id: cyberark
@@ -172,8 +174,6 @@ sponsors:
   #   level: platinum
   # - id: victorops
   #   level: platinum
-  # - id: appdynamics
-  #   level: gold
   # - id: influxdata
   #   level: gold
   # - id: pagerduty


### PR DESCRIPTION
Adding appdynamics as a sponsor for Boston, pushing from the ballroom at devops days toronto