### PR TITLE
[Berlin 2019] Fixing missing end date

### DIFF
--- a/data/events/2019-berlin.yml
+++ b/data/events/2019-berlin.yml
@@ -19,7 +19,7 @@ cfp_open: "false"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2018-12-01T00:00:00+02:00
-registration_date_end: # close registration. Leave blank if registration is not open yet.
+registration_date_end: 2019-11-27T00:00:00+02:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.


### PR DESCRIPTION
We were seeing an error in the builds:

ERROR 2019/01/03 15:18:31 theme/partials/events/cta.html template: theme/partials/events/cta.html:24:73: executing "theme/partials/events/cta.html" at <time $e.registration...>: error calling time: Unable to Cast <nil> to Time

I think this is happening because one city (Berlin) has a start date and no end date for registration. This is my attempt at fixing it.