### PR TITLE
[GENEVA-2019] update Daniel's workshop title & description

### DIFF
--- a/content/events/2019-geneva/program/daniel-maher.md
+++ b/content/events/2019-geneva/program/daniel-maher.md
@@ -2,10 +2,9 @@
 Talk_date = ""
 Talk_start_time = ""
 Talk_end_time = ""
-Title = "The How & Why of Public Speaking"
+Title = "Public Speaking for Technologists"
 Type = "talk"
 Speakers = ["daniel-maher"]
 +++
 
-There are thousands of professional speaking opportunities around the world every month, but why bother engaging? For the employee: professional development, personal satisfaction, and a deeper connection with the the topic and related community are among the rewards. For the employer: opportunities for networking, brand awareness, and recruiting are but a few of the benefits. In this presentation, we’ll explore the myriad reasons for speaking at a conference or a meet-up—from both the employee and employer standpoint—and dive into how to build an internal programme to develop and promote public speakers within your organisation.
-Note to conference organisers: I’d be happy to pair this with a workshop or open space covering one or more of the following topics: identifying material and opportunities, how to CFP successfully, preparing slides, and public speaking tips & tricks.
+In this workshop, we'll explore the following topics: identifying speaking opportunities, how to CFP successfully, preparing slides, and public speaking tips & tricks.


### PR DESCRIPTION
The title and description were taken from the original presentation proposal (which was a traditional _talk_). This PR modifies the title and description to more accurately match the _workshop_.