### PR TITLE
[Los Angeles 2019] Adjusting CFP opening

### DIFF
--- a/data/events/2019-los-angeles.yml
+++ b/data/events/2019-los-angeles.yml
@@ -8,7 +8,7 @@ event_group: "Los Angeles"
 startdate:  2019-03-08 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  2019-03-08 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-01-10  # start accepting talk proposals.
+cfp_date_start: 2018-12-19  # start accepting talk proposals.
 cfp_date_end: 2019-02-15 # close your call for proposals.
 cfp_date_announce: 2019-02-24 # inform proposers of status.
 


### PR DESCRIPTION
Hi, @irabinovitch - it appears that the CFP opening date was set to January when this was first listed, months ago. This prevents you from showing up (yet) in https://www.devopsdays.org/speaking/ - so I'm adjusting it to a few days ago when you recently updated the site. Please let us know if you actually don't want to be listed. Thanks!

