### PR TITLE
[MSP 2019] Added full datetime

### DIFF
--- a/data/events/2019-minneapolis.yml
+++ b/data/events/2019-minneapolis.yml
@@ -6,15 +6,14 @@ description: "Devopsdays Minneapolis will return in 2019!" # Edit this to suit y
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-08-06  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-08-07 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2019-08-06T08:00:00-05:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-08-07T18:00:00-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-01-21  # start accepting talk proposals.
-cfp_date_end: 2019-03-17  # close your call for proposals.
-cfp_date_announce: 2019-04-14  # inform proposers of status
+cfp_date_start: 2019-01-21T17:30:00-06:00 # start accepting talk proposals.
+cfp_date_end: 2019-03-17T23:59:00-05:00 # close your call for proposals.
+cfp_date_announce: 2019-04-14T23:00:00-05:00  # inform proposers of status
 
-cfp_open: "false"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet


### PR DESCRIPTION
I think this error is from having incomplete datetime in the CFP fields:

<i>
5:15:01 PM: ERROR 2019/01/21 23:15:01 theme/partials/events/cta.html template: theme/partials/events/cta.html:54:60: executing "theme/partials/events/cta.html" at <time $e.cfp_date_end>: error calling time: Unable to Cast <nil> to Time
</i>