### PR TITLE
Datetime datafile and template fix

### DIFF
--- a/data/events/2019-amsterdam.yml
+++ b/data/events/2019-amsterdam.yml
@@ -5,20 +5,24 @@ event_twitter: "devopsams" # Change this to the twitter handle for your event su
 description: "devopsdays Amsterdam is back for the 7th time!" # Edit this to suit your preferences
 ga_tracking_id: "UA-38891729-3" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-06-26 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-06-28 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-06-26T00:00:00+02:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-06-28T23:59:59+02:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-01-10 # start accepting talk proposals.
-cfp_date_end:  2019-04-01 # close your call for proposals.
-cfp_date_announce:  2019-04-14 # inform proposers of status
+cfp_date_start: 2019-01-10T00:00:00+01:00 # start accepting talk proposals.
+cfp_date_end:  2019-04-01T23:59:59+02:00 # close your call for proposals.
+cfp_date_announce:  2019-04-14T23:59:59+02:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://sessionize.com/dodams2019/" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-01-10 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-06-25 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-01-10T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-06-25T23:59:59+02:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 # Note: We use the HTML iframe solution to also advertise that we have direct to invoice as an option.

--- a/data/events/2019-aracaju.yml
+++ b/data/events/2019-aracaju.yml
@@ -6,22 +6,26 @@ event_logo: "logo-square.jpg"
 description: "DevOpsDays is coming to Aracaju!" # Edit this to suit your preferences
 ga_tracking_id: "UA-133453281-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-06-08 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-06-08 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-06-08T00:00:00-03:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-06-08T23:59:59-03:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-02-10 # start accepting talk proposals.
-cfp_date_end: 2019-04-30 # close your call for proposals.
-cfp_date_announce: 2019-05-10 # inform proposers of status
+cfp_date_start: 2019-02-10T00:00:00-03:00 # start accepting talk proposals.
+cfp_date_end: 2019-04-30T23:59:59-03:00 # close your call for proposals.
+cfp_date_announce: 2019-05-10T23:59:59-03:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsday-aracaju-2019" # if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 masthead_background: "skyline-aju.jpg"
 
-registration_date_start: 2019-03-07 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-06-07 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-03-07T00:00:00-03:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-06-07T23:59:59-03:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" # set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdaysaracaju.eventize.com.br" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-atlanta.yml
+++ b/data/events/2019-atlanta.yml
@@ -5,20 +5,24 @@ event_twitter: "devopsdaysATL" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to the Georgia Aquarium!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-04-09  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-04-10  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-04-09T00:00:00-04:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-04-10T23:59:59-04:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-12-01  # start accepting talk proposals.
-cfp_date_end: 2019-02-28  # close your call for proposals.
-cfp_date_announce: 2019-03-08  # inform proposers of status
+cfp_date_start: 2018-12-01T00:00:00-05:00  # start accepting talk proposals.
+cfp_date_end: 2019-02-28T23:59:59-05:00  # close your call for proposals.
+cfp_date_announce: 2019-03-08T23:59:59-05:00  # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdaysatl2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-12-13 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-04-02 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-12-13T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-04-02T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdaysatl2019.eventbrite.com" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-auckland.yml
+++ b/data/events/2019-auckland.yml
@@ -6,20 +6,25 @@ description: "Devopsdays is coming to Auckland!" # Edit this to suit your prefer
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: "New Zealand"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-#startdate: 2019-MM-DD # The start date of your event. Leave blank if you don't have a venue reserved yet.
-#enddate: 2019-MM-DD  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+#startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+#enddate:   # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-#cfp_date_start: 2019-MM-DD # start accepting talk proposals.
-#cfp_date_end: 2019-MM-DD # close your call for proposals.
-#cfp_date_announce: 2019-MM-DD  # inform proposers of status
+#cfp_date_start:  # start accepting talk proposals.
+#cfp_date_end:  # close your call for proposals.
+#cfp_date_announce:  # inform proposers of status
 
 #cfp_open: "false"
 #cfp_link: "https://www.papercall.io/devopsdays-auckland-2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-#registration_date_start: 2019-MM-DD # start accepting registration. Leave blank if registration is not open yet
-#registration_date_end: 2019-MM-DD # close registration. Leave blank if registration is not open yet.
+#registration_date_start:  # start accepting registration. Leave blank if registration is not open yet
+#registration_date_end:  # close registration. Leave blank if registration is not open yet.
 
 masthead_background: "harbour-bridge.jpg"
 

--- a/data/events/2019-austin.yml
+++ b/data/events/2019-austin.yml
@@ -6,14 +6,18 @@ description: "DevOpsDays Austin's 8th Year!" # Edit this to suit your preference
 
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-05-02 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-05-03 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-05-02T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-05-03T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-01-28 # start accepting talk proposals.
-cfp_date_end: 2019-02-28 # close your call for proposals.
-cfp_date_announce: 2019-03-11 # inform proposers of status
+cfp_date_start: 2019-01-28T00:00:00-05:00 # start accepting talk proposals.
+cfp_date_end: 2019-02-28T23:59:59-05:00 # close your call for proposals.
+cfp_date_announce: 2019-03-11T23:59:59-05:00 # inform proposers of status
 
 cfp_open: "true"
 # https://www.papercall.io/devopsdays-austin-2019

--- a/data/events/2019-baltimore.yml
+++ b/data/events/2019-baltimore.yml
@@ -5,19 +5,23 @@ event_twitter: "devopsdaysbmore"
 description: "DevOpsDays is coming back to Baltimore!"
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-04-24  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-04-25 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-04-24T00:00:00-04:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-04-25T23:59:59-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-12-01 # start accepting talk proposals.
-cfp_date_end: 2019-02-03 # close your call for proposals.
-cfp_date_announce: 2019-02-18 # inform proposers of status
+cfp_date_start: 2018-12-01T00:00:00-05:00 # start accepting talk proposals.
+cfp_date_end: 2019-02-03T23:59:59-05:00 # close your call for proposals.
+cfp_date_announce: 2019-02-18T23:59:59-05:00 # inform proposers of status
 
 cfp_link: "https://devopsdaysbaltimore2019.busyconf.com/proposals/new" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: "2019-01-31" # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: "2020-01-01" # close registration. Leave blank if registration is not open yet.
+registration_date_start: "2019-01-31T00:00:00-05:00" # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: "2020-01-01T00:00:00-05:00" # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 # Uncomment this when registration opens

--- a/data/events/2019-beijing.yml
+++ b/data/events/2019-beijing.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdays_cn" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming to beijing!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-05-11T00:00:00+08:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  2019-05-12T00:00:00+08:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-belo-horizonte.yml
+++ b/data/events/2019-belo-horizonte.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdaysbh" # Change this to the twitter handle for your event
 description: "Devopsdays is coming to Belo Horizonte!" # Edit this to suit your preferences
 ga_tracking_id: "UA-124055941-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-berlin.yml
+++ b/data/events/2019-berlin.yml
@@ -6,20 +6,24 @@ description: "Devopsdays is returning to Berlin!" # Edit this to suit your prefe
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_logo: "logo-square.jpg"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-11-27T00:00:00+02:00
-enddate: 2019-11-28T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-11-27T00:00:00+01:00
+enddate: 2019-11-28T23:59:59+01:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-02-12T00:00:00+02:00
+cfp_date_start: 2019-02-12T00:00:00+01:00
 cfp_date_end: 2019-07-31T23:59:59+02:00
 cfp_date_announce: 2019-08-15T23:59:59+02:00
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/2019-berlin" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-12-01T00:00:00+02:00
-registration_date_end: 2019-11-27T00:00:00+02:00 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-12-01T00:00:00+01:00
+registration_date_end: 2019-11-27T00:00:00+01:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-bogota.yml
+++ b/data/events/2019-bogota.yml
@@ -5,20 +5,24 @@ event_twitter: "DevopsdaysB" # Change this to the twitter handle for your event 
 description: "¡Sé parte del primer devopsdays Bogota!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-05-25T08:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2019-05-26T18:00:00-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-02-12T17:30:00-06:00  # start accepting talk proposals.
-cfp_date_end: 2019-05-01T23:59:00-06:00  # close your call for proposals.
-cfp_date_announce: 2019-05-13T23:59:00-06:00  # inform proposers of status
+cfp_date_start: 2019-02-12T17:30:00-05:00  # start accepting talk proposals.
+cfp_date_end: 2019-05-01T23:59:00-05:00  # close your call for proposals.
+cfp_date_announce: 2019-05-13T23:59:00-05:00  # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://www.papercall.io/devopsdaysbogota" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-03-01T17:30:00-06:00 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-05-24T17:30:00-06:00 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-03-01T17:30:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-05-24T17:30:00-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdays.co/entradas" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-boise.yml
+++ b/data/events/2019-boise.yml
@@ -5,20 +5,24 @@ event_twitter: "DevOpsDaysBoise" # Change this to the twitter handle for your ev
 description: "Devopsdays is coming to Boise!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: "2019-05-30"  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: "2019-05-30" # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-05-30T00:00:00-06:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-05-30T23:59:59-06:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: "2019-01-22"  # start accepting talk proposals.
-cfp_date_end: "2019-03-31" # close your call for proposals.
-cfp_date_announce: "2019-04-15"  # inform proposers of status
+cfp_date_start: 2019-01-22T00:00:00-07:00  # start accepting talk proposals.
+cfp_date_end: 2019-03-31T23:59:59-06:00 # close your call for proposals.
+cfp_date_announce: 2019-04-15T23:59:59-06:00  # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: "2018-12-01" # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: "2019-05-30" # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-12-01T00:00:00-07:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-05-30T23:59:59-06:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-boston.yml
+++ b/data/events/2019-boston.yml
@@ -5,9 +5,13 @@ event_twitter: "devopsdaysbos" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Boston!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-09-23 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-09-24 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-09-23T00:00:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-09-24T23:59:59-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2019-buffalo.yml
+++ b/data/events/2019-buffalo.yml
@@ -5,19 +5,23 @@ event_twitter: "DevOpsDaysBuf" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Buffalo!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-09-26
-enddate: 2019-09-27
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-09-26T00:00:00-04:00
+enddate: 2019-09-27T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-02-13
-cfp_date_end: 2019-03-30
-cfp_date_announce: 2019-04-01
+cfp_date_start: 2019-02-13T00:00:00-05:00
+cfp_date_end: 2019-03-30T23:59:59-04:00
+cfp_date_announce: 2019-04-01T23:59:59-04:00
 
 cfp_link: "https://www.papercall.io/dodbflo19" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-02-13
-registration_date_end: 2019-09-27
+registration_date_start: 2019-02-13T00:00:00-05:00
+registration_date_end: 2019-09-27T23:59:59-04:00
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://ti.to/devops-days-buffalo-2019/dodBFLO2019" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-cairo.yml
+++ b/data/events/2019-cairo.yml
@@ -6,9 +6,13 @@ description: "Please stay tuned for more information about DevOpsDays Cairo 2019
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: ""
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-09-09
-enddate: 2019-09-09
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-09-09T00:00:00+02:00
+enddate: 2019-09-09T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: # start accepting talk proposals.

--- a/data/events/2019-campinas.yml
+++ b/data/events/2019-campinas.yml
@@ -5,9 +5,13 @@ event_twitter: "devopsdayscamp" # Change this to the twitter handle for your eve
 description: "DevOpsDays is coming to Campinas!" # Edit this to suit your preferences
 # ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-10-04 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-10-04 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-10-04T00:00:00-03:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-10-04T23:59:59-03:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: # start accepting talk proposals.

--- a/data/events/2019-cape-town.yml
+++ b/data/events/2019-cape-town.yml
@@ -6,13 +6,17 @@ event_twitter: "devopsdayscpt"
 description: "Devopsdays is coming to Cape Town!"
 ga_tracking_id: "UA-105986234-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-09-05
-enddate: 2019-09-06
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-09-05T00:00:00+02:00
+enddate: 2019-09-06T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-02-18
-cfp_date_end: 2019-08-01
+cfp_date_start: 2019-02-18T00:00:00+02:00
+cfp_date_end: 2019-07-31T23:07:59+02:00
 cfp_date_announce:
 
 cfp_link: "https://www.papercall.io/devopsdayscpt2019"

--- a/data/events/2019-charlotte.yml
+++ b/data/events/2019-charlotte.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdays_clt" # Change this to the twitter handle for your eve
 description: "Devopsdays is coming back to Charlotte!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-02-07T00:00:00-05:00
 enddate: 2019-02-08T23:59:59-05:00
 

--- a/data/events/2019-chattanooga.yml
+++ b/data/events/2019-chattanooga.yml
@@ -7,7 +7,10 @@ ga_tracking_id: "UA-122945114-1" # If you have your own Google Analytics trackin
 
 masthead_background: "chattanooga-masthead.jpg"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
 startdate: 2019-11-12T00:00:00-05:00
 enddate: 2019-11-12T23:59:59-05:00

--- a/data/events/2019-chicago.yml
+++ b/data/events/2019-chicago.yml
@@ -5,14 +5,18 @@ event_twitter: "devopsdaysChi" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Chicago!" # Edit this to suit your preferences
 ga_tracking_id: "UA-74738648-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-08-27 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-08-28 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-08-27T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-08-28T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-02-15 # start accepting talk proposals.
-cfp_date_end: 2019-05-03 # close your call for proposals.
-cfp_date_announce: 2019-06-03 # inform proposers of status
+cfp_date_start: 2019-02-15T00:00:00-06:00 # start accepting talk proposals.
+cfp_date_end: 2019-05-03T23:59:59-05:00 # close your call for proposals.
+cfp_date_announce: 2019-06-03T23:59:59-05:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/data/events/2019-columbus.yml
+++ b/data/events/2019-columbus.yml
@@ -6,7 +6,11 @@ description: "Devopsdays Columbus is Back!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: "Columbus"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-09-18T00:00:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2019-09-19T23:59:59-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-copenhagen.yml
+++ b/data/events/2019-copenhagen.yml
@@ -5,13 +5,17 @@ event_twitter: "devopsdayscph" # Change this to the twitter handle for your even
 description: "Devopsdays is coming back to Copenhagen!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-04-03 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-04-04 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-04-03T00:00:00+02:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-04-04T23:59:59+02:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  2018-12-04 # start accepting talk proposals.
-cfp_date_end:  2019-01-21 # close your call for proposals.
+cfp_date_start:  2018-12-04T00:00:00+01:00 # start accepting talk proposals.
+cfp_date_end:  2019-01-21T23:59:59+01:00 # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
 cfp_open: "true"

--- a/data/events/2019-cuba.yml
+++ b/data/events/2019-cuba.yml
@@ -4,18 +4,20 @@ city: "Cuba" # The city name of the event. Capitalize it.
 friendly: "2019-cuba" # Four digit year and the city name in lower-case. Don't forget the dash!
 event_twitter: "devopsdayscuba"
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
-# Don't think thisis used anymore. - status: "" # Options are "past" or "current". Use "current" for upcoming.
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2017-01-05
-startdate: 2019-06-23  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-06-30 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-06-23T00:00:00-04:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-06-30T23:59:59-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-03-03  # start accepting talk proposals.
-cfp_date_end: 2019-04-24 # close your call for proposals.
-cfp_date_announce: 2019-04-30 # inform proposers of status
+cfp_date_start: 2019-03-03T00:00:00-05:00  # start accepting talk proposals.
+cfp_date_end: 2019-04-24T23:59:59-04:00 # close your call for proposals.
+cfp_date_announce: 2019-04-30T23:59:59-04:00 # inform proposers of status
 
-cfp_open: "2019-03-03"
 cfp_link: "https://www.papercall.io/cfps/2028/submissions/new"
 
 registration_open: "false"

--- a/data/events/2019-dallas.yml
+++ b/data/events/2019-dallas.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdaysdfw" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Dallas!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-denver.yml
+++ b/data/events/2019-denver.yml
@@ -6,20 +6,24 @@ description: "DevOpsDays Denver Coming Up!" # Edit this to suit your preferences
 friendly: "2019-denver" # Four digit year and the city name in lower-case. Don't forget the dash!
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-04-29 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-04-30 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-04-29T00:00:00-06:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-04-30T23:59:59-06:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-01-09 # start accepting talk proposals.
-cfp_date_end: 2019-03-03 # close your call for proposals.
-cfp_date_announce: 2019-03-18 # inform proposers of status
+cfp_date_start: 2019-01-09T00:00:00-07:00 # start accepting talk proposals.
+cfp_date_end: 2019-03-03T23:59:59-07:00 # close your call for proposals.
+cfp_date_announce: 2019-03-18T23:59:59-06:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://www.papercall.io/dod-den-2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-01-20 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-04-29 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-01-20T00:00:00-07:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-04-29T23:59:59-06:00 # close registration. Leave blank if registration is not open yet.
 
 #registration_closed: "false" # set this to true if you need to manually close registration before your registration end date
 #registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-des-moines.yml
+++ b/data/events/2019-des-moines.yml
@@ -5,20 +5,25 @@ event_twitter: "devopsdaysdsm" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Des Moines!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-05-02 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-05-03 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-05-02T00:01:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-05-03T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2019-01-01T00:00:00-06:00 # start accepting talk proposals.
 cfp_date_end:  2019-02-08T23:59:00-06:00 # close your call for proposals.
-cfp_date_announce:  2018-12-30T00:00:00-06:00 # inform proposers of status
+# this should be the date you plan to announce your completed program
+#cfp_date_announce:  2018-12-30T00:00:00-06:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://www.papercall.io/devopsdaysdesmoines2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2019-01-01T00:00:00-06:00 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-05-01T00:00:00-06:00 # close registration. Leave blank if registration is not open yet.
+registration_date_end: 2019-05-01T00:00:00-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://eventbrite.com/e/devopsdays-des-moines-2019-tickets-54007008416" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-detroit.yml
+++ b/data/events/2019-detroit.yml
@@ -5,21 +5,25 @@ event_twitter: "devopsdaysdet"
 description: "DevOpsDays Detroit's 4th Year!" # A short blurb of text to describe your event, defaults to common DevOpsDays description
 ga_tracking_id: "UA-94092408-1" # Google Analytics tracking ID
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-10-23
-enddate:   2019-10-24
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-10-23T00:00:00-04:00
+enddate:   2019-10-24T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:    2019-02-13 # start accepting talk proposals.
-cfp_date_end:      2019-07-30 # close your call for proposals.
-cfp_date_announce: 2019-08-06 # inform proposers of status
+cfp_date_start:    2019-02-13T00:00:00-05:00 # start accepting talk proposals.
+cfp_date_end:      2019-07-30T23:59:59-04:00 # close your call for proposals.
+cfp_date_announce: 2019-08-06T23:59:59-04:00 # inform proposers of status
 
 cfp_open: "true"
 ## Don't fill with our external site as we want navbar "propose" link to go to propose page, not offsite (yet)
 cfp_link: ""  #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-02-27
-registration_date_end: 2019-10-22
+registration_date_start: 2019-02-27T00:00:00-05:00
+registration_date_end: 2019-10-22T00:00:00-04:00
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-edinburgh.yml
+++ b/data/events/2019-edinburgh.yml
@@ -5,9 +5,13 @@ event_twitter: "devopsdaysedi" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Edinburgh!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-10-17  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-10-18 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-10-17T00:00:00+01:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-10-18T23:59:59+01:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2019-geneva.yml
+++ b/data/events/2019-geneva.yml
@@ -6,7 +6,11 @@ event_logo: "logo-square.jpg"
 description: "Devopsdays is coming to Geneva!" # Edit this to suit your preferences
 ga_tracking_id: "UA-85366825-4" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-02-21T08:00:00+01:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2019-02-22T17:00:00+01:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-ghent.yml
+++ b/data/events/2019-ghent.yml
@@ -6,9 +6,13 @@ description: "Devopsdays is coming BACK to Ghent!" # Edit this to suit your pref
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: "Ghent"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-10-28 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-10-30  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-10-28T00:00:00+01:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-10-30T23:59:59+01:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2019-hartford.yml
+++ b/data/events/2019-hartford.yml
@@ -5,9 +5,13 @@ event_twitter: "devopsdayshfd" # Change this to the twitter handle for your even
 description: "DevOpsDays Hartford is back at Infinity Hall for 2019!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-10-02 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-10-03 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-10-02T00:00:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-10-03T23:59:59-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2019-houston.yml
+++ b/data/events/2019-houston.yml
@@ -5,20 +5,24 @@ event_twitter: "DevOpsDaysHTown" # Change this to the twitter handle for your ev
 description: "Devopsdays is coming to Houston!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate:  2019-04-16 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-04-17 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate:  2019-04-16T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-04-17T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-12-01 # start accepting talk proposals.
-cfp_date_end: 2019-01-31 # close your call for proposals.
-cfp_date_announce: 2019-02-21 # inform proposers of status
+cfp_date_start: 2018-12-01T00:00:00-06:00 # start accepting talk proposals.
+cfp_date_end: 2019-01-31T23:59:59-06:00 # close your call for proposals.
+cfp_date_announce: 2019-02-21T23:59:59-06:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://www.papercall.io/2019-houston" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: "2019-01-21" # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: "2019-04-15" # close registration. Leave blank if registration is not open yet.
+registration_date_start: "2019-01-21T00:00:00-06:00" # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: "2019-04-15T23:59:59-05:00" # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.eventbrite.com/e/devopsdays-houston-2019-tickets-54629883452" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-indianapolis.yml
+++ b/data/events/2019-indianapolis.yml
@@ -6,20 +6,24 @@ status: "current"
 description: "DevOpsDays is coming to Indianapolis!" # Edit this to suit your preferences
 ga_tracking_id: "UA-109430778-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-07-25
-enddate: 2019-07-26
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-07-25T00:00:00-04:00
+enddate: 2019-07-26T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-12-06 # start accepting talk proposals.
-cfp_date_end: 2019-03-22 # close your call for proposals.
-cfp_date_announce: 2019-04-07 # inform proposers of status
+cfp_date_start: 2018-12-06T00:00:00-05:00 # start accepting talk proposals.
+cfp_date_end: 2019-03-22T23:59:59-04:00 # close your call for proposals.
+cfp_date_announce: 2019-04-07T23:59:59-04:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdaysindy2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-12-06  # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-07-27 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-12-06T00:00:00-05:00  # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-07-27T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdaysindy2019.eventbrite.com/?aff=devopsdays"

--- a/data/events/2019-istanbul.yml
+++ b/data/events/2019-istanbul.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdaysist" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming to Istanbul!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-09-19T00:00:00+03:00
 enddate: 2019-09-20T23:59:59+03:00
 

--- a/data/events/2019-jakarta.yml
+++ b/data/events/2019-jakarta.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdaysjkt" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Jakarta again!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-04-10T00:00:00+07:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2019-04-11T23:59:59+07:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-johannesburg.yml
+++ b/data/events/2019-johannesburg.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdays" # Change this to the twitter handle for your event s
 description: "Devopsdays is coming to Johannesburg!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-kansas-city.yml
+++ b/data/events/2019-kansas-city.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdayskc" # Change this to the twitter handle for your event
 description: "Devopsdays is coming to Kansas City!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-kiev.yml
+++ b/data/events/2019-kiev.yml
@@ -6,20 +6,24 @@ event_twitter: "days_dev" # Change this to the twitter handle for your event suc
 description: "Devopsdays is coming to Kyiv!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-05-17 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-05-18 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-05-17T00:00:00+03:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-05-18T23:59:59+03:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-09-01 # start accepting talk proposals.
-cfp_date_end: 2019-03-01 # close your call for proposals.
+cfp_date_start: 2018-09-01T00:00:00+03:00 # start accepting talk proposals.
+cfp_date_end: 2019-03-01T23:59:59+02:00 # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://goo.gl/forms/iuBcf8PbIiKKD42j2" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-01-01 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-05-17 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-01-01T00:00:00+02:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-05-17T23:59:59+03:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdayskyiv.2event.com" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-london.yml
+++ b/data/events/2019-london.yml
@@ -5,14 +5,18 @@ event_twitter: "DevOpsDaysLDN" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming to London!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-09-26T00:00:00+00:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-09-27T00:00:00+00:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-09-26T00:00:00+01:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-09-27T23:59:59+01:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2019-01-16T00:00:00+00:00
-cfp_date_end: 2019-05-26T23:59:59+00:00
-cfp_date_announce: 2019-06-26T00:00:00+00:00
+cfp_date_end: 2019-05-26T23:59:59+01:00
+cfp_date_announce: 2019-06-26T00:00:00+01:00
 
 cfp_open: "true"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/data/events/2019-los-angeles.yml
+++ b/data/events/2019-los-angeles.yml
@@ -4,13 +4,17 @@ city: "Los Angeles" # The displayed city name of the event. Capitalize it.
 description: "DevOpsDays is returning to Southern California in 2019" # A short blurb of text to describe your event, defaults to common DevOpsDays description
 event_group: "Los Angeles"
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate:  2019-03-08 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-03-08 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate:  2019-03-08T00:00:00-08:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-03-08T23:59:59-08:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-12-19  # start accepting talk proposals.
-cfp_date_end: 2019-01-15 # close your call for proposals.
-cfp_date_announce: 2019-02-15 # inform proposers of status.
+cfp_date_start: 2018-12-19T00:00:00-08:00  # start accepting talk proposals.
+cfp_date_end: 2019-01-15T23:59:59-08:00 # close your call for proposals.
+cfp_date_announce: 2019-02-15T23:59:59-08:00 # inform proposers of status.
 
 # Location
 #

--- a/data/events/2019-madison.yml
+++ b/data/events/2019-madison.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdaysmsn" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Madison!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-minneapolis.yml
+++ b/data/events/2019-minneapolis.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdaysmsp" # Change this to the twitter handle for your even
 description: "Devopsdays Minneapolis will return in 2019!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-08-06T08:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2019-08-07T18:00:00-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-montevideo.yml
+++ b/data/events/2019-montevideo.yml
@@ -5,7 +5,11 @@ event_twitter: "DevOpsDaysMVD" # Change this to the twitter handle for your even
 description: "DevOpsDays próximamente en Montevideo!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-montreal.yml
+++ b/data/events/2019-montreal.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsmontreal" # Change this to the twitter handle for your eve
 description: "Devopsdays is coming to Montreal!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-nashville.yml
+++ b/data/events/2019-nashville.yml
@@ -5,20 +5,24 @@ event_twitter: "devopsbna2019" # Change this to the twitter handle for your even
 description: "Devopsdays In Nashville returns in 2019" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-05-09 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-05-10 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-05-09T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-05-10T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-11-01 # start accepting talk proposals.
-cfp_date_end: 2019-02-01 # close your call for proposals.
-cfp_date_announce: 2019-03-01 # inform proposers of status
+cfp_date_start: 2018-11-01T00:00:00-06:00 # start accepting talk proposals.
+cfp_date_end: 2019-02-01T23:59:59-06:00 # close your call for proposals.
+cfp_date_announce: 2019-03-01T23:59:59-06:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-10-08 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-05-03 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-10-08T00:00:00-06:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-05-03T23:59:59-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://pheedloop.com/register/devopsdaysnashville/attendee/" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-natal.yml
+++ b/data/events/2019-natal.yml
@@ -6,22 +6,26 @@ event_logo: "logo-square.jpg"
 description: "DevOpsDays is coming to Natal!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-03-09 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-03-09 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-03-09T00:00:00-03:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-03-09T23:59:59-03:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-12-28 # start accepting talk proposals.
-cfp_date_end: 2019-02-15 # close your call for proposals.
-cfp_date_announce: 2019-02-16 # inform proposers of status
+cfp_date_start: 2018-12-28T00:00:00-03:00 # start accepting talk proposals.
+cfp_date_end: 2019-02-15T23:59:59-03:00 # close your call for proposals.
+cfp_date_announce: 2019-02-16T23:59:59-03:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://speakerfight.com/events/devopsday-natal-2019/" # if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 masthead_background: "natal.jpg"
 
-registration_date_start: 2019-01-22 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-03-06 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-01-22T00:00:00-03:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-03-06T23:59:59-03:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" # set this to true if you need to manually close registration before your registration end date
 registration_link: "https://devopsdaysnatal.eventize.com.br" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-new-york-city.yml
+++ b/data/events/2019-new-york-city.yml
@@ -8,14 +8,18 @@ event_group: "New York City"
 
 masthead_background: "nyc-masthead.jpg"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: "2019-01-24"  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: "2019-01-25"  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: "2019-01-24T00:00:00-05:00"  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: "2019-01-25T23:59:59-05:00"  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  "2018-09-14" # start accepting talk proposals.
-cfp_date_end:  "2018-10-30" # close your call for proposals.
-cfp_date_announce:  "2018-12-03"# inform proposers of status
+cfp_date_start:  "2018-09-14T00:00:00-04:00" # start accepting talk proposals.
+cfp_date_end:  "2018-10-30T23:59:59-04:00" # close your call for proposals.
+cfp_date_announce:  "2018-12-03T23:59:59-05:00" # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/dodnyc2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/data/events/2019-oslo.yml
+++ b/data/events/2019-oslo.yml
@@ -7,7 +7,11 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 event_logo: "logo.png"
 event_group: "Oslo"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-10-22T00:00:00+02:00
 enddate: 2019-10-23T23:59:59+02:00
 

--- a/data/events/2019-panama.yml
+++ b/data/events/2019-panama.yml
@@ -6,14 +6,18 @@ event_twitter: "dodpanama"
 ga_tracking_id: "UA-124724975-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 status: "current" # Options are "past" or "current". Use "current" for upcoming.
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2017-01-05
-startdate: 2019-09-24 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-09-25 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-09-24T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-09-25T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-03-06 # start accepting talk proposals.
-cfp_date_end: 2019-06-06 # close your call for proposals.
-cfp_date_announce: 2019-06-13 # inform proposers of status
+cfp_date_start: 2019-03-06T00:00:00-05:00 # start accepting talk proposals.
+cfp_date_end: 2019-06-06T23:59:59-05:00 # close your call for proposals.
+cfp_date_announce: 2019-06-13T23:59:59-05:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/cfps/2011/submissions/new"

--- a/data/events/2019-philadelphia.yml
+++ b/data/events/2019-philadelphia.yml
@@ -5,6 +5,11 @@ event_twitter: "DevOpsDaysPHL"
 description:
 ga_tracking_id: "UA-61551732-3"
 
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-10-22T00:00:00-04:00
 enddate: 2019-10-23T23:59:59-04:00
 

--- a/data/events/2019-portland.yml
+++ b/data/events/2019-portland.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdayspdx" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming to Portland!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-09-10T00:00:00-07:00
 enddate: 2019-09-12T23:59:59-07:00
 

--- a/data/events/2019-porto-alegre.yml
+++ b/data/events/2019-porto-alegre.yml
@@ -5,19 +5,23 @@ event_twitter: "poadevopsday" # Change this to the twitter handle for your event
 description: "A vida é muito curta pra trabalho manual" # Edit this to suit your preferences
 ga_tracking_id: "UA-85374985-2" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-05-24  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-05-25  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-05-24T00:00:00-03:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-05-25T23:59:59-03:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-01-16  # start accepting talk proposals.
-cfp_date_end: 2019-02-28  # close your call for proposals.
-cfp_date_announce: 2019-03-15 # inform proposers of status
+cfp_date_start: 2019-01-16T00:00:00-02:00  # start accepting talk proposals.
+cfp_date_end: 2019-02-28T23:59:59-03:00  # close your call for proposals.
+cfp_date_announce: 2019-03-15T23:59:59-03:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdayspoa2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-02-27T00:00:01-03:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_start: 2019-02-27T00:00:00-03:00 # start accepting registration. Leave blank if registration is not open yet
 registration_date_end: 2019-05-24T23:59:59-03:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date

--- a/data/events/2019-portugal.yml
+++ b/data/events/2019-portugal.yml
@@ -5,14 +5,18 @@ event_twitter: "devopsdayspt" # Change this to the twitter handle for your event
 description: "devopsdays is coming to Portugal for the first time!" # Edit this to suit your preferences
 ga_tracking_id: "UA-133818809-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate:  2019-06-03 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-06-04 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate:  2019-06-03T00:00:00+01:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-06-04T23:59:59+01:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-02-04 # start accepting talk proposals.
-cfp_date_end:  2019-03-31 # close your call for proposals.
-cfp_date_announce: 2019-04-10 # inform proposers of status
+cfp_date_start: 2019-02-04T00:00:00+00:00 # start accepting talk proposals.
+cfp_date_end:  2019-03-31T23:59:59+00:00 # close your call for proposals.
+cfp_date_announce: 2019-04-10T23:59:59+01:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdaysportugal2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/data/events/2019-poznan.yml
+++ b/data/events/2019-poznan.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdayspoz" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Poznań!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-raleigh.yml
+++ b/data/events/2019-raleigh.yml
@@ -5,9 +5,13 @@ event_twitter: "devopsdaysrdu" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Raleigh!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-10-01 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-10-02 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-10-01T00:00:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-10-02T23:59:59-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2019-01-01T00:00:00-05:00  # start accepting talk proposals.
@@ -17,8 +21,8 @@ cfp_date_announce: 2019-05-15T00:00:00-04:00 # inform proposers of status
 cfp_open: "false"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2018-12-01 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-10-02 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2018-12-01T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-10-02T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://www.eventbrite.com/e/devopsdays-raleigh-2019-tickets-49944558519" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-salt-lake-city.yml
+++ b/data/events/2019-salt-lake-city.yml
@@ -6,7 +6,11 @@ event_logo: "logo-square.jpg"
 description: "Devopsdays is returning to Salt Lake City!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-05-14T08:00:00-06:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2019-05-15T18:00:00-06:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-santa-maria.yml
+++ b/data/events/2019-santa-maria.yml
@@ -5,6 +5,11 @@ event_twitter: "devopsdays"
 description: "Devopsdays está em Santa Maria!"
 ga_tracking_id: ""
 
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-08-24T00:00:00-03:00
 enddate: 2019-08-24T23:59:59-03:00
 

--- a/data/events/2019-sao-paulo.yml
+++ b/data/events/2019-sao-paulo.yml
@@ -6,7 +6,11 @@ description: "Devopsdays está chegando em São Paulo!" # Edit this to suit your
 ga_tracking_id: "UA-36355678-5" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: "São Paulo"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-04-10T00:09:00-03:00
 enddate: 2019-04-11T18:00:00-03:00
 

--- a/data/events/2019-seattle.yml
+++ b/data/events/2019-seattle.yml
@@ -5,20 +5,24 @@ event_twitter: "devopsdayssea" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming back to Seattle!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate:  2019-04-23 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-04-24 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate:  2019-04-23T00:00:00-07:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-04-24T23:59:59-07:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2018-10-08 # start accepting talk proposals.
-cfp_date_end: 2019-01-06 # close your call for proposals.
-cfp_date_announce: 2019-02-01 # inform proposers of status
+cfp_date_start: 2018-10-08T00:00:00-08:00 # start accepting talk proposals.
+cfp_date_end: 2019-01-06T23:59:59-08:00 # close your call for proposals.
+cfp_date_announce: 2019-02-01T23:59:59-08:00 # inform proposers of status
 
 cfp_open: "false"
 cfp_link: "https://sessionize.com/devopsdays-seattle-2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-01-08 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-04-23 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-01-08T00:00:00-08:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-04-23T23:59:59-07:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-stockholm.yml
+++ b/data/events/2019-stockholm.yml
@@ -5,19 +5,23 @@ event_twitter: "devopsdayssthlm" # Change this to the twitter handle for your ev
 description: "DevOpsDays is coming back to Stockholm!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-09-17 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-09-18 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-09-17T00:00:00+02:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-09-18T23:59:59+02:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-03-01 # start accepting talk proposals.
-cfp_date_end: 2019-04-15 # close your call for proposals.
-cfp_date_announce: 2019-05-15 # inform proposers of status
+cfp_date_start: 2019-03-01T00:00:00+01:00 # start accepting talk proposals.
+cfp_date_end: 2019-04-15T23:59:59+02:00 # close your call for proposals.
+cfp_date_announce: 2019-05-15T23:59:59+02:00 # inform proposers of status
 
 cfp_link: "https://www.papercall.io/dod-sthlm-2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-03-08 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-09-16 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-03-08T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-09-16T23:59:59+02:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://ti.to/devopsdays-stockholm/2019" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-taipei.yml
+++ b/data/events/2019-taipei.yml
@@ -5,7 +5,11 @@ event_twitter: "DevOpsDaysTPE" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Taipei!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  2019-10-16T14:00:00+08:00
 enddate: 2019-10-18T18:00:00+08:00
 

--- a/data/events/2019-tampa.yml
+++ b/data/events/2019-tampa.yml
@@ -5,20 +5,24 @@ event_twitter: "devopsdaystampa" # Change this to the twitter handle for your ev
 description: "Devopsdays is coming to Tampa Bay!" # Edit this to suit your preferences
 ga_tracking_id: "UA-127670911-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-06-07  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-06-07  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-06-07T00:00:00-04:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-06-07T23:59:59-04:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-03-08  # start accepting talk proposals.
-cfp_date_end: 2019-04-12  # close your call for proposals.
-cfp_date_announce: 2019-04-19  # inform proposers of status
+cfp_date_start: 2019-03-08T00:00:00-05:00  # start accepting talk proposals.
+cfp_date_end: 2019-04-12T23:59:59-04:00  # close your call for proposals.
+cfp_date_announce: 2019-04-19T23:59:59-04:00  # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/dodtampabay" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2019-03-11 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-06-02 # close registration. Leave blank if registration is not open yet.
+registration_date_start: 2019-03-11T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: 2019-06-02T23:59:59-04:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.

--- a/data/events/2019-tokyo.yml
+++ b/data/events/2019-tokyo.yml
@@ -3,9 +3,13 @@ year: "2019" # The year of the event. Make sure it is in quotes.
 city: "Tokyo" # The displayed city name of the event. Capitalize it.
 description: # A short blurb of text to describe your event, defaults to common DevOpsDays description
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-04-09 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-04-10 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-04-09T00:00:00+09:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-04-10T23:59:59+09:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-12-06T00:00:00+09:00 # start accepting talk proposals.
 cfp_date_end: 2019-01-31T15:00:00+09:00  # close your call for proposals.

--- a/data/events/2019-toronto.yml
+++ b/data/events/2019-toronto.yml
@@ -5,9 +5,13 @@ event_twitter: "devopsdaysTO" # Change this to the twitter handle for your event
 description: "Be part of the sixth DevOpsDays Toronto!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
-startdate: 2019-05-29
-enddate: 2019-05-30
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-05-29T00:00:00-04:00
+enddate: 2019-05-30T23:59:59-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2019-01-02T00:00:00-05:00 # start accepting talk proposals.

--- a/data/events/2019-vancouver.yml
+++ b/data/events/2019-vancouver.yml
@@ -5,9 +5,13 @@ event_twitter: "devopsdaysyvr" # Change this to the twitter handle for your even
 description: "devopsdays is an inclusive, self-organizing conference for anyone interested in DevOps practices." # A short blurb of text to describe your event, defaults to common DevOpsDays description
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate:  2019-03-29 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2019-03-30 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate:  2019-03-29T00:00:00-07:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2019-03-30T23:59:59-07:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-11-27T08:00:00-08:00 # start accepting talk proposals.

--- a/data/events/2019-victoria.yml
+++ b/data/events/2019-victoria.yml
@@ -5,14 +5,18 @@ event_twitter: "devopsdaysyyj" # Change this to the twitter handle for your even
 description: "Devopsdays Victoria Canada 2019!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
-startdate: 2019-05-30 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2019-05-31 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2019-05-30T00:00:00-07:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-05-31T23:59:59-07:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  2019-02-08 # start accepting talk proposals.
-cfp_date_end: 2019-03-31 # close your call for proposals.
-cfp_date_announce: 2019-04-08 # inform proposers of status
+cfp_date_start:  2019-02-08T00:00:00-08:00 # start accepting talk proposals.
+cfp_date_end: 2019-03-31T23:59:59-07:00 # close your call for proposals.
+cfp_date_announce: 2019-04-08T23:59:59-07:00 # inform proposers of status
 
 cfp_open: "True"
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/data/events/2019-warsaw.yml
+++ b/data/events/2019-warsaw.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdayswaw" # Change this to the twitter handle for your even
 description: "Devopsdays is returning to Warsaw, Poland!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-11-25T00:00:00+01:00
 enddate: 2019-11-26T23:59:59+01:00
 

--- a/data/events/2019-washington-dc.yml
+++ b/data/events/2019-washington-dc.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdaysdc"
 description: "A house divided against itself cannot stand."
 ga_tracking_id: "UA-131045075-1"
 
-# All dates are in unquoted 2019-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 

--- a/data/events/2019-zurich.yml
+++ b/data/events/2019-zurich.yml
@@ -3,9 +3,14 @@ year: "2019" # The year of the event. Make sure it is in quotes.
 city: "Zürich" # The city name of the event. Capitalize it.
 event_twitter: "DevOpsZH"
 
-# All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate: 2019-05-14T00:00:00+02:00
 enddate: 2019-05-15T23:59:59+02:00
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2018-10-11T00:00:00+02:00 # start accepting talk proposals.
 cfp_date_end: 2019-01-10T23:59:59+01:00 # close your call for proposals.

--- a/utilities/examples/data/events/yyyy-city.yml
+++ b/utilities/examples/data/events/yyyy-city.yml
@@ -5,7 +5,11 @@ event_twitter: "devopsdayscityabbr" # Change this to the twitter handle for your
 description: "Devopsdays is coming to City!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
-# All dates are in unquoted YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T23:59:59+02:00
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 


### PR DESCRIPTION
We have a number of sort-order bugs in the theme that will be much easier to address when events have correct, full, usable datetime strings.

In this PR I am ensuring all 2019 events use full datetime strings with correct TZ offsets. I'm adding a clarifying comment to every event yaml file so hopefully people will submit usable datetime strings going forward.

I've corrected incorrect offsets and erroneous `"`s in a couple places as well. I've taken care not to change anyone's meaning.

I'm also changing the template so that new events are guided in the right direction.