### PR TITLE
[CHA-2018] Adding registration link, specifying image dimensions

### DIFF
--- a/content/events/2018-chattanooga/registration.md
+++ b/content/events/2018-chattanooga/registration.md
@@ -4,8 +4,4 @@ Type = "event"
 Description = "Registration for devopsdays Chattanooga 2018"
 +++
 
-<div style="width:100%; text-align:left;">
-
-Embed registration iframe/link/etc.
-</div></div>
-</div>
+<h3 style="margin: 30px 0"><a href="https://chadevopsdays.ticketspice.com/devopsdays-chattanooga" target="_blank">Register for DevOpsDays Chattanooga on TicketSpice</a></h3>

--- a/content/events/2018-chattanooga/sponsor.md
+++ b/content/events/2018-chattanooga/sponsor.md
@@ -25,7 +25,7 @@ The best thing to do is send engineers to interact with the experts at devopsday
 <table style="text-align:center">
   <tr>
     <td colspan="3">
-      <img src="/events/2018-chattanooga/chattanooga-2018-sponsor-table.png" />
+      <img alt"Chattanooga DevOpsDays Sponsorship Tiers" src="/events/2018-chattanooga/chattanooga-2018-sponsor-table.png" width="808" height="657" />
     </td>
   </tr>
 </table>

--- a/content/events/2018-chattanooga/welcome.md
+++ b/content/events/2018-chattanooga/welcome.md
@@ -6,7 +6,7 @@ Description = "DevOpsDays is coming to Chattanooga for the first time on Novembe
 +++
 
 <div style="text-align:center;">
-  {{< event_logo >}}
+  <img alt="DevOpsDays Chattanooga Logo" src="/events/2018-chattanooga/logo.png" width="600" height="524" />
 </div>
 
 <div class = "row">


### PR DESCRIPTION
Although the registration page is not enabled (we have a link specified instead), it's currently showing up at the top of Google search results, so I'm adding a link on that page to be safe. 