### PR TITLE
[BER-2019] Fix proposal page, so it points to papercall.io. 

### DIFF
--- a/content/events/2019-berlin/propose.md
+++ b/content/events/2019-berlin/propose.md
@@ -7,14 +7,24 @@ Description = "Propose a talk for devopsdays Berlin 2019"
 
 <hr>
 
-There are three ways to propose a topic at devopsdays:
+<h2>There are three ways to propose a topic at devopsdays:</h2>
 <ol>
   <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
   <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
   <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
+  <li><strong><em>Hands-On session</em></strong>: If your talk is of a technical nature, maybe it makes more sense to show others what and how you do it. These are 45 minute sessions parallel to the Open Space sessions. Give people a chance for questions. Please: No product demos.
 </ol>
-
+<p>If you’d like to demo your product or service, you should <a href="https://www.devopsdays.org/events/2019-berlin/sponsor/">sponsor</a> the event and demo it at your table.</p>
 <hr>
+
+<h2>What are we looking for?</h2>
+
+<h3>Can you talk about this?</h3>
+<p>We at DevOpsDays Berlin do prefer cultural talks over technical talks. So if you have a hiring success story, can talk about diversity in Teams or Leadership, have a great tale to tell about spreading DevOps to the rest of the company - we would like to hear that.</p>
+
+<p>On the other hand: We’re still engineers deep in our heart - so if you have some uncommon technical story to tell, we also like to hear from you. Please also think about submitting a Hands-On Workshop, if what you want to tell can also be shown to a broader audience</p>
+
+<h3>General Tips &amp; Tricks</h3>
 
 Choosing talks is part art, part science; here are some factors we consider when trying to assemble the best possible program for our local audience:
 
@@ -27,9 +37,6 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+<h2>How to submit a proposal:</h2>
+
+We're going with papercall.io this time, so please enter your submission <a href="https://www.papercall.io/2019-berlin">at the DevOpsDays Berlin 2019 page</a> there. 


### PR DESCRIPTION
Also make text on proposal page the same as the text on papercall.io.


