### PR TITLE
[LDN-2018] Last minute sponsor and custom url

### DIFF
--- a/data/events/2018-london.yml
+++ b/data/events/2018-london.yml
@@ -111,6 +111,8 @@ sponsors:
     level: silver
   - id: scalefactory
     level: silver
+  - id: sensu
+    level: silver
   - id: ticketmaster
     level: silver
   - id: which
@@ -232,6 +234,7 @@ program:
     date: 2018-09-20
     start_time: "19:00"
     end_time: "23:00"
+    custom_url: "https://www.altitudelondon.com/contact-us/"
 
 # # day 2
   - title: "Breakfast"


### PR DESCRIPTION
I needed to add a last minute sponsor (Sensu) to the site along with a
custom URL for our event event location, so those people who aren't
being led down there can find it on google maps and stuff.