### PR TITLE
[Vancouver 2019] Adding Van speaker bios

### DIFF
--- a/content/events/2019-vancouver/speakers/adron-hall.md
+++ b/content/events/2019-vancouver/speakers/adron-hall.md
@@ -1,6 +1,6 @@
 +++
 Title = "Adron Hall"
-Twitter = ""
+Twitter = "Adron"
 image = "adron-hall.jpg"
 type = "speaker"
 linktitle = "adron-hall"

--- a/content/events/2019-vancouver/speakers/jay-gordon.md
+++ b/content/events/2019-vancouver/speakers/jay-gordon.md
@@ -1,10 +1,10 @@
 +++
 Title = "Jay Gordon"
-Twitter = ""
+Twitter = "jaydestro"
 image = "jay-gordon.jpg"
 type = "speaker"
 linktitle = "jay-gordon"
 
 +++
 
-
+Jay Gordon is a Senior Cloud Ops Advocate with the Microsoft Azure Advocates. He and the rest of the Advocacy team are focused on helping Developers and Ops teams get the most out of their cloud experience with Microsoft Azure. Prior to Microsoft, Jay was part of teams at DigitalOcean, BuzzFeed and MongoDB. Jay lives in New York City with his wife and has a goofy pug named Rico.

--- a/content/events/2019-vancouver/speakers/jj-asghar.md
+++ b/content/events/2019-vancouver/speakers/jj-asghar.md
@@ -1,10 +1,12 @@
 +++
 Title = "JJ Asghar"
-Twitter = ""
+Twitter = "jjasghar"
 image = "jj-asghar.jpg"
 type = "speaker"
 linktitle = "jj-asghar"
 
 +++
 
+JJ works at IBM on the IBM cloud as a Developer Advocate. He’s focusing on the IBM Kubernetes Service trying to make companies and users have a successful on boarding to the Cloud Native ecosystem.
 
+He lives and grew up in Austin, Texas. He enjoys a good strong stout, hoppy IPA, and some team building Artemis, madding Dwarf Fortress or Rimworld or pair programming cluster Factorio. He’s a member of the Church of Emacs, though jumps into Vim on remote machines. He usually chooses Ubuntu over CentOS, but secretly wants FreeBSD everywhere. He’s always trying to become a better Ruby developer, but flirts with Go, Rust, and only when he has to, Node. A father and husband, if he’s not trying to automate his job away he’s always to convince his daughters to “be button makers not button pushers.”

--- a/content/events/2019-vancouver/speakers/kenzie-woodbridge.md
+++ b/content/events/2019-vancouver/speakers/kenzie-woodbridge.md
@@ -1,10 +1,10 @@
 +++
 Title = "Kenzie Woodbridge"
-Twitter = ""
+Twitter = "rainbowkenz"
 image = "kenzie-woodbridge.jpg"
 type = "speaker"
 linktitle = "kenzie-woodbridge"
 
 +++
 
-
+Kenzie Woodbridge is a Web Developer, Community Manager, and Knowledge Base Administrator at the British Columbia Institute of Technology. Kenzie also recently completed a MA in Professional Communication at Royal Roads University and their thesis focused on prosocial community in online Minecraft. Kenzie is awesome and you totally want to be their friend (offer of friendship void where local laws do not permit, not guaranteed in all circumstances, skill-testing questions required).

--- a/content/events/2019-vancouver/speakers/kris-nova.md
+++ b/content/events/2019-vancouver/speakers/kris-nova.md
@@ -1,10 +1,10 @@
 +++
 Title = "Kris Nova"
-Twitter = ""
+Twitter = "krisnova"
 image = "kris-nova.png"
 type = "speaker"
 linktitle = "kris-nova"
 
 +++
 
-
+Kris Nova is a senior developer advocate at VMware focusing on containers, infrastructure, and Kubernetes. Kris is also an ambassador for the Cloud Native Computing Foundation. Previously, she was a developer advocate and an engineer on Kubernetes at Heptio, and spent time working on Kubernetes in Azure at Microsoft. Nova has a deep technical background in the Go programming language and has authored many successful open source tools in Go. She is a Kubernetes maintainer and the creator of kubicorn, a successful Kubernetes infrastructure management tool. Nova organizes a special interest group in Kubernetes and is a leader in the community. She understands the grievances with running cloud-native infrastructure via a distributed cloud-native application and recently authored an O’Reilly book on the topic, Cloud Native Infrastructure. Kris lives in Seattle and spends her free time climbing mountains.

--- a/content/events/2019-vancouver/speakers/quintessence-anx.md
+++ b/content/events/2019-vancouver/speakers/quintessence-anx.md
@@ -1,10 +1,10 @@
 +++
 Title = "Quintessence Anx"
-Twitter = ""
+Twitter = "quintessenceanx"
 image = "quintessence-anx.jpg"
 type = "speaker"
 linktitle = "quintessence-anx"
 
 +++
 
-
+Quintessence has worked in the IT community for over 10 years, including as a database administrator and a DevOps / Cloud / Infrastructure engineer. She was a core contributor to Stark & Wayne’s SHIELD project, which adds backup functionality to Cloud Foundry, as well as a technical reviewer for Learning Go Programming published by Packt Publishing. Currently she is the US Developer Advocate for Logz.io, focusing community engagement related to DevOps. Outside of work she is a chapter leader of Girl Develop It’s Buffalo chapter to help women in the Buffalo community launch careers in development.

--- a/content/events/2019-vancouver/speakers/sonia-gupta.md
+++ b/content/events/2019-vancouver/speakers/sonia-gupta.md
@@ -1,10 +1,12 @@
 +++
 Title = "Sonia Gupta"
-Twitter = ""
+Twitter = "soniagupta504"
 image = "sonia-gupta.jpg"
 type = "speaker"
 linktitle = "sonia-gupta"
 
 +++
 
+Sonia Gupta is currently a software developer in Los Angeles, CA. Prior to becoming a developer, Sonia was a lawyer in Louisiana. She served as a Public Defender in New Orleans after Hurricane Katrina, then as a Prosecutor, and finally as an Assistant Attorney General doing torts and Civil Rights litigation.
 
+Sonia is an outspoken advocate of diversity and inclusion in tech and in life. She is passionate about fostering empathetic and effective communication on engineering teams, and believes that even if tech can’t always change the world, technologists absolutely can.

--- a/content/events/2019-vancouver/speakers/tiffany-longworth.md
+++ b/content/events/2019-vancouver/speakers/tiffany-longworth.md
@@ -1,10 +1,10 @@
 +++
 Title = "Tiffany Longworth"
-Twitter = ""
+Twitter = "thelongshanx"
 image = "tiffany-longworth.jpg"
 type = "speaker"
 linktitle = "tiffany-longworth"
 
 +++
 
-
+Tiffany Longworth is a Site Reliability Engineer at Zapproved. She has launched successful projects large and small, but has also worked on projects that were spectacular failures! She likes using her background as a Marine, her training as an English teacher, automation, and cat gifs as much as possible.


### PR DESCRIPTION
Adding speaker bios/twitter handles for Vancouver. approval requested from @Velutas or the rest of the team

(Note that there wasn't an obvious choice for Adron's but I asked him.)