### PR TITLE
adds more TZ info to event data

### DIFF
--- a/data/events/2018-amsterdam.yml
+++ b/data/events/2018-amsterdam.yml
@@ -6,19 +6,19 @@ description: "devopsdays is coming to Amsterdam!" # Edit this to suit your prefe
 ga_tracking_id: "UA-38891729-3" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2018-01-05
-startdate: 2018-06-27
-enddate: 2018-06-29
+startdate: 2018-06-27T00:00:00+02:00
+enddate: 2018-06-29T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-01-15T00:00:00+01:00  # start accepting talk proposals.
-cfp_date_end:  2018-04-01T00:00:00+02:00 # close your call for proposals.
+cfp_date_end:  2018-04-01T23:59:59+02:00 # close your call for proposals.
 cfp_date_announce: 2018-04-30T00:00:00+02:00 # inform proposers of status
 
 cfp_open: "false"
 # cfp_link: "https://www.papercall.io/dodams2018"
 
-registration_date_start: 2018-01-31 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-06-25 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-01-31T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-06-25T23:59:59+02:00 # close registration. Leave blank if registration is not open yet.
 # registration_closed: "true" #set this to true if you need to manually close registration before your registration end date
 # registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 

--- a/data/events/2018-atlanta.yml
+++ b/data/events/2018-atlanta.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Atlanta!" # Edit this to suit your prefere
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: "2018-04-17" # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  "2018-04-18" # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-04-17T00:00:00-04:00
+enddate: 2018-04-18T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-10-01T00:00:00-04:00

--- a/data/events/2018-austin.yml
+++ b/data/events/2018-austin.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Austin!" # Edit this to suit your preferen
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-05-03 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-05-04 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-05-03T00:00:00-05:00
+enddate: 2018-05-04T23:59:59-05:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-02-26T00:00:00-06:00 # start accepting talk proposals.

--- a/data/events/2018-baltimore.yml
+++ b/data/events/2018-baltimore.yml
@@ -6,19 +6,19 @@ description: "Devopsdays is coming to Baltimore!" # Edit this to suit your prefe
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-03-22
-enddate: 2018-03-23
+startdate: 2018-03-22T00:00:00-04:00
+enddate: 2018-03-23T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2017-12-04 # start accepting talk proposals.
-cfp_date_end: 2018-01-07 # close your call for proposals.
-cfp_date_announce: 2018-01-15 # inform proposers of status
+cfp_date_start: 2017-12-04T00:00:00-05:00 # start accepting talk proposals.
+cfp_date_end: 2018-01-07T23:59:59-05:00 # close your call for proposals.
+cfp_date_announce: 2018-01-15T00:00:00-05:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://devopsdaysbaltimore2018.busyconf.com/proposals/new" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2017-12-04 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-03-24 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2017-12-04T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-03-24T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdaysbaltimore2018.busyconf.com/bookings/new" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-beijing.yml
+++ b/data/events/2018-beijing.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Beijing!" # Edit this to suit your prefere
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-05-04 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-05-05 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-05-04T00:00:00+08:00
+enddate: 2018-05-05T23:59:59+08:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-01-29T00:00:00+08:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-04-15T00:00:00+08:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "http://exinchina.mikecrm.com/xfAu6Qs" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-03-09 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-05-04 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-03-09T00:00:00+08:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-05-04T23:59:59+08:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: false #set this to true if you need to manually close registration before your registration end date
 registration_link: "http://event.31huiyi.com/1281765435/index?c=ibpa" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-bengaluru.yml
+++ b/data/events/2018-bengaluru.yml
@@ -7,8 +7,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 event_group: "Bengaluru"
 
 # All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-12-08 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-12-09 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-12-08T00:00:00+05:30
+enddate: 2018-12-09T23:59:59+05:30
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-10T00:00:00+05:30 # start accepting talk proposals.
@@ -18,8 +18,8 @@ cfp_date_announce: 2018-10-15T00:00:00+05:30 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/dodi18" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-05-10 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-12-08 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-05-10T00:00:00+05:30 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-12-08T23:59:59+05:30 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.townscript.com/e/dodi18" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-berlin.yml
+++ b/data/events/2018-berlin.yml
@@ -6,12 +6,12 @@ description: "DevOpsDays is returning to Berlin, Germany!" # Edit this to suit y
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-12 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-09-13 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-09-12T00:00:00+02:00
+enddate: 2018-09-13T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-01T00:00:00+02:00  # start accepting talk proposals.
-cfp_date_end:  2018-06-30T00:00:00+02:00 # close your call for proposals.
+cfp_date_end:  2018-06-30T23:59:59+02:00 # close your call for proposals.
 cfp_date_announce: 2018-07-15T00:00:00+02:00 # inform proposers of status
 
 cfp_open: "false"

--- a/data/events/2018-boise.yml
+++ b/data/events/2018-boise.yml
@@ -5,11 +5,12 @@ event_twitter: "devopsdaysboise" # The twitter handle for your event, which is o
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-06-06 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-06-06 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate:  2018-06-06T00:00:00-06:00
+enddate: 2018-06-06T23:59:59-06:00
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-02-15T00:00:00-07:00 # start accepting talk proposals.
-cfp_date_end:  2018-04-15T00:00:00-06:00 # close your call for proposals.
+cfp_date_end:  2018-04-15T23:59:59-06:00 # close your call for proposals.
 cfp_date_announce: 2018-04-30T00:00:00-06:00 # inform proposers of status
 
 # Location

--- a/data/events/2018-boston.yml
+++ b/data/events/2018-boston.yml
@@ -5,8 +5,8 @@ event_twitter: "devopsdaysbos" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Boston!" # Edit this to suit your preferences
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-24  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-09-25 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-09-24T00:00:00-04:00
+enddate: 2018-09-25T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-04-02T00:00:00-04:00  # start accepting talk proposals.

--- a/data/events/2018-cairo.yml
+++ b/data/events/2018-cairo.yml
@@ -7,8 +7,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 event_group: ""
 
 # All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-17 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-09-17 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-09-17T00:00:00+02:00
+enddate: 2018-09-17T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-04-24T00:00:00+02:00 # start accepting talk proposals.
@@ -215,4 +215,3 @@ program:
     date: 2018-09-17
     start_time: "17:30"
     end_time: "18:00"
-    

--- a/data/events/2018-cape-town.yml
+++ b/data/events/2018-cape-town.yml
@@ -7,8 +7,8 @@ description: "Devopsdays is coming to Cape Town!"
 ga_tracking_id: "UA-105986234-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-20
-enddate: 2018-09-21
+startdate: 2018-09-20T00:00:00+02:00
+enddate: 2018-09-21T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-06-01T00:00:00+02:00

--- a/data/events/2018-charlotte.yml
+++ b/data/events/2018-charlotte.yml
@@ -6,8 +6,9 @@ description: "Devopsdays is coming back to Charlotte!" # Edit this to suit your 
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-02-22 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-02-23
+startdate:  2018-02-22T00:00:00-05:00
+enddate: 2018-02-23T23:59:59-05:00
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-10-28T00:00:00-04:00 # start accepting talk proposals.
 cfp_date_end:  2017-12-10T00:00:00-05:00 # close your call for proposals.
@@ -16,8 +17,8 @@ cfp_date_announce:  2017-12-15T00:00:00-05:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://papercall.io/dodclt2018" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-10-28 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-02-21 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-10-28T00:00:00-04:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-02-21T23:59:59-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.eventbrite.com/e/devopsdays-charlotte-2018-tickets-38783477425" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-chattanooga.yml
+++ b/data/events/2018-chattanooga.yml
@@ -9,19 +9,19 @@ event_group: "Chattanooga"
 masthead_background: "chattanooga-masthead.jpg"
 
 # All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: "2018-11-13" # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: "2018-11-13" # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-11-13T00:00:00-05:00
+enddate: 2018-11-13T23:59:59-05:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: "2018-08-10"  # start accepting talk proposals.
-cfp_date_end: "2018-09-20" # close your call for proposals.
-cfp_date_announce: "2018-10-04" # inform proposers of status
+cfp_date_start: 2018-08-10T00:00:00-04:00  # start accepting talk proposals.
+cfp_date_end: 2018-09-20T23:59:59-04:00 # close your call for proposals.
+cfp_date_announce: 2018-10-04T00:00:00-04:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdayschattanooga" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: "2018-08-10" # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: "2018-11-12" # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-08-10T00:00:00-04:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-11-12T00:00:00-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://chadevopsdays.ticketspice.com/devopsdays-chattanooga" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-chicago.yml
+++ b/data/events/2018-chicago.yml
@@ -6,8 +6,8 @@ description: "The group that brought you DevOpsDays Chicago 2014-2017 is back to
 ga_tracking_id: "UA-74738648-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-08-28
-enddate: 2018-08-29
+startdate: 2018-08-28T00:00:00-05:00
+enddate: 2018-08-29T23:59:59-05:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-03-19T00:00:00-05:00 # start accepting talk proposals.
@@ -16,8 +16,8 @@ cfp_date_announce: 2018-06-15T00:00:00-05:00  # inform proposers of status
 
 cfp_link: "https://www.papercall.io/devopsdays-chicago-2018" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-03-19  # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-08-28 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-03-19T00:00:00-05:00  # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-08-28T23:59:59-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" # set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdayschi2018.eventbrite.com/?aff=devopsdaysorg" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-columbus.yml
+++ b/data/events/2018-columbus.yml
@@ -7,8 +7,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 event_group: "Columbus"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: "2018-09-19" # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: "2018-09-20" # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-09-19T00:00:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-09-20T23:59:59-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-11T00:00:00-04:00 # start accepting talk proposals.

--- a/data/events/2018-copenhagen.yml
+++ b/data/events/2018-copenhagen.yml
@@ -6,19 +6,19 @@ description: "DevOpsDays is coming to Copenhagen for the first time. Don't miss 
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-04-24 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-04-25 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate:  2018-04-24T00:00:00+02:00
+enddate: 2018-04-25T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2018-01-10T00:00:00+01:00 # start accepting talk proposals.
-cfp_date_end:  2018-02-11T00:00:00+01:00 # close your call for proposals.
+cfp_date_end:  2018-02-11T23:59:59+01:00 # close your call for proposals.
 cfp_date_announce:  2018-02-28T00:00:00+01:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdayscph" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-01-15 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-04-23 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-01-15T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-04-23T23:59:59+02:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.eventbrite.co.uk/e/devops-days-copenhagen-tickets-41996806579" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-dallas.yml
+++ b/data/events/2018-dallas.yml
@@ -6,8 +6,8 @@ description: "The same group of organizers that brought you DevOpsDays DFW 2 yea
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-08-29 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-08-31 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-08-29T00:00:00-05:00
+enddate: 2018-08-31T23:59:59-05:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-06-10T00:00:00-05:00 # start accepting talk proposals.

--- a/data/events/2018-denver.yml
+++ b/data/events/2018-denver.yml
@@ -6,8 +6,8 @@ event_logo: "logo-square.jpg"
 friendly: "2018-denver" # Four digit year and the city name in lower-case. Don't forget the dash!
 status: "current" # Options are "past" or "current".
 
-startdate: 2018-04-17 # The start date of your event, in YYYY-MM-DD format. Leave blank if you don't have a date yet.
-enddate: 2018-04-18 # The end date of your event, in YYYY-MM-DD format. Leave blank if you don't have a date yet.
+startdate: 2018-04-17T00:00:00-06:00
+enddate: 2018-04-18T23:59:59-06:00
 
 cfp_date_start: 2017-12-21T00:00:00-07:00
 cfp_date_end: 2018-02-28T23:59:59-07:00

--- a/data/events/2018-des-moines.yml
+++ b/data/events/2018-des-moines.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Des Moines!" # Edit this to suit your pref
 ga_tracking_id: "UA-100057712-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-04-12 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-04-13 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-04-12T00:00:00-05:00
+enddate: 2018-04-13T23:59:59-05:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-11-06T00:00:00-06:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-02-15T00:00:00-06:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdaysdesmoines"
 
-registration_date_start: 2017-12-01 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-04-01 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2017-12-01T00:00:00-06:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-04-01T23:59:59-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.eventbrite.com/e/devopsdays-des-moines-tickets-39855883019" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-detroit.yml
+++ b/data/events/2018-detroit.yml
@@ -7,8 +7,9 @@ status: "current"
 ga_tracking_id: "UA-94092408-1" # Google Analytics tracking ID
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-10-03
-enddate:  2018-10-04
+startdate:  2018-10-03T00:00:00-04:00
+enddate: 2018-10-04T23:59:59-04:00
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-23T00:00:00-04:00  # start accepting talk proposals.
 cfp_date_end: 2018-08-06T23:59:59-04:00 # close your call for proposals.

--- a/data/events/2018-edinburgh.yml
+++ b/data/events/2018-edinburgh.yml
@@ -6,19 +6,19 @@ description: "Devopsdays is coming back to Edinburgh in 2018!" # Edit this to su
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-11-01  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-11-02 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-11-01T00:00:00+00:00
+enddate: 2018-11-02T23:59:59+00:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-07T00:00:00+01:00 # start accepting talk proposals.
-cfp_date_end:  2018-08-12T00:00:00+01:00 # close your call for proposals.
+cfp_date_end:  2018-08-12T23:59:59+01:00 # close your call for proposals.
 cfp_date_announce:  2018-09-16T00:00:00+01:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-04-11 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-10-31 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-04-11T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-10-31T23:59:59+01:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "false" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-hartford.yml
+++ b/data/events/2018-hartford.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Hartford!" # Edit this to suit your prefer
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-16  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-17  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-10-16T00:00:00-04:00
+enddate: 2018-10-17T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-21T00:00:00-04:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-08-17T00:00:00-04:00  # inform proposers of status
 cfp_open: "true"
 # cfp_link: "https://dodhart2018.busyconf.com/proposals/new" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-05-21 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-10-15 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-05-21T00:00:00-04:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-10-15T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 # registration_link: "https://dodhart2018.busyconf.com/bookings/new" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-indianapolis.yml
+++ b/data/events/2018-indianapolis.yml
@@ -7,8 +7,8 @@ description: "DevOpsDays is coming to Indianapolis!" # Edit this to suit your pr
 ga_tracking_id: "UA-109430778-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-07-23
-enddate: 2018-07-24
+startdate: 2018-07-23T00:00:00-04:00
+enddate: 2018-07-24T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-11-09T00:00:00-05:00 # start accepting talk proposals.
@@ -18,8 +18,8 @@ cfp_date_announce: 2017-11-09T00:00:00-05:00 # inform proposers of status
 cfp_open: "false"
 cfp_link: "https://www.papercall.io/devopsdaysindy" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: "2017-11-09" # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: "2018-07-24" # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2017-11-09T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-07-24T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdaysindy.eventbrite.com/?aff=devopsdays" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-istanbul.yml
+++ b/data/events/2018-istanbul.yml
@@ -6,8 +6,8 @@ description: "DevOpsDays is coming to Istanbul!" # Edit this to suit your prefer
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-20 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-09-20 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-09-20T00:00:00+03:00
+enddate: 2018-09-20T23:59:59+03:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2018-01-24T00:00:00+03:00 # start accepting talk proposals.

--- a/data/events/2018-jakarta.yml
+++ b/data/events/2018-jakarta.yml
@@ -6,19 +6,19 @@ description: "Devopsdays is coming to Jakarta!" # Edit this to suit your prefere
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-04-26
-enddate: 2018-04-27
+startdate: 2018-04-26T00:00:00+07:00
+enddate: 2018-04-27T23:59:59+07:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2017-12-20T00:00:00+07:00
-cfp_date_end:  2018-02-15T00:00:00+07:00
+cfp_date_end:  2018-02-15T23:59:59+07:00
 cfp_date_announce: 2018-02-20T00:00:00+07:00
 
 cfp_open: "false"
 #  "https://goo.gl/forms/RlTj5bavs6MxtZmr1" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2017-12-20 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-02-27 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2017-12-20T00:00:00+07:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-02-27T23:59:59+07:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "true" #set this to true if you need to manually close registration before your registration end date
 # registration_link: "https://www.eventbrite.com/e/devopsdays-jakarta-tickets-42226649044" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-kansas-city.yml
+++ b/data/events/2018-kansas-city.yml
@@ -6,19 +6,19 @@ description: "Devopsdays is coming back to Kansas City!" # Edit this to suit you
 ga_tracking_id: "UA-93890142-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-17 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-18 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-10-17T00:00:00-05:00
+enddate: 2018-10-18T23:59:59-05:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2018-03-20T00:00:00-05:00 # start accepting talk proposals.
-cfp_date_end:  2018-06-17T00:00:00-05:00 # close your call for proposals.
+cfp_date_end:  2018-06-17T23:59:59-05:00 # close your call for proposals.
 cfp_date_announce:  2018-03-20T00:00:00-05:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "http://cfp.devopsdayskc.org/" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-03-20 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-10-18 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-03-20T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-10-18T23:59:59-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdayskc.eventbrite.com" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
@@ -199,7 +199,6 @@ sponsors:
     level: premium
   - id: newrelic
     level: amenity
-    
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.

--- a/data/events/2018-kazan.yml
+++ b/data/events/2018-kazan.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Kazan!" # Edit this to suit your preferenc
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-14  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-09-15 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-09-14T00:00:00+02:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-09-15T23:59:59+02:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2018-kiel.yml
+++ b/data/events/2018-kiel.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Kiel!" # Edit this to suit your preference
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-05-16  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-05-17  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-05-16T00:00:00+02:00
+enddate: 2018-05-17T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-10-02T00:00:00+02:00 # start accepting talk proposals.
@@ -331,24 +331,3 @@ ignites:
     date: 2018-05-16
   - title: "axel-giernas"
     date: 2018-05-17
-      
-  
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-
-
-    
-    
-
-    
-                                                                                                      

--- a/data/events/2018-kiev.yml
+++ b/data/events/2018-kiev.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Kiev!" # Edit this to suit your preference
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-05-05 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-05-05 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-05-05T00:00:00+03:00
+enddate: 2018-05-05T23:59:59+03:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-12-01T00:00:00+02:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce:  # inform proposers of status
 cfp_open: "false"
 cfp_link: "https://goo.gl/forms/yrdB4jKfG6tgScFl1" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-01-01 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-05-05 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-01-01T00:00:00+02:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-05-05T23:59:59+03:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://2event.com/ru/events/1328005" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-london.yml
+++ b/data/events/2018-london.yml
@@ -5,9 +5,9 @@ event_twitter: "DevOpsDaysLDN" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming to London!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-20  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:   2018-09-21  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-09-20T00:00:00+01:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:   2018-09-21T00:00:00+01:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2018-04-27T00:00:00+01:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-07-01T00:00:00+01:00 # inform proposers of status
 cfp_open: "false"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-05-22 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-09-19 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-05-22T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-09-19T23:59:59+01:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-los-angeles.yml
+++ b/data/events/2018-los-angeles.yml
@@ -4,9 +4,9 @@ city: "Los Angeles" # The displayed city name of the event. Capitalize it.
 description: "DevOpsDays is returning to Southern California in 2018" # A short blurb of text to describe your event, defaults to common DevOpsDays description
 event_group: "Los Angeles"
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-03-09 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-03-09 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate:  2018-03-09T00:00:00-08:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-03-09T23:59:59-08:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-01-10T00:00:00-08:00  # start accepting talk proposals.
 cfp_date_end: 2018-02-15T23:59:59-08:00 # close your call for proposals.

--- a/data/events/2018-maringa.yml
+++ b/data/events/2018-maringa.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdays" # Change this to the twitter handle for your event s
 description: "Devopsdays is coming to Maringá!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-03-23 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-03-24 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-03-23T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-03-24T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-01-01T00:00:00-05:00  # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-01-24T00:00:00-05:00  # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://docs.google.com/forms/d/e/1FAIpQLSfKDLLrTseEa2j4S4Pn9KI7Jj8fweYio_T6ixElUPK3kwTFxA/viewform?usp=send_form" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-01-01 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-03-24 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-01-01T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-03-24T23:59:59-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.eventbrite.com/e/devopsdays-maringa-tickets-42271081944" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-minneapolis.yml
+++ b/data/events/2018-minneapolis.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdaysmsp" # Change this to the twitter handle for your even
 description: "devopsdays returned to Minneapolis for a fifth year!"
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-07-12  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-07-13  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-07-12T00:00:00-05:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-07-13T23:59:59-05:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 cfp_date_start: 2017-11-08T00:00:00-06:00
 cfp_date_end: 2018-04-08T23:59:59-05:00
@@ -16,8 +16,8 @@ cfp_date_announce: 2018-05-06T00:00:00-05:00
 cfp_open: "false"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2017-11-08
-registration_date_end: 2018-07-06
+registration_date_start: 2017-11-08T00:00:00-06:00
+registration_date_end: 2018-07-06T23:59:59-05:00
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-montreal.yml
+++ b/data/events/2018-montreal.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsmontreal" # Change this to the twitter handle for your eve
 description: "devopsdays is coming to Montreal! / devopsdays arrive en ville!" # Edit this to suit your preferences
 ga_tracking_id: "UA-118473645-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-10 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-11 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-10-10T00:00:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-10-11T23:59:59-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-04-26T00:00:00-04:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-07-16T00:00:00-04:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdays-mtl-2018" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-05-18 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-10-10 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-05-18T00:00:00-04:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-10-10T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.eventbrite.ca/e/devops-day-montreal-2018-tickets-45899626017" # valid link, not ok yet. 2018-05-09

--- a/data/events/2018-moscow.yml
+++ b/data/events/2018-moscow.yml
@@ -5,9 +5,9 @@ event_twitter: "DevOpsDaysMSK" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Moscow!" # Edit this to suit your preferences
 #ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-06-16 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-06-16 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-06-16T00:00:00+03:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-06-16T23:59:59+03:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-04-02T00:00:00+03:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-06-01T00:00:00+03:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://goo.gl/forms/TYweAvJEEZ8zpPVG2" # if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-04-02 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-06-15 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-04-02T00:00:00+03:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-06-15T23:59:59+03:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdays.timepad.ru/event/663105/" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-new-york-city.yml
+++ b/data/events/2018-new-york-city.yml
@@ -7,9 +7,9 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 event_group: "New York City"
 speakers_verbose: "true"
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate:  "2018-01-18" # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  "2018-01-19" # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate:  2018-01-18T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-01-19T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2017-10-12T00:00:00-04:00 # start accepting talk proposals.

--- a/data/events/2018-newcastle.yml
+++ b/data/events/2018-newcastle.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdaysnewy" # Change this to the twitter handle for your eve
 description: "Devopsdays is coming to Newcastle! (Australia)" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-24 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-25 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-10-24T00:00:00+11:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2018-10-25T23:59:59+11:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-07-16 # start accepting talk proposals.

--- a/data/events/2018-oslo.yml
+++ b/data/events/2018-oslo.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdaysoslo" # Change this to the twitter handle for your eve
 description: "Devopsdays is coming to Oslo!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-29 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-30  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-10-29T00:00:00+02:00
+enddate: 2018-10-30T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-04-16T00:00:00+02:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-09-16T00:00:00+02:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://sessionize.com/devopsdays-oslo-2018" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-09-06 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-10-29 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-09-06T00:00:00+02:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-10-29T23:59:59+02:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdays-oslo.eventbrite.com/?aff=webpage" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-paris.yml
+++ b/data/events/2018-paris.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsrex" # Change this to the twitter handle for your event su
 description: "La conférence devops 100% retour d’expérience" # Edit this to suit your preferences
 ga_tracking_id: "UA-81620980-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-16 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-16 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-10-16T00:00:00+02:00
+enddate: 2018-10-16T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-04-02T00:00:00+02:00 # start accepting talk proposals.

--- a/data/events/2018-philadelphia.yml
+++ b/data/events/2018-philadelphia.yml
@@ -5,9 +5,9 @@ event_twitter: "DevOpsDaysPHL" # Change this to the twitter handle for your even
 description: # Edit this to suit your preferences
 ga_tracking_id: "UA-61551732-3" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-23 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-24 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-10-23T00:00:00-04:00
+enddate: 2018-10-24T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-14T00:00:00-04:00  # start accepting talk proposals.

--- a/data/events/2018-phoenix.yml
+++ b/data/events/2018-phoenix.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdaysphx" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Phoenix!" # Edit this to suit your preferences
 ga_tracking_id: "UA-122312566-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-23 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-23  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00#
+startdate: 2018-10-23T00:00:00-07:00
+enddate: 2018-10-23T23:59:59-07:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 #cfp_date_start: 2018-07-01 # start accepting talk proposals.

--- a/data/events/2018-portland.yml
+++ b/data/events/2018-portland.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdayspdx" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming to Portland!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-11 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-09-13 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-09-11T00:00:00-07:00
+enddate: 2018-09-13T23:59:59-07:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-02-15T00:00:00-08:00 # start accepting talk proposals.

--- a/data/events/2018-porto-alegre.yml
+++ b/data/events/2018-porto-alegre.yml
@@ -5,9 +5,9 @@ event_twitter: "poadevopsday" # Change this to the twitter handle for your event
 description: "a vida é muito curta pra trabalho manual"
 ga_tracking_id: "UA-85374985-2" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate: "2018-09-15"
-enddate: "2018-09-15"
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00#
+startdate: 2018-09-15T00:00:00-03:00
+enddate: 2018-09-15T23:59:59-03:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-04-07T00:00:00-03:00

--- a/data/events/2018-raleigh.yml
+++ b/data/events/2018-raleigh.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdaysrdu" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Raleigh!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-09-10 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-09-11 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-09-10T00:00:00-04:00
+enddate: 2018-09-11T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-01-01T00:00:00-05:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-05-15T00:00:00-04:00  # inform proposers of status
 cfp_open: "false"
 cfp_link: "https://goo.gl/forms/2UpFilKPOswrHcqp2"
 
-registration_date_start: 2018-01-24
-registration_date_end: 2018-09-11
+registration_date_start: 2018-01-24T00:00:00-05:00
+registration_date_end: 2018-09-11T23:59:59-04:00
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.eventbrite.com/e/devops-days-raleigh-2018-tickets-42510017607" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-riga.yml
+++ b/data/events/2018-riga.yml
@@ -9,9 +9,9 @@ ga_tracking_id: UA-105774008-1
 #The image, relative to static/events/YYYY-CITY that you want to be the background of the header on your page.
 masthead_background: "riga-cover-2018-medium.png"
 
-# All dates are in unquoted 2017-MM-DD, like this: variable: 2016-01-05
-startdate:  2018-09-27
-enddate:  2018-09-28
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate:  2018-09-27T00:00:00+03:00
+enddate: 2018-09-28T23:59:59+03:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-03-07T00:00:00+03:00  # start accepting talk proposals.
@@ -20,8 +20,8 @@ cfp_date_announce: 2018-08-17T00:00:00+03:00 # inform proposers of status
 #cfp_link: "https://www.papercall.io/devopsdays-riga-2018"
 
 # Registration dates
-#registration_date_start: YYYY-MM-DD
-#registration_date_end: YYYY-MM-DD
+#registration_date_start: YYYY-MM-DDTHH:MM:SS+TZ:TZ
+#registration_date_end: YYYY-MM-DDTHH:MM:SS+TZ:TZ
 #registration_closed: "false"
 #registration_link: ""
 

--- a/data/events/2018-saint-louis.yml
+++ b/data/events/2018-saint-louis.yml
@@ -4,7 +4,7 @@ city: "Saint Louis" # The displayed city name of the event. Capitalize it.
 status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: "DevOpsDays is coming to Saint Louis in 2018! It'll be a great opportunity to share knowledge, socialize, and have fun with other members of our great technical community." # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2018-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:    # The end date of your event. Leave blank if you don't have a venue reserved yet.
 # Leave CFP dates blank if you don't know yet, or set all three at once.

--- a/data/events/2018-salt-lake-city.yml
+++ b/data/events/2018-salt-lake-city.yml
@@ -6,9 +6,9 @@ event_logo: "logo-square.jpg"
 description: "Devopsdays is returning to Salt Lake City!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-05-15
-enddate: 2018-05-16 
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-05-15T00:00:00-06:00
+enddate: 2018-05-16T23:59:59-06:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-11-03T00:00:00-06:00
@@ -18,8 +18,8 @@ cfp_date_announce: 2018-03-01T00:00:00-07:00
 cfp_open: "false"
 cfp_link: "https://www.papercall.io/slcdevops2018" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-02-10 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-05-15 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-02-10T00:00:00-07:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-05-15T23:59:59-06:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.slcdevopsdays.org/purchase-tickets/" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-salvador.yml
+++ b/data/events/2018-salvador.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to Salvador!" # Edit this to suit your prefer
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: "2018-10-27" # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  "2018-10-27" # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-10-27T00:00:00-06:00
+enddate: 2018-10-27T23:59:59-06:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: "2018-07-16"  # start accepting talk proposals.
@@ -73,7 +73,7 @@ proposal_email: "organizers-salvador-2018@devopsdays.org" # Put your proposal em
 sponsors:
   - id: samplesponsorname
     level: gold
- #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.   
+ #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
   - id: arresteddevops
     level: community
 

--- a/data/events/2018-santa-maria.yml
+++ b/data/events/2018-santa-maria.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdays" # Change this to the twitter handle for your event s
 description: "Devopsdays is coming to santa maria!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: "2018-08-04" # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: "2018-08-04" # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-08-04T00:00:00-03:00
+enddate: 2018-08-04T23:59:59-03:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-19T00:00:00-03:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-07-09T00:00:00-03:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "/events/2018-santa-maria/cfp" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: "2018-05-12" # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: "2018-08-03" # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-05-12T00:00:00-03:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-08-03T23:59:59-03:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://polvotickets.com.br/e/devopsday-sm" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-sao-paulo.yml
+++ b/data/events/2018-sao-paulo.yml
@@ -5,9 +5,9 @@ event_twitter: "sp_devopsdays" # Change this to the twitter handle for your even
 description: "Devopsdays está chegando em São Paulo!" # Edit this to suit your preferences
 ga_tracking_id: "UA-36355678-5" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-06-06 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-06-07 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-06-06T00:00:00-03:00
+enddate: 2018-06-07T23:59:59-03:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-02-14T00:00:00-02:00 # start accepting talk proposals.
@@ -17,8 +17,8 @@ cfp_date_announce: 2018-04-09T00:00:00-03:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-03-01 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-05-31 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-03-01T00:00:00-03:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-05-31T23:59:59-03:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-seattle.yml
+++ b/data/events/2018-seattle.yml
@@ -5,9 +5,9 @@ event_twitter: "DevOpsDaysSEA" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming to Seattle!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-04-24 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-04-25 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-04-24T00:00:00-07:00
+enddate: 2018-04-25T23:59:59-07:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-10-09T00:00:00-07:00  # start accepting talk proposals.

--- a/data/events/2018-shanghai.yml
+++ b/data/events/2018-shanghai.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdays" # Change this to the twitter handle for your event s
 description: "Devopsdays is coming to Shanghai!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-08-18 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-08-19  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-08-18T00:00:00+08:00
+enddate: 2018-08-19T23:59:59+08:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-05-18T00:00:00+08:00 # start accepting talk proposals.

--- a/data/events/2018-shenzhen.yml
+++ b/data/events/2018-shenzhen.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdays" # Change this to the twitter handle for your event s
 description: "Devopsdays is coming to Shenzhen!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-11-16 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-11-17  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-11-16T00:00:00+08:00
+enddate: 2018-11-17T23:59:59+08:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2018-silicon-valley.yml
+++ b/data/events/2018-silicon-valley.yml
@@ -6,9 +6,9 @@ description: "Devopsdays is coming to Silicon Valley!" # Edit this to suit your 
 ga_tracking_id: "UA-74608411-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: "Silicon Valley"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-05-17  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-05-18  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-05-17T00:00:00-07:00
+enddate: 2018-05-18T23:59:59-07:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-01-08T00:00:00-08:00  # start accepting talk proposals.
@@ -18,8 +18,8 @@ cfp_date_announce: 2018-02-16T00:00:00-08:00 # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://dodsv2018.busyconf.com/proposals/new" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-01-08 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-05-17 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-01-08T00:00:00-08:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-05-17T23:59:59-07:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://dodsv2018.busyconf.com/bookings/new" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2018-singapore.yml
+++ b/data/events/2018-singapore.yml
@@ -5,9 +5,9 @@ event_twitter: "devopsdaysSG"
 description: "devopsdays is returning to Singapore for a 4th year!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-10-11 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-10-12 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate: 2018-10-11T00:00:00+08:00
+enddate: 2018-10-12T23:59:59+08:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-07-05  # start accepting talk proposals.
@@ -284,4 +284,3 @@ program:
     date: 2018-10-12
     start_time: "16:45"
     end_time: "17:00"
-

--- a/data/events/2018-stockholm.yml
+++ b/data/events/2018-stockholm.yml
@@ -5,7 +5,7 @@ event_twitter: "devopsdayssthlm" # Change this to the twitter handle for your ev
 description: "Devopsdays is coming back to Stockholm!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
@@ -98,4 +98,3 @@ sponsor_levels:
     label: Space Gray
   - id: community
     label: Community
-

--- a/data/events/2018-taipei.yml
+++ b/data/events/2018-taipei.yml
@@ -5,9 +5,9 @@ event_twitter: "DevOpsDaysTPE" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Taipei!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-09-10 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-09-12 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate:  2018-09-10T00:00:00+08:00
+enddate: 2018-09-12T23:59:59+08:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2018-tel-aviv.yml
+++ b/data/events/2018-tel-aviv.yml
@@ -5,9 +5,9 @@ event_twitter: "DevOpsDaysTLV" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Tel Aviv!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-12-18
-enddate:  2018-12-19
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+startdate:  2018-12-18T00:00:00+02:00
+enddate: 2018-12-19T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2018-07-01

--- a/data/events/2018-tokyo.yml
+++ b/data/events/2018-tokyo.yml
@@ -3,9 +3,9 @@ year: "2018" # The year of the event. Make sure it is in quotes.
 city: "Tokyo" # The displayed city name of the event. Capitalize it.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-04-24 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-04-25 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted 2017-MM-DDTHH:MM:SS-TZ:TZ, like this:   variable: 2016-01-05T00:00:00-09:00
+startdate: 2018-04-24T00:00:00-09:00
+enddate: 2018-04-25T23:59:59-09:00
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:   # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.

--- a/data/events/2018-toronto.yml
+++ b/data/events/2018-toronto.yml
@@ -6,19 +6,19 @@ description: "Be part of the fifth devopsdays Toronto!" # Edit this to suit your
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-05-30 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-05-31 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate:  2018-05-30T00:00:00-04:00
+enddate: 2018-05-31T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2017-12-01T00:00:00-05:00 # start accepting talk proposals.
-cfp_date_end:  2018-02-02T00:00:00-05:00 # close your call for proposals.
+cfp_date_end:  2018-02-02T23:59:59-05:00 # close your call for proposals.
 cfp_date_announce:  2018-02-23T00:00:00-05:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://www.papercall.io/2018-toronto" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-01-01 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-05-29 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-01-01T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-05-29T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
@@ -369,4 +369,3 @@ ignites:
     date: 2018-05-31
   - title: "matty-stratton"
     date: 2018-05-31
-

--- a/data/events/2018-vancouver.yml
+++ b/data/events/2018-vancouver.yml
@@ -5,12 +5,12 @@ event_twitter: "devopsdaysyvr"
 status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: "devopsdays is an inclusive, self-organizing conference for anyone interested in DevOps practices." # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate:  2018-04-20 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-04-21 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate:  2018-04-20T00:00:00-07:00
+enddate: 2018-04-21T23:59:59-07:00
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-01-03T00:00:00-08:00 # start accepting talk proposals.
-cfp_date_end:  2018-02-26T00:00:00-08:00 # close your call for proposals.
+cfp_date_end:  2018-02-26T23:59:59-08:00 # close your call for proposals.
 cfp_date_announce: 2018-03-05T00:00-08:00 # inform proposers of status
 cfp_link: "https://www.papercall.io/devopsdays-vancouver-2018"
 registration_open: "true"

--- a/data/events/2018-victoria.yml
+++ b/data/events/2018-victoria.yml
@@ -5,9 +5,8 @@ event_twitter: "devopsdaysyyj" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Victoria, Canada!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-05-25 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2018-05-25 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-05-25T00:00:00-07:00
+enddate: 2018-05-25T23:59:59-07:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-02-01T00:00:00-08:00 # start accepting talk proposals.
@@ -17,8 +16,8 @@ cfp_date_announce: 2018-04-12T00:00:00-07:00  # inform proposers of status
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdays-victoria" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-04-04 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2018-05-10 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-04-04T00:00:00-07:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2018-05-10T23:59:59-07:00 # close registration. Leave blank if registration is not open yet.
 registration_open: "true"
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
@@ -209,4 +208,3 @@ program:
     start_time: "5:30"
     end_time: "9:00"
     background_color: "#BDBDBD"
-

--- a/data/events/2018-warsaw.yml
+++ b/data/events/2018-warsaw.yml
@@ -3,9 +3,9 @@ year: "2018" # The year of the event. Make sure it is in quotes.
 city: "Warsaw" # The city name of the event. Capitalize it.
 friendly: "2018-warsaw" # Four digit year and the city name in lower-case. Don't forget the dash!
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2017-01-05
-startdate: 2018-11-19 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-11-20 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-11-19T00:00:00+01:00
+enddate: 2018-11-20T23:59:59+01:00
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-04-21T00:00:00+02:00 # start accepting talk proposals.
 cfp_date_end: 2018-09-30T23:59:59+02:00 # close your call for proposals.

--- a/data/events/2018-washington-dc.yml
+++ b/data/events/2018-washington-dc.yml
@@ -5,19 +5,19 @@ event_twitter: "devopsdaysdc"
 description: "A house divided against itself cannot stand."
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-startdate:  2018-06-06
-enddate:  2018-06-07
+startdate:  2018-06-06T00:00:00-04:00
+enddate: 2018-06-07T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2018-03-09T00:00:00-05:00
-cfp_date_end:  2018-04-15T00:00:00-04:00
+cfp_date_end:  2018-04-15T23:59:59-04:00
 cfp_date_announce:  2018-04-22T00:00:00-04:00
 
 cfp_open: "false"
 cfp_link: "https://devopsdaysdc2018.busyconf.com/proposals/new"
 
-registration_date_start: 2018-03-09
-registration_date_end: 2018-06-08
+registration_date_start: 2018-03-09T00:00:00-05:00
+registration_date_end: 2018-06-08T23:59:59-04:00
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdaysdc2018.busyconf.com/bookings/new"

--- a/data/events/2018-wellington.yml
+++ b/data/events/2018-wellington.yml
@@ -7,8 +7,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 event_group: "New Zealand"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-11-05 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2018-11-06 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2018-11-05T00:00:00+13:00
+enddate: 2018-11-06T23:59:59+13:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-06-16T00:00:00+12:00 # start accepting talk proposals.
@@ -122,4 +122,3 @@ sponsor_levels:
     label: Gold
   - id: silver
     label: Silver
-

--- a/data/events/2018-zurich.yml
+++ b/data/events/2018-zurich.yml
@@ -4,8 +4,8 @@ city: "Zürich" # The city name of the event. Capitalize it.
 event_twitter: "DevOpsZH"
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate: 2018-05-02
-enddate: 2018-05-03
+startdate: 2018-05-02T00:00:00+02:00
+enddate: 2018-05-03T23:59:59+02:00
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2017-10-01T00:00:00+02:00 # start accepting talk proposals.
 cfp_date_end: 2018-01-31T23:59:59+01:00 # close your call for proposals.


### PR DESCRIPTION
This PR continues the work discussed in https://github.com/devopsdays/devopsdays-web/pull/5213#issuecomment-416575633 by adding more TZ data:

@tgross wrote:
> Yeah, just to avoid a bunch of rework I'll hold off on making that data fix until the theme update gets deployed. But once that's been done I'll knock that out.

This adds all the stashed changes I had, after reconciling with the changes to events merged in since then. It only covers events from 2018 and not historical events. cc @bridgetkromhout 