### PR TITLE
Remove deprecated field from example config

### DIFF
--- a/utilities/examples/data/events/yyyy-city.yml
+++ b/utilities/examples/data/events/yyyy-city.yml
@@ -14,7 +14,6 @@ cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
-cfp_open: "false"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet


### PR DESCRIPTION
`cfp_open` is deprecated so we should remove it from the example. 