### PR TITLE
Sidebar hotfix

### DIFF
--- a/themes/devopsdays-theme/layouts/partials/future.html
+++ b/themes/devopsdays-theme/layouts/partials/future.html
@@ -1,6 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (time .enddate) now -}}
+    {{- if ge (time .enddate) (now.AddDate 0 0 -1) -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}


### PR DESCRIPTION
This is a band-aid hotfix related to https://github.com/devopsdays/devopsdays-theme/issues/656 (because the sidebar is controlled from a different place than the front-page logos.) I'll PR it into the theme repo too, but I want to get it live for NYC's day 2. Thanks to @kmugrage for the heads-up.