### PR TITLE
[LDN-2019] Add sponsorship brochure and thumbnail

### DIFF
--- a/content/events/2019-london/sponsor.md
+++ b/content/events/2019-london/sponsor.md
@@ -130,7 +130,8 @@ education, government, and consulting.</p>
 </div>
     </div>
     </div>
-    <!--<div class="col-md-3 col-sm-12">
-      <a href="https://assets.devopsdays.org/events/2018/london/devopsdays-london-2018-prospectus.pdf"><img src="/events/2018-london/devopsdays-london-2018-prospectus.jpg" class="img-fluid"></a>
-    </div>-->
+    <div class="col-md-3 col-sm-12">
+      <a href="https://assets.devopsdays.org/events/2019/london/devopsdays-london-2019-brochure.pdf"><img src="https://assets.devopsdays.org/events/2019/london/thumbnail.jpg" class="img-fluid"></a>
+    </div>
+
   </div>


### PR DESCRIPTION
We've got the brochure locked down and have been sending it through to
potential sponsors. We'll use the same layout as last year and link through to the new off-site assets.

***
**This PR requires https://github.com/devopsdays/devopsdays-assets/pull/52 to also be merged**
***

Signed-off-by: Chris Mills <me@christophermills.co.uk>

