### PR TITLE
[CPH-2019] Add thoughtworks

### DIFF
--- a/content/events/2019-boise/propose.md
+++ b/content/events/2019-boise/propose.md
@@ -6,7 +6,7 @@ year = "2019"
 +++
 {{< cfp_dates >}}
 <br />
-It is a pleasure to invite you to participate in the {{< param year >}} devopsdays Boise Conference. The conference will take place at {{< event_location >}} in downtown Boise on {{< event_start >}}.
+It is a pleasure to invite you to participate in the  devopsdays Boise Conference. The conference will take place at {{< event_location >}} in downtown Boise on {{< event_start >}}.
 
 This is a technical conference aimed at sharing and improving the current software development practices of local technology businesses. Sharing these practices benefits all industries and makes our region more competitive and attractive to the constrained talent pool. Every year we plan to inspire local technical and business leaders with a world class line up of presentations.
 
@@ -50,4 +50,4 @@ Choosing talks is part art, part science; here are some factors we consider when
   <li><i>Optional</i>: Slides or extended description
 </ol>
 
-We look forward to seeing you at the {{< param year >}} devopsdays Boise Conference!
+We look forward to seeing you at the  devopsdays Boise Conference!

--- a/content/events/2019-boise/propose.md
+++ b/content/events/2019-boise/propose.md
@@ -6,7 +6,7 @@ year = "2019"
 +++
 {{< cfp_dates >}}
 <br />
-It is a pleasure to invite you to participate in the  devopsdays Boise Conference. The conference will take place at {{< event_location >}} in downtown Boise on {{< event_start >}}.
+It is a pleasure to invite you to participate in the {{< param year >}} devopsdays Boise Conference. The conference will take place at {{< event_location >}} in downtown Boise on {{< event_start >}}.
 
 This is a technical conference aimed at sharing and improving the current software development practices of local technology businesses. Sharing these practices benefits all industries and makes our region more competitive and attractive to the constrained talent pool. Every year we plan to inspire local technical and business leaders with a world class line up of presentations.
 
@@ -50,4 +50,4 @@ Choosing talks is part art, part science; here are some factors we consider when
   <li><i>Optional</i>: Slides or extended description
 </ol>
 
-We look forward to seeing you at the  devopsdays Boise Conference!
+We look forward to seeing you at the {{< param year >}} devopsdays Boise Conference!

--- a/data/events/2019-copenhagen.yml
+++ b/data/events/2019-copenhagen.yml
@@ -86,6 +86,8 @@ proposal_email: "proposals-copenhagen-2019@devopsdays.org" # Put your proposal e
 sponsors:
   - id: praqma
     level: gold
+  - id: thoughtworks-gocd
+    level: silver
  #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
   - id: arresteddevops
     level: community


### PR DESCRIPTION
I added thoughtworks as silver sponsor.

I could not view the local website, it gave me an error message that pointed to {{< param year >}} in the Boise event. So I temporarily removed it and put it back. I did not really change anything, but this is why it shows in my commits :)

If anyone can suggest a solution to that problem, I'm interested :)
