### PR TITLE
[Chattanooga 2018] Remove "propose a talk" link

### DIFF
--- a/content/events/2018-chattanooga/welcome.md
+++ b/content/events/2018-chattanooga/welcome.md
@@ -36,14 +36,14 @@ Description = "DevOpsDays is coming to Chattanooga for the first time on Novembe
   </div>
 </div> -->
 
-<div class = "row">
+<!-- <div class = "row">
   <div class = "col-md-2">
     <strong>Propose</strong>
   </div>
   <div class = "col-md-8">
     <a href="https://www.papercall.io/devopsdayschattanooga" target="_blank">Propose a talk!</a>
   </div>
-</div>
+</div> -->
 
 <!-- <div class = "row">
   <div class = "col-md-2">


### PR DESCRIPTION
Hi, @robscott - I'm removing the "propose a talk" link from your event page as your CFP is long since closed. You can examine that `welcome.md` file and uncomment other sections if you want links to speakers, program, etc in the text of the page as well as in the menu.