### PR TITLE
[la2019] fix sponsor ids la 2019

### DIFF
--- a/data/events/2019-los-angeles.yml
+++ b/data/events/2019-los-angeles.yml
@@ -62,7 +62,7 @@ sponsor_levels:
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
-  - id: "Amazon Web Services"
+  - id: "aws"
     level: lanyard
   - id: codefresh
     level: sponsor
@@ -72,7 +72,7 @@ sponsors:
     level: sponsor
   - id: logdna
     level: sponsor
-  - id: "Release Team"
+  - id: "releaseteam"
     level: sponsor
   - id: sumologic
     level: sponsor


### PR DESCRIPTION
AWS and Release team needed adjustment to show up correctly.