### PR TITLE
Email correction

### DIFF
--- a/data/events/2018-bengaluru.yml
+++ b/data/events/2018-bengaluru.yml
@@ -76,7 +76,7 @@ team_members: # Name is the only required field for team members.
     github: "asheet-bhaskar"
     image: "asheet.jpg"
 
-organizer_email: "satish@emergingtechs.in" # Put your organizer email address here
+organizer_email: "organizers-bengaluru-2018@devopsdays.org" # Put your organizer email address here
 proposal_email: "proposals-bengaluru-2018@devopsdays.org" # Put your proposal email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.

--- a/data/events/2018-tel-aviv.yml
+++ b/data/events/2018-tel-aviv.yml
@@ -85,7 +85,7 @@ team_members: # Name is the only required field for team members.
     github: "burdandrei"
     linkedin: "https://www.linkedin.com/in/burdandrei/"
 
-organizer_email: "satish@emergingtechs.in" # Put your organizer email address here
+organizer_email: "organizers-tel-aviv-2018@devopsdays.org" # Put your organizer email address here
 proposal_email: "proposals-tel-aviv-2018@devopsdays.org" # Put your proposal email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.


### PR DESCRIPTION
The published organizer email addresses for Tel Aviv and Bengalaru 2018 were accidentally changed in https://github.com/devopsdays/devopsdays-web/pull/5863 to an organizer from Bengalaru. This was in error; we require the published organizer emails to be in the format organizer-cityname-year@devopsdays.org. This PR corrects it. /cc @budhram @gilzellner @phrawzty 