### PR TITLE
[WLG-2018] Remove Mrinal Mukherjee as organiser

### DIFF
--- a/data/events/2018-wellington.yml
+++ b/data/events/2018-wellington.yml
@@ -68,8 +68,6 @@ team_members: # Name is the only required field for team members.
     twitter: "_yogi_7"
   - name: "BMK"
     twitter: "lbmkrishna"
-  - name: "Mrinal Mukherjee"
-    twitter: "mukherjee_mk"
   - name: "Adriano Bastos"
     twitter: "aaobastos"
   - name: "Judy Marcelo"


### PR DESCRIPTION
Mrinal is stepping into a speaker role this year.
