### PR TITLE
[MTL-2018] added papercall.io link to propose page

### DIFF
--- a/content/events/2018-montreal/propose.md
+++ b/content/events/2018-montreal/propose.md
@@ -27,9 +27,4 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+<strong>Submit a proposal here:</strong> <a href="https://www.papercall.io/devopsdays-mtl-2018">https://www.papercall.io/devopsdays-mtl-2018</a>


### PR DESCRIPTION
we were missing the link to talk submission, so I added it and removed the option to have people submit talks via email.
