### PR TITLE
[PT-2019] Fix proposal link in propose page

### DIFF
--- a/content/events/2019-portugal/propose.md
+++ b/content/events/2019-portugal/propose.md
@@ -27,9 +27,5 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+<strong>How to submit a proposal:</strong> We are using Papercall.io this year to manage proposals. Please go to [{{< cfp_link >}}] and fill out the submission form.
+

--- a/content/events/2019-portugal/propose.md
+++ b/content/events/2019-portugal/propose.md
@@ -27,5 +27,5 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> We are using Papercall.io this year to manage proposals. Please go to [{{< cfp_link >}}] and fill out the submission form.
+<strong>How to submit a proposal:</strong> We are using Papercall.io this year to manage proposals. Please go to <a href="https://www.papercall.io/devopsdaysportugal2019">https://www.papercall.io/devopsdaysportugal2019</a> and fill out the submission form.
 


### PR DESCRIPTION
since we are using papercall, it is better for us to have the talk submissions going to the event page there.