### PR TITLE
[Van-2019] email on welcome page to reach organizers

### DIFF
--- a/content/events/2019-vancouver/welcome.md
+++ b/content/events/2019-vancouver/welcome.md
@@ -5,6 +5,11 @@ aliases = ["/events/2019-vancouver"]
 Description = "Welcome | devopsdays Vancouver 2019"
 +++
 
+
+<strong>
+  Email us at: <a href="mailto:organizers-vancouver-2019@devopsdays.org?subject=devopsdays Vancouver - 2019">organizers-vancouver-2019@devopsdays.org</a>
+</strong>
+
 <div style="text-align:center;">
   {{< event_logo >}}
 </div>


### PR DESCRIPTION
This adds a link on the Welcome page for attendees/sponsors/etc to reach the even organizers.
