### PR TITLE
[NYC-2019] Adjust welcome.md's above/below the fold placement

### DIFF
--- a/content/events/2019-new-york-city/welcome.md
+++ b/content/events/2019-new-york-city/welcome.md
@@ -5,10 +5,6 @@ aliases = ["/events/2019-new-york-city/"]
 Description = "devopsdays New York City 2019"
 +++
 
-<div style="text-align:center;">
-  {{< event_logo >}}
-</div>
-
 <div class = "row">
   <div class = "col-md-2">
     <strong>Dates</strong>
@@ -83,3 +79,7 @@ Description = "devopsdays New York City 2019"
 
 
 {{< event_twitter >}}
+
+<div style="text-align:center;">
+  {{< event_logo >}}
+</div>


### PR DESCRIPTION
The bullet list of Dates, Sponsors, etc. should be "above the fold".  Moving the NYC logo lower so that the most important content is no longer obscured.