### PR TITLE
[DET-2019] Updates for 2019 and CFP local link fix

### DIFF
--- a/content/events/2019-detroit/propose.md
+++ b/content/events/2019-detroit/propose.md
@@ -1,20 +1,20 @@
 +++
-Title = "Propose"
-Type = "event"
+title = "propose"
+type = "event"
 Description = "Propose a talk for DevOpsDays Detroit 2019"
 +++
 
   {{< cfp_dates >}}
 
 <hr/>
-[Submit your proposal](https://sessionize.com/devopsdaysdet2019/)
+[Submit your proposal!](https://sessionize.com/devopsdaysdet2019/)
 <hr/>
 
 
 # DevopsDays Detroit CFP closes July 30th, 2019
 ## What we’re looking this year
 
-Types of Accepted Proposals 
+Types of Accepted Proposals
 
 - Ignite Talks: 5-minute, auto-forwarding talk.
 - Presentations: A 30-minute talk on a topic of your choice, with some time for questions.
@@ -58,5 +58,5 @@ The Ignite Talks are 5 minute talks with 20 slides (max., 15 seconds per slide) 
 - Open Space Fodder: Will this talk help generate discussion in the Open Spaces?
 
 <hr/>
-[Submit your proposal](https://sessionize.com/devopsdaysdet2019/)
+[Submit your proposal!](https://sessionize.com/devopsdaysdet2019/)
 <hr/>

--- a/content/events/2019-detroit/welcome.md
+++ b/content/events/2019-detroit/welcome.md
@@ -53,6 +53,15 @@ Description = "devopsdays Detroit 2019"
 
 <div class = "row">
   <div class = "col-md-2">
+    <strong>Propose</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="propose" text="Propose a talk!" >}}
+  </div>
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
     <strong>Sponsors</strong>
   </div>
   <div class = "col-md-8">

--- a/data/events/2019-detroit.yml
+++ b/data/events/2019-detroit.yml
@@ -2,7 +2,7 @@ name: "2019-detroit" # The name of the event. Four digit year with the city name
 year: "2019" # The year of the event. Make sure it is in quotes.
 city: "Detroit" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysdet"
-description: "DevOpsDays Detroit's 6th Year!" # A short blurb of text to describe your event, defaults to common DevOpsDays description
+description: "DevOpsDays Detroit's 4th Year!" # A short blurb of text to describe your event, defaults to common DevOpsDays description
 ga_tracking_id: "UA-94092408-1" # Google Analytics tracking ID
 
 # All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
@@ -15,7 +15,8 @@ cfp_date_end:      2019-07-30 # close your call for proposals.
 cfp_date_announce: 2019-08-06 # inform proposers of status
 
 cfp_open: "true"
-cfp_link: "https://sessionize.com/devopsdaysdet2019/"  #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+## Don't fill with our external site as we want navbar "propose" link to go to propose page, not offsite (yet)
+cfp_link: ""  #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2019-02-27
 registration_date_end: 2019-10-22
@@ -56,7 +57,7 @@ team_members: # Name is the only required field for team members.
     employer: Autonomic
     twitter: AimmeKeener
   - name: "Mario Loria"
-    employer: orchestructure.io
+    employer: StockX
     twitter: marioploria
   - name: "Aaron Maturen"
     employer: Cengage
@@ -73,7 +74,6 @@ proposal_email: "proposals-detroit-2019@devopsdays.org" # Put your proposal emai
 sponsors:
   - id: russellvideo
     level: AV
-
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Some minor 2019 related updates and remove custom CFP link so local propose linkage actually directs to propose page, not external submission page.