### PR TITLE
[WLG-2018] Removed email process to submit CFP

### DIFF
--- a/content/events/2018-wellington/propose.md
+++ b/content/events/2018-wellington/propose.md
@@ -58,10 +58,4 @@ There are three ways to propose a topic at DevOpsDays Wellington:
 </ol>
 
 <hr>
-
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+<strong>Support</strong> If you have any questions about the CFP, please feel free to send an email to the organising team [{{< email_proposals >}}]


### PR DESCRIPTION
Have reworded submission action to only use papercall.

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2018] Add Bluth Company as a sponsor`*
