### PR TITLE
[NYC-2019] Remove Mani Soundararajan

### DIFF
--- a/data/events/2019-new-york-city.yml
+++ b/data/events/2019-new-york-city.yml
@@ -104,7 +104,6 @@ team_members: # Name is the only required field for team members.
     employer: "Contino"
     twitter: "shahadarsh"
     linkedin: "https://www.linkedin.com/in/adarsh-shah"
-  - name: "Mani Soundararajan"
   - name: "Tom Reingold"
   - name: "Stephen Thomas"
     employer: "iconectiv"


### PR DESCRIPTION
Mani has moved out of the area and will no longer be an organizer for NYC-2019.