### PR TITLE
[GAL-2018] Add Google as a sponsor

### DIFF
--- a/data/events/2018-galway.yml
+++ b/data/events/2018-galway.yml
@@ -171,6 +171,8 @@ sponsors:
     level: silver
   - id: smartbear
     level: silver
+  - id: googlecloud
+    level: silver
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Add Google as a silver sponsor for Devopsdays Galway 2018

