### PR TITLE
[DC 2019] add Excella as sponsor

### DIFF
--- a/data/events/2019-washington-dc.yml
+++ b/data/events/2019-washington-dc.yml
@@ -325,5 +325,7 @@ sponsor_levels:
 sponsors:
   - id: pyramid-systems
     level: platinum
+  - id: excella
+    level: platinum
   - id: circleci
     level: gold


### PR DESCRIPTION
Excella already has an entry for [sponsor data](https://github.com/devopsdays/devopsdays-web/blob/master/data/sponsors/excella.yml) and [a square graphic](https://github.com/devopsdays/devopsdays-web/blob/master/static/img/sponsors/excella.png).

@nathenharvey @xzilla 