### PR TITLE
[AMS-2018] update an organizer twitter handle

### DIFF
--- a/data/events/2018-amsterdam.yml
+++ b/data/events/2018-amsterdam.yml
@@ -72,7 +72,7 @@ team_members: # Name is the only required field for team members.
   - name: "Peter Nijenhuis"
     twitter: "Peter_Nijenhuis"
   - name: "Chris Lennon"
-    twitter: "leapyearboy88"
+    twitter: "cdlennon"
   - name: "Daniel Paulus"
     twitter: "dpnl87"
     # employer: "Acme Anvil Co."


### PR DESCRIPTION
Update to an organizer twitter handle (my own).

Seems I missed this when I was originally added.