### PR TITLE
[Dallas 2018] Remove "Propose"; link to program & speakers

### DIFF
--- a/content/events/2018-dallas/welcome.md
+++ b/content/events/2018-dallas/welcome.md
@@ -39,30 +39,30 @@ The Leadership Summit will be a workshop that will be delivered by Author, Speak
     {{< event_link page="registration" text="Register to attend the conference!" >}}
   </div>
 </div> -->
-<div class = "row">
+<!-- <div class = "row">
   <div class = "col-md-2">
     <strong>Propose</strong>
   </div>
   <div class = "col-md-8">
     {{< event_link page="propose" text="Propose a talk!" >}}
   </div>
-</div> 
-<!-- <div class = "row">
+</div>   -->
+<div class = "row">
   <div class = "col-md-2">
     <strong>Program</strong>
   </div>
   <div class = "col-md-8">
     View the {{< event_link page="program" text="program." >}}
   </div>
-</div> -->
-<!-- <div class = "row">
+</div>
+<div class = "row">
   <div class = "col-md-2">
     <strong>Speakers</strong>
   </div>
   <div class = "col-md-8">
     Check out the {{< event_link page="speakers" text="speakers!" >}}
   </div>
-</div> -->
+</div>
 <div class = "row">
   <div class = "col-md-2">
     <strong>Sponsors</strong>

--- a/data/events/2018-dallas.yml
+++ b/data/events/2018-dallas.yml
@@ -41,8 +41,6 @@ nav_elements: # List of pages you want to show up in the navigation of your page
     icon: bullhorn
   - name: registration
     icon: "pencil"
-  - name: propose
-    icon: "paper-plane"
   - name: sponsor
     icon: "hand-holding-usd"
   - name: contact


### PR DESCRIPTION
Suggested changes for @MikeRosTX to review - to make sure what's linked is valid. You're no longer accepting proposals, and you may want the program and speakers linked in the welcome page text.