### PR TITLE
[BOS-2018] managed to add ca wrong

### DIFF
--- a/data/events/2018-boston.yml
+++ b/data/events/2018-boston.yml
@@ -191,7 +191,7 @@ sponsors:
   - id: cloudbees
     level: gold
   - id: ca
-    level: evening
+    level: alacarte
   - id: launch-darkly
     level: alacarte
   - id: genians


### PR DESCRIPTION
added the sponsor, but added them to a group that didn't exist, rather than alacarte