### PR TITLE
[MIN/CHAR 2017/2018] HTTP => HTTPS

### DIFF
--- a/content/events/2017-minneapolis/program/kristen-womack.md
+++ b/content/events/2017-minneapolis/program/kristen-womack.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Logs & Alerts, Not Just for Ops"
 Type = "talk"
 Speakers = ["kristen-womack"]
-pdf = "http://kristenwomack.io/DevOps-Minneapolis-Ignite-2017"
+pdf = "https://kristenwomack.io/DevOps-Minneapolis-Ignite-2017"
 youtube = "hJZEwvoaymI"
 +++
 

--- a/content/events/2018-charlotte/program.md
+++ b/content/events/2018-charlotte/program.md
@@ -4,4 +4,4 @@ Type = "program"
 Description = "Program for devopsdays Charlotte 2018"
 +++
 
-<a id="sched-embed" href="http://devopsdayscharlotte2018.sched.com/">View the DevOpsDays Charlotte 2018 schedule &amp; directory.</a><script type="text/javascript" src="http://devopsdayscharlotte2018.sched.com/js/embed.js"></script>
+<a id="sched-embed" href="https://devopsdayscharlotte2018.sched.com/">View the DevOpsDays Charlotte 2018 schedule &amp; directory.</a><script type="text/javascript" src="https://devopsdayscharlotte2018.sched.com/js/embed.js"></script>


### PR DESCRIPTION
There's two references in these files that cause mixed content issues.
This resolves this issue and removes the warnings that appear in netlify

```
10:49:11 PM: Mixed content detected in: /events/2017-minneapolis/program/kristen-womack/index.html
10:49:11 PM: --> insecure iframe urls:
10:49:11 PM:   - http://kristenwomack.io/DevOps-Minneapolis-Ignite-2017
10:51:46 PM: Mixed content detected in: /events/2018-charlotte/program/index.html
10:51:46 PM: --> insecure script urls:
10:51:46 PM:   - http://devopsdayscharlotte2018.sched.com/js/embed.js
10:55:16 PM: Post processing done
```