### PR TITLE
[2018-FLO] Correct mixed content

### DIFF
--- a/content/events/2018-florianopolis/location.md
+++ b/content/events/2018-florianopolis/location.md
@@ -6,7 +6,7 @@ Description = "Location for Devopsdays Florianópolis 2018"
 
 ## Auditório da Softplan
 
-![alt text](http://2.bp.blogspot.com/-iheMfVGjYGM/UPaio7dNJ-I/AAAAAAAAAfA/7nz-2ojpGsI/s1600/CamExterna+-cam+01.jpg "Softplan")
+![alt text](https://2.bp.blogspot.com/-iheMfVGjYGM/UPaio7dNJ-I/AAAAAAAAAfA/7nz-2ojpGsI/s1600/CamExterna+-cam+01.jpg "Softplan")
 
 *Sapiens Parque - Av. Luiz Boiteux Piazza, 1302 - Cachoeira do Bom Jesus, Florianópolis - SC, 88056-000*
 


### PR DESCRIPTION
Netlify is complaining about mixed content on this page:
```
4:55:02 PM: Mixed content detected in: /events/2018-florianopolis/location/index.html
4:55:02 PM: --> insecure img urls:
4:55:02 PM:   - http://2.bp.blogspot.com/-iheMfVGjYGM/UPaio7dNJ-I/AAAAAAAAAfA/7nz-2ojpGsI/s1600/CamExterna+-cam+01.jpg
4:55:02 PM:   - http://2.bp.blogspot.com/-iheMfVGjYGM/UPaio7dNJ-I/AAAAAAAAAfA/7nz-2ojpGsI/s1600/CamExterna+-cam+01.jpg 1x, http://2.bp.blogspot.com/-iheMfVGjYGM/UPaio7dNJ-I/AAAAAAAAAfA/7nz-2ojpGsI/s1600/CamExterna+-cam+01@2x.jpg 2x
```

Note to the maintainers that I'm not one of the organisers of this event so apologies if this confuses anyone/causes any problems.


Signed-off-by: Chris M <millscj01@gmail.com>
