### PR TITLE
Updating contributor guidelines and how-to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to devopsdays-web
 
-This document contains the technical details on how to set up [Hugo](https://gohugo.io/) (to see your edits locally before pushing them to GitHub), and how to prepare a Pull Request for inclusion on the [devopsdays](http://www.devopsdays.org/) website.
+This document contains the technical details on how to set up [Hugo](https://gohugo.io/) (to see your edits locally before pushing them to GitHub), and how to prepare a pull request to make changes to content on the [devopsdays](https://www.devopsdays.org/) website.
 
-If you'd like to assist in contributing to the code of the website, please see [devopsdays/devopsdays-theme](https://github.com/devopsdays/devopsdays-theme).
+If you'd like to assist in contributing to the code itself (as opposed to the content) of the website, please see [devopsdays/devopsdays-theme](https://github.com/devopsdays/devopsdays-theme).
 
 ## Setup
 
@@ -10,8 +10,8 @@ If you'd like to edit a specific devopsdays event site (and/or contribute code),
 
 ### Quick Overview
 
-1. Install [Hugo](http://gohugo.io). The version we use can be found in the `.travis.yml` file. [(Quick Install)](https://gohugo.io/getting-started/installing#binary-cross-platform)
-1. Fork this repo.
+1. Install [Hugo](http://gohugo.io). The current Hugo version we're using can be found in the [.circleci/config.yml](https://github.com/devopsdays/devopsdays-web/blob/master/.circleci/config.yml) file. [(Quick Install)](https://gohugo.io/getting-started/installing#binary-cross-platform)
+1. [Fork](https://help.github.com/articles/fork-a-repo/) this repo and clone a copy locally.
 
 ### View site locally
 
@@ -25,8 +25,7 @@ Now open `http://localhost:1313` in a browser and navigate to the content that y
 
 ## Pull requests
 
-### Process
-
+### Setting your fork up the first time
 
 Make your own [fork](https://help.github.com/articles/fork-a-repo/) of the `devopsdays-web` repository.
 
@@ -40,17 +39,22 @@ or
 git remote add upstream https://github.com/devopsdays/devopsdays-web.git
 ```
 
-Before starting any new change, it is essential that you `rebase` your local repository from the upstream. Issue these commands:
+You only need to create your fork once, as long as you don't delete it.
+
+
+### Editing your site
+
+1. Before starting any new change, it is essential that you `rebase` your local repository from the upstream. You may think that working from your fork is enough, but sometimes upstream changes will affect your work in ways you may not anticipate, so you'll want to stay current. Issue these commands:
 
 
  - `git checkout master`
  - `git pull upstream master --rebase`
 
 
- This confirms you are on the master branch locally, and then applies the changes from the upstream to your copy.
+This confirms you are on the master branch locally, and then applies the changes from the upstream to your copy.
 
 
-Create a new local [branch](https://help.github.com/articles/about-branches/) for your changes. This helps to keep things tidy!
+2. Create a new local [branch](https://help.github.com/articles/about-branches/) for your changes. This helps to keep things tidy!
 
   ```
   $ git checkout -b fix_that_thing
@@ -58,20 +62,21 @@ Create a new local [branch](https://help.github.com/articles/about-branches/) fo
   (Replace `fix_that_thing` with a quick description of your *actual* change.)
 
 
-Make your changes, test them locally (see above), then push that branch up to `origin` on your fork.
+3. Make your changes, test them locally (see above), then push that branch up to `origin` on your fork.
 
   ```
   $ git push origin fix_that_thing
   ```
 
-6. Submit a [Pull Request](https://help.github.com/articles/using-pull-requests/) for the branch you just pushed. Please title the pull request according to the event affected, i.e., `[CHI-2017] Add Bluth Company as a sponsor`
-7. Take a break - you've earned it!
-8. When a commit is merged to `master` on GitHub (ideally via a PR reviewed by at least one other person), `Netlify` (a build tool) will automatically build the site and publish it to [http://www.devopsdays.org](http://www.devopsdays.org).
+4. Submit a [Pull Request](https://help.github.com/articles/using-pull-requests/) for the branch you just pushed. Please title the pull request according to the event affected, i.e., `[CHI-2017] Add Bluth Company as a sponsor`
+5. Optionally, open your [pull request](https://github.com/devopsdays/devopsdays-web/pulls) in a browser and look at the preview that `Netlify` (a build tool) built.
+6. You can mention on devopsdays Slack's #website if you'd like a PR merged quickly. (Availability of maintainers varies.)
+7. When a commit is merged to `master` on GitHub, Netlify will automatically build the site and publish it to [https://www.devopsdays.org](https://www.devopsdays.org).
 
 ### Guidelines
 
-1. Code changes that affect the overall site will be merged only in the [devopsdays-theme](https://github.com/devopsdays/devopsdays-theme) repo. Theme changes should be made there, and when released, will be used in this repo.
-1. We use [github issues](https://github.com/devopsdays/devopsdays-theme/issues) to track work, so feel free to create new issues if you like (or read/comment on existing ones).
+1. Code changes that affect the overall site will be merged only in the [devopsdays-theme](https://github.com/devopsdays/devopsdays-theme) repo. Theme changes should be made there, and when released, will be used in the `devopsdays-web` repo.
+1. We use [github issues](https://github.com/devopsdays/devopsdays-theme/issues) to track work, so feel free to create new issues if you like (or read/comment/work on existing ones).
 1. If you are proposing a change that affects the overall site, and is not tied to an existing issue, please open a [new issue](https://github.com/devopsdays/devopsdays-theme/issues) so that it can be discussed by the team, prior to submitting a pull request.
 1. If you're using CRLF line terminators (like on Windows), the site won't build correctly if the first `+++` line of frontmatter in speaker and program files ends in a space like `+++ `. The [workaround](https://github.com/devopsdays/devopsdays-theme/issues/652) is to remove the trailing space.
 
@@ -79,12 +84,21 @@ Make your changes, test them locally (see above), then push that branch up to `o
 - A maintainer will merge the PR if it is mergable, as soon as the checks pass.
 - If you do not want your PR merged immediately, in most cases you should not open the PR.
 - Our [workflow guide](https://github.com/devopsdays/devopsdays-web/blob/master/utilities/docs/workflow/README.md) provides solutions to most `WIP` use cases without opening a PR.
-- Questions about specific cases not covered in the guide can be be asked in the #website channel on devopsdays slack.
+- Questions about specific cases not covered in the guide can be asked in the #website channel on devopsdays Slack.
 
-### Only make changes to event content files
-"Content" means anything inside the `/content/...`, `/data/...`, or `/static/...` directories.
+### Acceptable changes
 
-Changes to event-specific content should be submitted in a separate PR from changes to more general content for the whole site.
+- In general, only make changes to event content files. "Event content" means anything inside the `/content/...`, `/data/...`, or `/static/...` directories.
+- Changes to event-specific content should be submitted in a separate PR from changes to more general content for the whole site.
+
+### Minimal large files
+
+Generally speaking, you should avoid storing any files other than logos or small images inside the repo itself (out of consideration for your fellow devopsdays organizers who have to pull down this repo). Please follow these guidelines:
+
+* Do not upload presentations or other artifacts from your event into this repo. Either link to the presentation on Speakerdeck/Slideshare from the presenter, or even better, create a Speakerdeck account for your event and put the presos there.
+* Small web images are fine (logos, etc). If you have high-resolution versions of your logo to share with others, please do not host them on the devopsdays-web repo.
+* It is acceptable to add in a single PDF for your sponsor prospectus if you desire (in `static/events/YYYY-city`), but please keep this file under 3 MB. It is better to host it on Google Drive or something similar, and then link to it from your site.
+* OPTIONAL - you can host your PDFs for prospectus, etc, in the repo at [devopsdays/devopsdays-assets](https://github.com/devopsdays/devopsdays-assets) and then link to them from there. Files in that repo are presented under their relative URL at https://assets.devopsdays.org. For example, the file located at `static/events/2016/chicago/devopsdays-chicago-2016-prospectus.pdf` in the `devopsdays/devopsdays-assets` repo will be presented at `https://assets.devopsdays.org/events/2016/chicago/devopsdays-chicago-2016-prospectus.pdf`
 
 
 ## Maintainer Guidelines
@@ -92,7 +106,7 @@ Changes to event-specific content should be submitted in a separate PR from chan
 If you have permissions to merge PRs on this repo, here are a few guidelines to consider:
 
 1. Is the requestor authorized to make changes for that event? They need to appear on the contact list for the year and city they're editing.
-1. Do not allow any PRs that change files outside of the above-mentioned "content" directories. Especially watch out for `.gitignore`, `config.toml`, `config-windows.toml`, and anything in the `themes` directory. Our bot will notify maintainers for any changes to non-content files and assign the PR's to the maintainers, so that should help.
+1. Do not allow any PRs that change files outside of the above-mentioned "content" directories. Especially watch out for `.gitignore`, `config.toml`, `config-windows.toml`, and anything in the `themes` directory. Our bot will notify maintainers for any changes to non-event-content files and assign the PRs to the maintainers, so that should help.
 1. Check to see if the tests pass, but use your judgement on merging something that fails (see "PR Tests" below for guidance)
 1. If you are unsure about merging a PR, please use the "request a review" button on the PR to request one from other maintainers.
 1. If you're reviewing all the details of a PR before merging or are communicating with the *Submitter*, add yourself to *Assignees* so that others know someone is waiting on a response or reviewing all the details of the PR thoroughly. Be sure to also add a comment into the PR that you are reviewing it, and if you need a change from the *Submitter* prior to merge, be sure to label the PR as `do-not-merge`.
@@ -101,10 +115,9 @@ If you have permissions to merge PRs on this repo, here are a few guidelines to 
 
 The following tests run when a PR is submitted:
 
-1. [Travis](https://travis-ci.org/devopsdays/devopsdays-web/) - this is a basic test that confirms that the site can be built with Hugo on linux, and it runs an `html-min` gulp task which will identify if there is any invalid HTML in the site. This protects the final build, so if the Travis tests fail, please take a look as to why they failed.
-1. [Appveyor](https://ci.appveyor.com/project/DevOpsDays/devopsdays-web) - this again is a small test that builds Hugo on Windows, to ensure that no Windows-incompatible files have been included. If Appveyor tests fail, merge at your own discretion, based upon the failure reason.
-1. [Gitmagic](https://gitmagic.io/) - This is a bot that makes sure our pull requests are fashioned cleanly. See [contributing.json](https://github.com/devopsdays/devopsdays-web/blob/master/contributing.json) for a list of rules that we enforce.
-1. [Netlify](https://app.netlify.com/sites/devopsdays-web) - This is a very useful test. It builds the site, and hosts an ephemeral preview version of it (viewable by clicking on the "details" link next to the test once it has turned green). It's pretty important to view this "deploy preview" if the PR has changed anything significant (adding a sponsor, etc, probably not...but changing content in a large way? Yes.)
+1. [CircleCI](https://circleci.com/gh/devopsdays/devopsdays-web) - this test confirms that the site can be built with Hugo on linux, and it runs an `html-min` gulp task which will identify if there is any invalid HTML in the site. This protects the final build, so if the CircleCI build or test jobs fail, please take a look as to why they failed.
+1. [Appveyor](https://ci.appveyor.com/project/DevOpsDays/devopsdays-web) - this test builds Hugo on Windows, to ensure that no Windows-incompatible files have been included. If Appveyor tests fail, merge at your own discretion, based upon the failure reason.
+1. [Netlify](https://app.netlify.com/sites/devopsdays-web) - this test builds the site, and hosts an ephemeral preview version of it (viewable by clicking on the "details" link next to the test once it has turned green). It's a good idea to view this "deploy preview" if the PR has changed anything significant (adding a sponsor, etc, probably not...but changing content in a large way? Yes.)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/devopsdays/devopsdays-web.svg?branch=master)](https://travis-ci.org/devopsdays/devopsdays-web) [![Build status](https://ci.appveyor.com/api/projects/status/3lobrrssphdb20xd?svg=true)](https://ci.appveyor.com/project/DevOpsDays/devopsdays-web)
+[![Build Status](https://circleci.com/gh/devopsdays/devopsdays-web.svg?branch=master)](https://circleci.com/gh/devopsdays/devopsdays-web) [![Build status](https://ci.appveyor.com/api/projects/status/3lobrrssphdb20xd?svg=true)](https://ci.appveyor.com/project/DevOpsDays/devopsdays-web)
 [![license](https://img.shields.io/github/license/devopsdays/devopsdays-theme.svg)](https://github.com/devopsdays/devopsdays-web/blob/master/LICENSE) [![Greenkeeper badge](https://badges.greenkeeper.io/devopsdays/devopsdays-web.svg)](https://greenkeeper.io/)
 
 
@@ -6,32 +6,25 @@
 
 This is the repo for managing [devopsdays.org](http://www.devopsdays.org).
 
-## Managing event content
+## Managing your event content
 
-Reference documentation for the currently available theme is available in [themes/devopsdays-theme/REFERENCE.md](https://github.com/devopsdays/devopsdays-web/blob/master/themes/devopsdays-theme/REFERENCE.md).
+If you are on a local devopsdays team and you'd like to edit [devopsdays.org](http://www.devopsdays.org) for your events, you're in the right place.
 
-Instructions and utilities are available for [managing sponsors, events, speakers, and more](utilities/README.md).
+Guidelines for contributing event-specific content to this repository are outlined in [CONTRIBUTING.md](CONTRIBUTING.md). If you intend to contribute (and we hope you do!), please take a moment to review that document so you can get set up correctly.
 
-## Reporting issues
+When you're ready to add content, instructions and utilities are available for [managing sponsors, events, speakers, and more](utilities/README.md).
 
-If you discover an issue with the theme, please open an issue in the [devopsdays-theme repo](https://github.com/devopsdays/devopsdays-theme/issues/new).
+## Site-wide Hugo theme
 
-## Binary files
+You may find that you want to improve the site in some way that's not specific to your event. We use a custom Hugo theme, and reference documentation is available in [themes/devopsdays-theme/REFERENCE.md](https://github.com/devopsdays/devopsdays-web/blob/master/themes/devopsdays-theme/REFERENCE.md).
 
-Generally speaking, you should avoid storing any files other than logos or small images inside the repo itself (out of consideration for your fellow devopsdays organizers who have to pull down this repo). Please follow these guidelines:
+The technical details for contributing to the site-wide theme's development are covered in [devopsdays-theme's CONTRIBUTING.md](https://github.com/devopsdays/devopsdays-theme/blob/master/CONTRIBUTING.md).
 
-* Do not upload presentations, artifacts from your event, etc. Either link to the preso on Speakerdeck/Slideshare from the presenter, or even better, create a Speakerdeck account for your event and put the presos there.
-* Small, web images are fine (logos, etc). If you have high-resolution versions of your logo to share with others, please do not host them on the devopsdays-web repo.
-* It is acceptable to add in a single PDF for your sponsor prospectus if you desire (in `static/events/YYYY-city`), but please keep this file under 3 MB. It is better to host it on Google Drive or something similar, and then link to it from your site.
-* OPTIONAL - you can host your PDF's for prospectus, etc, in the repo at [devopsdays/devopsdays-assets](https://github.com/devopsdays/devopsdays-assets) and then link to them from there. Files in that repo are presented under their relative URL at https://assets.devopsdays.org. For example, the file located at `static/events/2016/chicago/devopsdays-chicago-2016-prospectus.pdf` in the `devopsdays/devopsdays-assets` repo will be presented at `https://assets.devopsdays.org/events/2016/chicago/devopsdays-chicago-2016-prospectus.pdf`
+## Reporting issues & feature requests
 
-## Feature Requests
-If there is a feature in the theme that you would like to see, please [submit an issue](https://github.com/devopsdays/devopsdays-theme/issues/new) to this repository and prepend the title with `[ENHANCEMENT]`. If you discover an issue with the theme, [submit an issue](https://github.com/devopsdays/devopsdays-theme/issues/new) and prepend the title with `[BUG]`.
+If you discover an issue with the site that isn't specific to an event's content, please open an issue in the [devopsdays-theme repo](https://github.com/devopsdays/devopsdays-theme/issues/new) and prepend the title with `[BUG]`.
+
+If there is a feature that you would like to see, please [submit an issue](https://github.com/devopsdays/devopsdays-theme/issues/new) to the theme repository and prepend the title with `[ENHANCEMENT]`.
 
 If you would like to help prioritize enhancements, please upvote the original issue by [adding a reaction](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments).
 
-## Contributing
-
-The technical details and guidelines for contributing to this repository are outlined in [CONTRIBUTING.md](CONTRIBUTING.md). If you intend to contribute (and we sure hope you do!), please take a moment to review that document.
-
-Guidelines for contributing event-specific content to this repository are outlined in [CONTRIBUTING.md](CONTRIBUTING.md). If you intend to contribute (and we sure hope you do!), please take a moment to review that document. The technical details for contributing to the site-wide theme's development are covered in [devopsdays-theme's CONTRIBUTING.md](https://github.com/devopsdays/devopsdays-theme/blob/master/CONTRIBUTING.md).

--- a/utilities/README.md
+++ b/utilities/README.md
@@ -5,15 +5,15 @@ These scripts help devopsdays organizers manage their events.
 
 The technical details and guidelines for contributing to this repository are outlined in [CONTRIBUTING.md](../CONTRIBUTING.md).
 
-Full reference of all fields and features is located in [REFERENCE.md](https://github.com/devopsdays/devopsdays-web/blob/master/themes/devopsdays-theme/REFERENCE.md) in the theme directory. 
+Full reference of all fields and features is located in [REFERENCE.md](https://github.com/devopsdays/devopsdays-web/blob/master/themes/devopsdays-theme/REFERENCE.md) in the currently released theme directory.
 
-New utilities and updates to existing utilities are welcome, as are suggestions for default content. Add new script in [contrib](contrib/).
+New utilities and updates to existing utilities are welcome, as are suggestions for default content. Add new scripts in [contrib](contrib/).
 
-If you want others in your team to be able to preview/approve changes before they are merged, we recommend you follow [these steps](https://github.com/devopsdays/devopsdays-web/tree/master/utilities/docs/workflow) to work with your own repo prior to submitting a PR.
+If you want others in your team to be able to preview/approve changes before they are merged, we recommend you follow [this workflow](https://github.com/devopsdays/devopsdays-web/tree/master/utilities/docs/workflow) to work with your own repo prior to submitting a PR.
 
 ## Events
 
-Use [add_new_event.sh](add_new_event.sh) to add a new event.
+Use [add_new_event.sh](add_new_event.sh) to add a new event. This is year-specific, so you would run this when setting up the upcoming year's event for the first time.
 
 1. If your city name contains spaces or special characters, the script will remove them for purposes of the event stub, which will be used in the URL and have a name like `yyyy-city`.
 1. The script will create a data file for your event in `data/events/yyyy-city.yml`. This is where you will configure many of your updates and customizations. In particular, you need to list your local organizer team here.
@@ -22,11 +22,11 @@ Use [add_new_event.sh](add_new_event.sh) to add a new event.
 
 ## Google Analytics
 
-If you have set up a Google Analytics account for tracking your specific event, you can enable tracking for your event pages by updating the `ga_tracking_id` field in your `YYYY-CITY.yml` file. Example: `ga_tracking_id: "UA-74738648-1"`
+If you have set up a Google Analytics account for tracking your specific event, you can enable tracking for your event pages by updating the `ga_tracking_id` field in your `yyyy-city.yml` file. Example: `ga_tracking_id: "UA-74738648-1"`
 
 ### Event Square Logo
 
-To customize the logo that appears on the root of devopsdays.org, place a square file (jpg format only) in `static/events/yyyy-city`. It must be named `logo-square.jpg` and should be a minimum 300px x 300px, but optimizally should be 600px x 600px. 
+To customize the logo that appears on the root of devopsdays.org, place a square file (jpg format only) in `static/events/yyyy-city`. It must be named `logo-square.jpg` and should be at minimum 300px x 300px, but optimally should be 600px x 600px.
 
 ### Reference Content
 
@@ -43,7 +43,7 @@ The sample datafile has some sponsor levels pre-populated; edit as desired. You 
 Sometimes, an existing sponsor will want an event-specific URL for your event. Rather than creating a new sponsor, you can add an optional `url` field to the sponsor in your event data file to override the default URL for that sponsor. For example:
 
 ```
-sponsors: 
+sponsors:
   - id: victorops
     level: social
   - id: netapp
@@ -77,21 +77,24 @@ Guidelines regarding sponsor logo files and formatting:
 
 * The dimensions of the image file must be at least 200px wide. 600px will look best for high-density display.
 * The background must be either white or transparent.
+* Images do not need to be square, but they may look better if they are.
 
+<!--
 All logos will be resized at release time, to 200px wide. Versions for high-density display (ex. Retina) will also be created. It is recommended that you do not use a sponsor logo that is smaller than 200px wide to keep from quality degradation at resize time.
+-->
 
 ## Local Organizers
 
 See the example local organizer team members listed in the generated data file found in `data/events/201?-yourcity.yml`. To generate the  `team_members: ` section you can use [add_organizers.sh](add_organizers.sh).
 
-The organizer photo must be in JPG format, and should be a minimum 300px x 300px, but optimally 600px x 600px. These images should be placed in the `static/events/YYYY-CITY/organizers` directory (which the `add_organizers.sh` script will do).
+The organizer photo must be in JPG format, and should be a minimum 300px x 300px, but optimally 600px x 600px. These images should be placed in the `static/events/yyyy-city/organizers` directory (which the `add_organizers.sh` script will do).
 
-Any PRs adding a new local organizer will need to be accompanied by an email to `info@devopsdays.org` with their full name and email address.
+Any PRs adding a new local organizer will need to be accompanied by an email to `info@devopsdays.org` with their full name and email address. We merge the PR at the same time as adding them to email lists and Slack, so if you aren't ready to send that email, merging your PR will be delayed until we have that info.
 
 
 ## Social sharing image
 
-A sharing image is added to the Open Graph tags for your event pages, to improve the sharing on social networks such as Facebook (or in Slack). This image must be named `sharing.jpg` and located in `static/events/YYYY-CITY`. It should be a minimum 1200px x 630px, and use ratio: 1.91:1.
+A sharing image is added to the Open Graph tags for your event pages, to improve the sharing on social networks such as Facebook (or in Slack). This image must be named `sharing.jpg` and located in `static/events/yyyy-city`. It should be a minimum 1200px x 630px, and use ratio: 1.91:1.
 
 If no image is provided, then the meta tag will not be created. Facebook might try to infer it, but the links shared will just likely have no images.
 
@@ -116,13 +119,20 @@ If you have a two-speaker talk, create both speakers, add the talk under one of 
 Speakers = ["rainbow-dash","twilight-sparkle"]
 ```
 
+You can also rename the generated program file to include them both: `mv content/events/2017-ponyville/program/rainbow-dash.md content/events/2017-ponyville/program/dash-sparkle.md`. As long as the Speakers line is set correctly, this will work fine.
+
+
 ### Program
 
 Use [add_program.sh](add_program.sh) to add the program for your event. The program template expects 4 full talks each day and lists default times, but you can customize. The program data is stored in the event datafile such as `data/events/2017-ponyville.yml`. You don't need to know any or all of your speakers when adding the sample program, but if you have selected speakers you can list them on the program with this script.
 
+If you start working on the program before you have all your speakers, by default you'll have `talk-1` through `talk-8` and you can replace those with slugs like `rainbow-dash` or `dash-sparkle` as appropriate.
+
 
 ### Speaker Images
+
 The headshots for your speaker images can be either .png or .jpg. They must be square, preferably 600px square. If they are not square, they will be cropped at build time to the production site (note; image processing does not occur when running Hugo locally or in a deploy preview)
+
 
 # Adding slides and video
 
@@ -147,8 +157,8 @@ copy `.envrc.example` to `.envrc` and run `direnv allow`. See
 
 ```
 # devopsdays
-export DOD_YEAR="2019"            # your year
-export DOD_CITY="new-york-city"   # your city
+export DOD_YEAR="2019"            # set this to your year
+export DOD_CITY="new-york-city"   # set this to your city
 export DODPATH=~/git/devopsdays-web   # location of Git files
 alias dod='cd $DODPATH'
 alias dods='cd $DODPATH/content/events/$DOD_YEAR-$DOD_CITY/speakers'


### PR DESCRIPTION
I revised guidelines and docs to meet the following goals:

- moving a lot of detail about large file storage to the CONTRIBUTING file, out of the initial README people would start with
- updates related to the move from Travis to CircleCI
- language changes to more accurately address the audience (often an organizer from a new event, reading the docs for the first time)
- overall consistency, clarification, and error correction

Likely we'll want @mattstratton to sign off on this since there's a fair amount of technical site-related detail. Until he gets to merging this, feel free to weigh in with opinions. :) (After it's merged, just add a new PR with your edits.)