### PR TITLE
[LDN-2018] Minor change to get Velvet back

### DIFF
--- a/data/events/2018-london.yml
+++ b/data/events/2018-london.yml
@@ -153,7 +153,7 @@ program:
     date: 2018-09-20
     start_time: "11:25"
     end_time: "12:00"
-  - title: "velvet"
+  - title: "velvet-spors"
     type: talk
     date: 2018-09-20
     start_time: "12:00"


### PR DESCRIPTION
When I added the surname for Velvet I made the changes in content/ but
not in data/ so the programme page wasn't showing the talk. This minor
fix corrects that