### PR TITLE
[Cape-Town-2018] Temporary notice on 2017 welcome page

### DIFF
--- a/content/events/2017-cape-town/welcome.md
+++ b/content/events/2017-cape-town/welcome.md
@@ -7,6 +7,12 @@ Description = "DevOpsDays is coming back to Cape Town! Tickets on sale now."
 
 +++
 
+<h1 style="text-align: center;">
+<br>Looking for the topic suggestions for 2018?<br>
+Sorry, we made a mistake in our mail.<br>
+Go here ---> <a href="http://bit.ly/dodcpt18topic">2018 Open Spaces Topic Suggestions</a><br><br>
+</h1>
+
 <div style="text-align:center;">
   {{< event_logo >}}
 </div>


### PR DESCRIPTION
Add a temporary notice to our 2017 event welcome page, due to a paste error in a sent Mailchimp campaign.