### PR TITLE
[LDN-2019] Add basic sponsorship packages, welcome and date.

### DIFF
--- a/content/events/2019-london/sponsor.md
+++ b/content/events/2019-london/sponsor.md
@@ -1,66 +1,149 @@
 +++
 Title = "Sponsor"
 Type = "event"
-Description = "Sponsor devopsdays London 2019"
+Description = "Sponsor DevOpsDays London 2019"
 +++
 
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
-
-<hr>
-
-devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
-<p>
-Gold sponsors get a full table and Silver sponsors a shared table where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.
-<p>
-The best thing to do is send engineers to interact with the experts at devopsdays on their own terms.
-<p>
-
-<!--
 <hr/>
+<div class="container-fluid">
+  <div class="row justify-content-start">
+    <div class="col-md-9">
+      <div>
+      <h3>Join the community</h3>
+<p>DevOpsDays London is run as a single track of curated talks in the morning and in the afternoon we host self organized conversations. The self organized content is known as “open spaces”. As a sponsor of DevOpsDays London you are encouraged to participate in the event. We want you to attend the talks and to take part in the open spaces - We want you to get involved!</p>
 
-<div style="width:590px">
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>packages</i></th>
-    <th><center><b><u>Bronze<br />1000 usd</u></center></b></th>
-    <th><center><b><u>Silver<br />3000 usd</u></center></b></th>
-    <th><center><b><u>Gold<br />5000 usd</u></center></b></th>
-    <th></th>
-  </tr>
-<tr><td>2 included tickets</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on event website</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on shared slide, rotating during breaks</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on all email communication</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on its own slide, rotating during breaks</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>1 minute pitch to full audience (including streaming audience)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr></tr>
-<tr><td>2 additional tickets (4 in total)</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>4 additional tickets (6 in total)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>shared table for swag</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>booth/table space</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-</table>
-<hr/>
-There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
-<br/>
-<br/>
+      </div>
+      <h3>Sponsorship Packages</h3>
+      <div class="alert alert-info">
+        We are offering the following packages (<strong>all prices are excluding VAT @20%</strong>):
+      </div>
+      <div class="table-responsive">
+      <table class="table table-bordered table-hover table-responsive-md">
+        <thead class="thead-light">
+          <tr>
+            <th scope="col">
+              <i>Packages</i>
+            </th>
+            <th scope="col">
+              <center>Bronze</center>
+            </th>
+            <th scope="col">
+              <center>Silver</center>
+            </th>
+            <th scope="col">
+              <center>Gold</center>
+            </th>
+            <th scope="col">
+              <center>Platinum<sup><a href="#1">1</a></sup></center>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Pricing</th>
+            <td>
+              <center>£1,000</center>
+            </td>
+            <td>
+              <center>£4,000</center>
+            </td>
+            <td>
+              <center>£6,000</center>
+            </td>
+            <td>
+              <center>£10,000</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">&nbsp;</th>
+            <th>
+              <center><span class="badge badge-success">Available</span></center>
+            </th>
+            <th>
+              <center><span class="badge badge-success">Available</span></center>
+            </th>
+            <th>
+              <center><span class="badge badge-success">Available</span></center>
+            </th>
+            <th>
+              <center><span class="badge badge-success">Available</span></center>
+            </th>
+          </tr>
+          <tr>
+            <th scope="row">Included tickets</td>
+            <td>
+              <center>2</center>
+            </td>
+            <td>
+              <center>3</center>
+            </td>
+            <td>
+              <center>5</center>
+            </td>
+            <td>
+              <center>10</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Stand Size<sup><a href="#2">2</a></sup></th>
+            <td class="table-warning">
+              <center>&nbsp;</center>
+            </td>
+            <td>
+              <center>Small</center>
+            </td>
+            <td>
+              <center>Large</center>
+            </td>
+            <td>
+              <center>Very Large</center>
+            </td>
 
-<br>
-<br>
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>Sponsor FAQ</i></th>
-    <th><center><b>Answers to questions frequently asked by sponsors&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</center></b></th>
-    <th></th>
-  </tr>
-<tr><td>What dates/times can we set up and tear down?</td><td></td></tr>
-<tr><td>How do we ship to the venue?</td><td></td></tr>
-<tr><td>How do we ship from the venue?</td><td></td></tr>
-<tr><td>Whom should we send?</td><td></td></tr>
-<tr><td>What should we expect regarding electricity? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>What should we expect regarding WiFi? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>How do we order additional A/V equipment?</td><td></td></tr>
-<tr><td>Additional important details</td><td></td></tr>
-</table>
+          </tr>
+          <tr>
+            <th scope="row">Delegate Address<sup><a href="#3">3</a></sup></th>
+            <td class="table-warning">
+              <center>&nbsp;</center>
+            </td>
+            <td class="table-warning">
+              <center>&nbsp;</center>
+            </td>
+            <td>
+              <center>1 Minute</center>
+            </td>
+            <td>
+              <center>1 Minute</center>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+<div>
+
+<p>Sponsoring DevOpsDays London will expose your brand to practitioners, managers, and executives
+from companies of all sizes and industries including retail, banking, manufacturing, medical technology,
+education, government, and consulting.</p>
+
+<p>If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].</p>
+
+
+<p>Location: DevOpsDays London will be returning to the QEII Centre in London.</p>
+<!--<p>Number of Delegates: This year we intend to sell over 400 tickets.</p>-->
 </div>
-
--->
-<hr/>
+      <hr/>
+      <ul class="list-unstyled">
+        <li>
+          <p><small><a id="1">1</a>. Our Platinum Inclusivity sponsorship money will be put towards additional elements that make our event more  inclusive. We will offer 1 Platinum Sponsorship packages and funds from these will go towards offering childcare, sign  language / closed captioning and distribution of 50 free tickets to groups that support under-represented people in tech.</small></p>
+        </li>
+        <li>
+          <p><small><a id="2">2</a>. Sponsors will be able to locate stands close to the main conference room and the catering space, for further details of layout of venue please contact us.</small></p>
+        </li>
+        <!--<li>
+          <p><small><a id="3">3</a>. A one-minute presentation to the audience is available for Platinum, the Evening Event and Gold packages only.</small></p>
+        </li>-->
+      </ul>
+    </div>
+    </div>
+    <!--<div class="col-md-3 col-sm-12">
+      <a href="https://assets.devopsdays.org/events/2018/london/devopsdays-london-2018-prospectus.pdf"><img src="/events/2018-london/devopsdays-london-2018-prospectus.jpg" class="img-fluid"></a>
+    </div>-->
+  </div>

--- a/content/events/2019-london/welcome.md
+++ b/content/events/2019-london/welcome.md
@@ -1,87 +1,35 @@
 +++
-Title = "devopsdays London 2019"
+Title = "DevOpsDays London 2019"
 Type = "welcome"
 aliases = ["/events/2019-london/"]
 Description = "devopsdays London 2019"
 +++
+<div class="row">
+  <!--<div class="col-md-4">
+    <img alt="DevOpsDays London 2019" src="/events/2019-london/logo.png" class="img-fluid">
+  </div>-->
 
-<!-- <div style="text-align:center;">
-  {{< event_logo >}}
-</div> -->
-
-<div class = "row">
-  <div class = "col-md-2">
-    <strong>Dates</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_start >}} - {{< event_end >}}
+  <div class="col-md-7">
+    <p>The first DevOpsDays was held in Ghent, Belgium in 2009. Since then, DevOpsDays events have multiplied and expanded globally with over 55 events in for 2018.</p>
+    <p>DevOpsDays is a worldwide series of community run technical conferences covering topics of software development, IT infrastructure operations, and the intersection between them. It is run by volunteers from community, for the benefit of the community.
+      We are not a commercial conference and we believe that our focus on serving the community creates a truly unique experience for both delegates and sponsors.
+    </p>
+    <p>We expect 400 people this year and will be holding the event on September 26-27, 2019 at the QEII Centre in Westminster.</p>
+    <p>The format of DevOpsDays London includes a single track of 30 minute talks in the morning of each event, followed by Ignite talks (5 minute, auto forwarding). We spend the rest of the afternoon in Open Spaces, which are considered a key portion
+      of the event.
+    </p>
+    <div class="d-flex flex-row">
+      <div class="col-md-12">
+        <div class="p-2">
+          <a class="btn btn-secondary btn-block" href="/events/2019-london/sponsor"> <i class="fa fa-money fa-lg"></i>&nbsp;&nbsp;&nbsp;Sponsor the Conference</a>
+        </div>
+        <!--<div class="p-2">
+          <a class="btn btn-secondary btn-block" href="https://www.eventbrite.com/e/devopsdays-london-2018-tickets-45511364717" target="_blank" rel="noopener"> <i class="fa fa-ticket fa-lg"></i>&nbsp;&nbsp;&nbsp;Buy a ticket</a>
+        </div>-->
+        <div class="p-2">
+          <a class="btn btn-secondary btn-block" href="/events/2019-london/contact"> <i class="fa fa-envelope-o fa-lg"></i>&nbsp;&nbsp;&nbsp;Contact the Organizers</a>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Location</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_location >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Register</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="registration" text="Register to attend the conference!" >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Propose</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="propose" text="Propose a talk!" >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Program</strong>
-  </div>
-  <div class = "col-md-8">
-    View the {{< event_link page="program" text="program." >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Speakers</strong>
-  </div>
-  <div class = "col-md-8">
-    Check out the {{< event_link page="speakers" text="speakers!" >}}
-  </div>
-</div> -->
-
-<div class = "row">
-  <div class = "col-md-2">
-    <strong>Sponsors</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="sponsor" text="Sponsor the conference!" >}}
-  </div>
-</div>
-
-<div class = "row">
-  <div class = "col-md-2">
-    <strong>Contact</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="contact" text="Get in touch with the organizers" >}}
-  </div>
-</div>
-
-<!-- Uncomment if you added your city twitter name -->
-<!--
-{{< event_twitter >}}
--->

--- a/data/events/2019-london.yml
+++ b/data/events/2019-london.yml
@@ -6,8 +6,8 @@ description: "Devopsdays is coming to London!" # Edit this to suit your preferen
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2019-09-26T00:00:00+00:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-09-27T00:00:00+00:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.
@@ -27,8 +27,8 @@ registration_link: "" # If you have a custom registration link, enter it here. T
 #
 coordinates: "51.507351, -0.127758" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "London" # Defaults to city, but you can make it the venue name.
-#
-location_address: "" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+
+location_address: "QEII Centre, Broad Sanctuary, Westminster"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
  # - name: propose
@@ -111,9 +111,6 @@ sponsor_levels:
   - id: gold
     label: Gold
     max: 8
-  - id: evening
-    label: Evening Event
-    max: 1
   - id: silver
     label: Silver
     max: 12


### PR DESCRIPTION
We've started by adding the basic sponsorship packages and a bunch of clickable stuff on the main page such as sponsorship and contact.

We're still missing a bunch of stuff like prospectus, CFP dates and such but this commit initially kicks off the basic packages which we can start selling places for.

Signed-off-by: Chris Mills <me@christophermills.co.uk>