### PR TITLE
[2018-PDX] Added lunch details and platinum sponsor blurb (for parity with 2017)

### DIFF
--- a/content/events/2018-portland/welcome.md
+++ b/content/events/2018-portland/welcome.md
@@ -84,3 +84,36 @@ Description = "DevOpsDays Portland 2018"
 <!-- Uncomment if you added your city twitter name -->
 
 {{< event_twitter >}}
+
+<hr />
+<h4 class="sponsor-cta">Platinum Sponsor Information:</h4>
+We're pleased to announce [IGNW](http://www.ignw.io) as a platinum sponsor of our conference:
+
+*IGNW’s Dev/Ops, Hybrid IT, App Mod, CI/CD, IaC Automation and SI Practices combine our deep TECHNICAL domain expertise with an insanely powerful ability to execute against your most important business priorities TODAY.  Big name consulting firms dig deep into your business- and dig deep into your budget. Our Agile Practice Area Frameworks get you the business results you need RIGHT NOW without wasting time and resources telling you what you already know. WE build; YOU transform!*
+
+<hr />
+<br />
+<h4 class="sponsor-cta">Lunch Information:</h4>
+<h5>Lunch Location:</h5>
+<a href="/events/2017-portland/pdx2017_food_trucks_map.png"><img width="768" src="/events/2017-portland/pdx2017_food_trucks_map.png" /></a>
+
+<h5>Menu:</h5>
+<ul>
+  <li><b>September 12th:</b></li>
+    <ul>
+      <li><i>Ramy's Lamb Shack:</i> Mediterranean (vegetarian option)</li>
+      <li><i>Home Plate Sliders:</i> American/Burgers (vegetarian option)</li>
+      <li><i>Tamale Boy:</i> Mexican (vegetarian option)</li>
+      <li><i>El Taco Yucateco:</i> Mexican (vegetarian option) (GF option)</li>
+      <li><i>Cafe de Crepe:</i> French (vegetarian option)</li>
+    </ul>
+
+  <li><b>September 13th:</b></li>
+    <ul>
+      <li><i>Ash Wood Fired:</i> Pizza (vegetarian option)</li>
+      <li><i>Bro Dogs and Burgers:</i> American (vegetarian option)</li>
+      <li><i>Polli-Tico:</i> Peruvian (vegetarian option) (GF option)</li>
+      <li><i>El Taco Yucateco:</i> Mexican (vegetarian option) (GF option)</li>
+      <li><i>Cafe de Crepe:</i> French (vegetarian option)</li>
+    </ul>
+</ul>


### PR DESCRIPTION
I'm reusing the 2017 food cart map which is still applicable for 2018 (read: image URL is not a typo).