### PR TITLE
[DC-2018] Add some twitter handles

### DIFF
--- a/data/sponsors/arresteddevops.yml
+++ b/data/sponsors/arresteddevops.yml
@@ -1,2 +1,3 @@
 name: "Arrested DevOps"
 url: "https://www.arresteddevops.com"
+twitter: "arresteddevops"

--- a/data/sponsors/booz_allen_hamilton.yml
+++ b/data/sponsors/booz_allen_hamilton.yml
@@ -1,2 +1,3 @@
 name: booz_allen_hamilton
 url: http://www.boozallen.com
+twitter: boozallen

--- a/data/sponsors/compuware.yml
+++ b/data/sponsors/compuware.yml
@@ -1,2 +1,3 @@
 name: "Compuware"
-url: "http://compuware.com/apm/"
+url: "http://compuware.com/"
+twitter: "compuware"

--- a/data/sponsors/metis-machine.yml
+++ b/data/sponsors/metis-machine.yml
@@ -1,2 +1,3 @@
 name: "Metis Machine"
 url: "https://metismachine.com"
+twitter: "metismachine"

--- a/data/sponsors/uspto.yml
+++ b/data/sponsors/uspto.yml
@@ -1,2 +1,3 @@
 name: uspto
 url: http://www.uspto.gov/
+twitter: uspto


### PR DESCRIPTION
Note, this doesn't really do anything for the site but is helpful for
organizers when building twitter lists such as
https://twitter.com/devopsdaysdc/lists/doddc-2018-sponsors/members

Signed-off-by: Nathen Harvey <nharvey@chef.io>
