### PR TITLE
[LDN-2019] Add CircleCI and Pivotal as Sponsors

### DIFF
--- a/data/events/2019-london.yml
+++ b/data/events/2019-london.yml
@@ -85,6 +85,9 @@ sponsors:
     # Evening Event
   - id: f5
     level: evening
+    # Gold
+  - id: circleci
+    level: gold
     # Silver
   - id: tecknuovo
     level: silver

--- a/data/events/2019-london.yml
+++ b/data/events/2019-london.yml
@@ -88,6 +88,8 @@ sponsors:
     # Gold
   - id: circleci
     level: gold
+  - id: pivotal
+    level: gold
     # Silver
   - id: tecknuovo
     level: silver


### PR DESCRIPTION
Simple change adding two sponsors to data/events/2019-london.yml. Currently in draft whilst I OK with other members of the LDN team.