### PR TITLE
[KC 2018] - Fix typo on URL

### DIFF
--- a/data/sponsors/stackify.yml
+++ b/data/sponsors/stackify.yml
@@ -1,3 +1,3 @@
 name: "stackify"
-url: "hhttps://stackify.com"
+url: "https://stackify.com"
 twitter: Stackify


### PR DESCRIPTION
Fix typo that prevented hyperlink from working on new sponsor image.  