### PR TITLE
[KIEV-2019] add k[iy][ei]v events to same event_group

### DIFF
--- a/data/events/2018-kiev.yml
+++ b/data/events/2018-kiev.yml
@@ -1,6 +1,7 @@
 name: "2018-kiev" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2018" # The year of the event. Make sure it is in quotes.
 city: "Kiev" # The displayed city name of the event. Capitalize it.
+event_group: "Kiev"
 event_twitter: "days_dev" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Kiev!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"

--- a/data/events/2019-kiev.yml
+++ b/data/events/2019-kiev.yml
@@ -1,6 +1,7 @@
 name: "2019-kiev" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2019" # The year of the event. Make sure it is in quotes.
 city: "Kyiv" # The displayed city name of the event. Capitalize it.
+event_group: "Kiev"
 event_twitter: "days_dev" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Kyiv!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"


### PR DESCRIPTION
This adds both Kiev events to the same `event_group` thus ensuring that they're cross-referenced properly. Example:
![image](https://user-images.githubusercontent.com/625232/48848200-a6482c00-eda3-11e8-94b5-cbcca6f42e08.png)

cc @delgod 😄 