### PR TITLE
[RDU-2019] Fixing twitter handle for Chris Bailey

### DIFF
--- a/data/events/2018-raleigh.yml
+++ b/data/events/2018-raleigh.yml
@@ -65,7 +65,7 @@ team_members: # Name is the only required field for team members.
     website: "https://opensource.com"
     employer: "Red Hat"
   - name: "Chris Bailey"
-    twitter: "cbailey119"
+    twitter: "seebails"
     github: "nonstickzan"
   - name: "Andrew Sullivan"
   - name: "Kyle Anderson"

--- a/data/events/2019-raleigh.yml
+++ b/data/events/2019-raleigh.yml
@@ -61,7 +61,7 @@ team_members: # Name is the only required field for team members.
     website: "https://opensource.com"
     employer: "Red Hat"
   - name: "Chris Bailey"
-    twitter: "cbailey119"
+    twitter: "seebails"
     github: "nonstickzan"
   - name: "Andrew Sullivan"
   - name: "Kyle Anderson"


### PR DESCRIPTION
paging @nonstickzan for :+1:

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>
