### PR TITLE
[AMS-2019] Add f5 as sponsor

### DIFF
--- a/data/events/2019-amsterdam.yml
+++ b/data/events/2019-amsterdam.yml
@@ -84,6 +84,12 @@ organizer_email: "organizers-amsterdam-2019@devopsdays.org" # Put your organizer
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
+  # Coffee
+  - id: f5
+    level: foodtrucks
+  # Golds
+  - id: f5
+    level: gold
 
 sponsors_accepted : "no" # Whether you want "Become a XXX Sponsor!" link
 

--- a/data/events/2019-amsterdam.yml
+++ b/data/events/2019-amsterdam.yml
@@ -91,7 +91,7 @@ sponsors:
   - id: f5
     level: gold
 
-sponsors_accepted : "no" # Whether you want "Become a XXX Sponsor!" link
+sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.
 # You may optionally include a "max" attribute to limit the number of sponsors per level. For

--- a/data/events/2019-amsterdam.yml
+++ b/data/events/2019-amsterdam.yml
@@ -98,6 +98,9 @@ sponsors_accepted : "no" # Whether you want "Become a XXX Sponsor!" link
 # unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
 # sponsorship for a specific level, it is best to remove the level.
 sponsor_levels:
+  - id: BBQ
+    label: BBQ
+    max: "1"
   - id: coffee
     label: Coffee
     max: "1"

--- a/data/events/2019-amsterdam.yml
+++ b/data/events/2019-amsterdam.yml
@@ -101,6 +101,9 @@ sponsor_levels:
   - id: BBQ
     label: BBQ
     max: "1"
+  - id: "Social event"
+    label: social
+    max: "1"
   - id: coffee
     label: Coffee
     max: "1"

--- a/data/events/2019-amsterdam.yml
+++ b/data/events/2019-amsterdam.yml
@@ -104,29 +104,29 @@ sponsor_levels:
   - id: "Social event"
     label: social
     max: "1"
-  - id: coffee
-    label: Coffee
-    max: "1"
   - id: beer
     label: Beer
     max: "1"
-  - id: games
-    label: Games
+  - id: coffee
+    label: Coffee
     max: "1"
-  - id: foodtrucks
-    label: "Food Trucks"
-    max: "4"
   - id: gold
     label: Gold
     max: "8"
-  - id: recharge
-    label: "Power recharge"
+  - id: games
+    label: "Arcade Games"
     max: "1"
   - id: silver
     label: Silver
     max: "8"
+  - id: recharge
+    label: "Power recharge"
+    max: "1"
   - id: lanyard
     label: Lanyard
     max: "1"
+  - id: foodtrucks
+    label: "Food Trucks"
+    max: "4"
   - id: bronze
     label: Bronze


### PR DESCRIPTION
With this PR we:
- Enable the sponsors wanted link;
- Add missing sponsors options;
- Sort on investment;
- Add F5 as first sponsor.