### PR TITLE
[Cape Town 2018] Fix speakers alphabetical order

### DIFF
--- a/content/events/2018-cape-town/speakers/karl-fischer.md
+++ b/content/events/2018-cape-town/speakers/karl-fischer.md
@@ -1,8 +1,9 @@
 +++
 Title = "Karl Fischer"
-Twitter = "kmf"
 image = "karl-fischer.jpg"
 type = "speaker"
+twitter = "kmf"
+linktitle = "karl-fischer"
 +++
 
 Linux User since 1999, I love open source and free software, I'm currently DevOps lead at Obsidian Systems, I hate long walks on the beach and I'm happily married with lots of children.

--- a/content/events/2018-cape-town/speakers/marek-denis.md
+++ b/content/events/2018-cape-town/speakers/marek-denis.md
@@ -1,8 +1,9 @@
 +++
 Title = "Marek Denis"
-Twitter = "marekdenis"
 image = "marek-denis.jpg"
 type = "speaker"
+twitter = "marekdenis"
+linktitle = "marek-denis"
 +++
 
 Marek Denis works as a Software/Production Engineer at Facebook. He is currently part of the Active Network Monitoring team, where he spends days (and sometimes nights) designing and implementing systems that can keep up with Facebook’s massive infrastructure and provide clean and actionable signal for network on-calls. His work ranges from implementing modules in Linux kernel up to applying statistical models to find anomalies and outliers in endless streams of samples. Strongly believes in the motto “you can’t improve it if you can’t measure it”. Before joining Facebook he worked for 4 years at CERN in Switzerland as a Research Fellow. He designed and implemented federated identity systems for CERN’s private cloud.

--- a/content/events/2018-cape-town/speakers/ruaan-erasmus.md
+++ b/content/events/2018-cape-town/speakers/ruaan-erasmus.md
@@ -1,8 +1,9 @@
 +++
 Title = "Ruaan Erasmus"
-Twitter = "RErasmus"
 image = "ruaan-erasmus.jpg"
 type = "speaker"
+twitter = "RErasmus"
+linktitle = "ruaan-erasmus"
 +++
 
 Ruaan is a programming professional with more than 12 years’ experience in the software development industry.

--- a/content/events/2018-cape-town/welcome.md
+++ b/content/events/2018-cape-town/welcome.md
@@ -28,6 +28,11 @@ Description = "DevOpsDays Cape Town 2018 will take place September 20-21, 2018!"
               <i class="fa fa-twitter fa-lg"></i>&nbsp;&nbsp;&nbsp;Follow Us On Twitter
             </a>
           </div>
+          <div class = "d-flex p-2">
+            <a class="btn btn-primary btn-block"  style = "margin-top: 10px; margin-bottom: 10px; background-color: #96bfe6; border-color: #96bfe6;" href="https://instagram.com/devopsdayscpt">
+              <i class="fa fa-instagram fa-lg"></i>&nbsp;&nbsp;&nbsp;Follow Us On Instagram
+            </a>
+          </div>
         </div>
       </div>
     </div><!-- end a content element -->

--- a/data/events/2018-cape-town.yml
+++ b/data/events/2018-cape-town.yml
@@ -17,10 +17,10 @@ cfp_date_announce: 2018-06-01
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdayscpt2018"
 
-registration_date_start:
-registration_date_end:
+registration_date_start: 2018-06-01
+registration_date_end: 2018-09-20
 
-registration_closed:
+registration_closed: ""
 registration_link: "https://www.quicket.co.za/events/48403-devopsdays-cape-town-2018/" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 
 coordinates: "-33.935600, 18.457423"


### PR DESCRIPTION
And a few other tweaks.


Apparently if you leave out the `linktitle` by mistake, alphabetical order is lost.