### PR TITLE
[Taipei 2018] Adding more clear link

### DIFF
--- a/data/events/2018-taipei.yml
+++ b/data/events/2018-taipei.yml
@@ -39,7 +39,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: sponsor
   - name: contact
   - name: conduct
-  - name: Taipei
+  - name: devopsdays.tw
     url: https://devopsdays.tw/
 # - name: example
 #   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/


### PR DESCRIPTION
The offsite link in the nav bar should be more explicit (since just the city name alone is also the link back to the "welcome" page).