### PR TITLE
Updating to fix jpg/jpeg issue

### DIFF
--- a/bin/netlify-production.sh
+++ b/bin/netlify-production.sh
@@ -1,4 +1,4 @@
-#npm rebuild
+npm rebuild
 hugo version
 hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="$URL/"
-#gulp
+gulp

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 # repository branch will inherit these settings.
 [context.production]
  command = "bin/netlify-production.sh"
- publish = "public/"
+ publish = "dist/"
 
  [context.deploy-preview]
   command = "bin/netlify.sh"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-imagemin": "^5.0.0",
     "gulp-img-retina": "0.0.4",
     "gulp-rename": "^1.2.2",
-    "gulp-responsive": "^2.11.0",
+    "gulp-responsive": "~2.11.0",
     "gulp-rev": "^9.0.0",
     "gulp-rev-replace": "^0.4.3",
     "gulp-sass": "latest",


### PR DESCRIPTION
Fixes https://github.com/devopsdays/devopsdays-web/issues/6157 by being more strict on the version; turns the npm/gulp processing back on in the production build.