### PR TITLE
2018-montreal: Fix schedule timing

### DIFF
--- a/data/events/2018-montreal.yml
+++ b/data/events/2018-montreal.yml
@@ -200,12 +200,12 @@ program:
     type: talk
     date: 2018-10-10
     start_time: "11:50"
-    end_time: "12:12"
+    end_time: "12:30"
 
   - title: "Lunch"
     type: break
     date: 2018-10-10
-    start_time: "12:12"
+    start_time: "12:30"
     end_time: "13:40"
     background_color: "#ff8282"
 


### PR DESCRIPTION
This entry was put in as an inside joke, but we should probably update
it so attendees see the right time =D


*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2018] Add Bluth Company as a sponsor`*