### PR TITLE
[CHA-2018] Ensuring everything points to PaperCall for CFPs

### DIFF
--- a/content/events/2018-chattanooga/propose.md
+++ b/content/events/2018-chattanooga/propose.md
@@ -3,33 +3,6 @@ Title = "Propose"
 Type = "event"
 Description = "Propose a talk for devopsdays Chattanooga 2018"
 +++
-  {{< cfp_dates >}}
 
-<hr>
+<h3 style="margin: 30px 0"><a href="https://www.papercall.io/devopsdayschattanooga" target="_blank">Propose a talk for DevOpsDays Chattanooga</a></h3>
 
-There are three ways to propose a topic at devopsdays:
-<ol>
-  <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
-  <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
-  <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
-</ol>
-
-<hr>
-
-Choosing talks is part art, part science; here are some factors we consider when trying to assemble the best possible program for our local audience:
-
-- _broad appeal_: How will your talk play out in a room of people with a variety of backgrounds? Technical deep dives need more levels to provide value for the whole room, some of whom might not use your specific tool.
-- _new local presenters_: You are the only one who can tell your story. We are very interested in the challenges and successes being experienced in our local area. We are happy to provide guidance/coaching for new speakers upon request.
-- _under-represented voices_: We want to hear all voices, including those that may speak less frequently at similar events. Whether you're in a field not typically thought of as a technology field, you're in a large, traditional organization, or you're the only person at your organization with your background, we are interested in your unique experience.
-- _original content_: We will consider talks that have already been presented elsewhere, but we prefer talks that the local area isn't likely to have already seen.
-- _no third-party submissions_: This is a small community-driven event, and speakers need to be directly engaged with the organizers and attendees. If a PR firm or your marketing department is proposing the talk, you've already shown that as a speaker you're distant from the process.
-- _no vendor pitches_: As much as we value vendors and sponsors, we are not going to accept a talk that appears to be a pitch for your product.
-
-<hr>
-
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>

--- a/content/events/2018-chattanooga/welcome.md
+++ b/content/events/2018-chattanooga/welcome.md
@@ -41,7 +41,7 @@ Description = "DevOpsDays is coming to Chattanooga for the first time on Novembe
     <strong>Propose</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_link page="propose" text="Propose a talk!" >}}
+    <a href="https://www.papercall.io/devopsdayschattanooga" target="_blank">Propose a talk!</a>
   </div>
 </div>
 


### PR DESCRIPTION
We had some links that weren't properly pointed to PaperCall, this attempts to fix that.