### PR TITLE
Add conditional for gnu-sed on MacOS

### DIFF
--- a/utilities/add_new_event.sh
+++ b/utilities/add_new_event.sh
@@ -6,10 +6,13 @@ cd `dirname ${0}`
 
 # Detect OS for correct 'sed' syntax
 OSNAME=`uname`
+GNUSED=$(which sed)
 SEDCMD(){
   if [[ $OSNAME == 'Linux' ]]; then
     sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' ]]; then
+  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
+    sed -i "$@"
+  else
     sed -i '' "$@"
   fi
 }

--- a/utilities/add_organizers.sh
+++ b/utilities/add_organizers.sh
@@ -9,10 +9,13 @@ OUT=$(mktemp /tmp/output.XXXXXXXXXX) || { echo "Failed to create temp file"; exi
 
 # Detect OS for correct 'sed' syntax
 OSNAME=`uname`
+GNUSED=$(which sed)
 SEDCMD(){
   if [[ $OSNAME == 'Linux' ]]; then
     sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' ]]; then
+  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
+    sed -i "$@"
+  else
     sed -i '' "$@"
   fi
 }

--- a/utilities/add_program.sh
+++ b/utilities/add_program.sh
@@ -6,10 +6,13 @@ cd `dirname ${0}`
 
 # Detect OS for correct 'sed' syntax
 OSNAME=`uname`
+GNUSED=$(which sed)
 SEDCMD(){
   if [[ $OSNAME == 'Linux' ]]; then
     sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' ]]; then
+  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
+    sed -i "$@"
+  else
     sed -i '' "$@"
   fi
 }

--- a/utilities/add_speakers.sh
+++ b/utilities/add_speakers.sh
@@ -6,10 +6,13 @@ cd `dirname ${0}`
 
 # Detect OS for correct 'sed' syntax
 OSNAME=`uname`
+GNUSED=$(which sed)
 SEDCMD(){
   if [[ $OSNAME == 'Linux' ]]; then
     sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' ]]; then
+  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
+    sed -i "$@"
+  else
     sed -i '' "$@"
   fi
 }

--- a/utilities/add_sponsors.sh
+++ b/utilities/add_sponsors.sh
@@ -5,10 +5,13 @@ set -e
 cd `dirname ${0}`
 # Detect OS for correct 'sed' syntax
 OSNAME=`uname`
+GNUSED=$(which sed)
 SEDCMD(){
   if [[ $OSNAME == 'Linux' ]]; then
     sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' ]]; then
+  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
+    sed -i "$@"
+  else
     sed -i '' "$@"
   fi
 }


### PR DESCRIPTION
Hey people,

When setting up the new site for Amsterdam I noticed that `add_new_event.sh` failed with the following error:

```
./add_new_event.sh
Enter your event year (default: 2018): 2019
Enter your city name: Amsterdam
Enter your devopsdays event twitter handle (defaults to devopsdays): dodams
sed: can't read s/YYYY/2019/: No such file or directory
```

I had a look at this script and the others and noticed that it was calling `sed`, but I have `gnu-sed` installed on my Mac which when installed (via brew) will automatically change to be used by default.

There were two ways to fix this:

1) Rename the line with [sed](https://github.com/devopsdays/devopsdays-web/blob/master/utilities/add_new_event.sh#L13) (and in the other files as well) to `/usr/bin/sed` which is where the default BSD `sed` is located.
2) Add a conditional to use `gnu-sed` when found in the brew installation directory.

If you'd prefer a PR with option #1 instead let me know. 😃