### PR TITLE
Remove references to absURL to help deploy previews

### DIFF
--- a/themes/devopsdays-theme/layouts/404.html
+++ b/themes/devopsdays-theme/layouts/404.html
@@ -6,7 +6,7 @@
     <p class="page-404-content">The devopsdays yak can't find that page. It's probably fine.</p>
   </div>
   <div class = "col-lg-6 col-md-12">
-    <img src = "{{ "img/404-yak.png" | absURL }}" class = "img-fluid">
+    <img src = "{{ "/img/404-yak.png" }}" class = "img-fluid">
   </div>
 </div>
 

--- a/themes/devopsdays-theme/layouts/_default/baseof.html
+++ b/themes/devopsdays-theme/layouts/_default/baseof.html
@@ -20,7 +20,7 @@
                   {{- block "main" . }} {{- end -}}
               </div>
               <div class="col-md-2 pull-md-8">
-                  <a href = "{{ "events" | absURL }}" class="left-nav-navs">PAST EVENTS</a><br />
+                  <a href = "{{ "/events" }}" class="left-nav-navs">PAST EVENTS</a><br />
                   {{- partial "future.html" . -}}
               </div>
             {{- end -}}
@@ -29,7 +29,7 @@
                 {{- block "main" . }} {{- end -}}
             </div>
             <div class="col-md-2 pull-md-8">
-                <a href = "{{ "events" | absURL }}" class="left-nav-navs">PAST EVENTS</a><br />
+                <a href = "{{ "/events"}}" class="left-nav-navs">PAST EVENTS</a><br />
                 {{- partial "future.html" . -}}
             </div>
         {{- end -}}

--- a/themes/devopsdays-theme/layouts/events/single.html
+++ b/themes/devopsdays-theme/layouts/events/single.html
@@ -32,18 +32,18 @@
       {{- end -}}
       {{- if ne .startdate .enddate }}
       {{- if eq (time .startdate).Month (time .enddate).Month -}}
-        <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "events-page-event">
+        <a href = "{{ (printf "/events/%s" .name) }}" class = "events-page-event">
       {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2" .enddate }}:
       {{ .city }}
         </a><br />
       {{- else -}}
-    <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "events-page-event">
+    <a href = "{{ (printf "/events/%s" .name) }}" class = "events-page-event">
       {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2" .enddate }}:
       {{ .city }}
     </a><br />
       {{- end -}}
       {{- else -}}
-      <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "events-page-event">
+      <a href = "{{ (printf "/events/%s" .name) }}" class = "events-page-event">
         {{ dateFormat "Jan 2" .startdate }}:
         {{ .city }}
       </a><br />
@@ -56,7 +56,7 @@
 <h4 class="events-page-months">TBD</h4>
 {{- range $.Site.Data.events -}}
   {{- if not .startdate -}}
-    <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "events-page-event">{{ .city }}</a><br />
+    <a href = "{{ (printf "/events/%s" .name) }}" class = "events-page-event">{{ .city }}</a><br />
   {{- end -}}
 {{- end -}}
 </div>

--- a/themes/devopsdays-theme/layouts/index.html
+++ b/themes/devopsdays-theme/layouts/index.html
@@ -16,12 +16,12 @@
             {{- $.Scratch.Set "contentdir" (printf "static/events/%s/" ($.Scratch.Get "subdir")) -}}
             {{- if (where (readDir "static/events") "Name" ($.Scratch.Get "subdir")) -}}
                 {{- if (where (readDir ($.Scratch.Get "contentdir")) "Name" "logo-square.jpg") -}}
-                    <a href="{{ (printf "events/%s" .name) | absURL}}"><img src="{{ (printf "events/%s/logo-square.jpg" .name) | absURL }}" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
+                    <a href="{{ (printf "/events/%s" .name) }}"><img src="{{ (printf "/events/%s/logo-square.jpg" .name)  }}" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
                     {{- $.Scratch.Set "logo" "set" -}}
                 {{- end -}}
             {{- end -}}
             {{- if ne ($.Scratch.Get "logo") "set" -}}
-                <a href="{{ (printf "events/%s" .name) | absURL}}"><img src="{{"img/event-logo-square.jpg" | absURL }}" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
+                <a href="{{ (printf "/events/%s" .name) }}"><img src="{{"/img/event-logo-square.jpg"  }}" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
                 {{- end -}}
                 <br/>
       {{- if or (ne (time .startdate).Month (time .enddate).Month) (ne (time .startdate).Day (time .enddate).Day) -}}
@@ -34,7 +34,7 @@
             </span>
       {{- end -}}
         <span class="homepage-grid-city">
-            <a href="{{ (printf "events/%s" .name) | absURL}}">{{ .city }}</a>
+            <a href="{{ (printf "/events/%s" .name) }}">{{ .city }}</a>
         </span>
             </div>
             {{- if modBool ($.Scratch.Get "i") 4 -}}

--- a/themes/devopsdays-theme/layouts/partials/blog_pagination.html
+++ b/themes/devopsdays-theme/layouts/partials/blog_pagination.html
@@ -1,7 +1,7 @@
 {{- if .Paginator.HasPrev -}}
-  <a href="{{ .Paginator.Prev.URL | absURL }}">Previous</a>&nbsp;&nbsp;
+  <a href="{{ .Paginator.Prev.URL }}">Previous</a>&nbsp;&nbsp;
 {{- end -}}
 Page {{.Paginator.PageNumber}} of {{.Paginator.TotalPages}}
 {{- if .Paginator.HasNext -}}
-  &nbsp;&nbsp;<a href="{{ .Paginator.Next.URL | absURL }}">Next</a>
+  &nbsp;&nbsp;<a href="{{ .Paginator.Next.URL }}">Next</a>
 {{- end -}}

--- a/themes/devopsdays-theme/layouts/partials/events/cta.html
+++ b/themes/devopsdays-theme/layouts/partials/events/cta.html
@@ -7,12 +7,12 @@
       {{- if eq $e.registration_open "true" -}}
         {{- if $e.registration_link -}}
           {{- if eq $e.registration_link "" -}}
-            {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) | absURL ) -}}
+            {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) ) -}}
           {{- else -}}
             {{- $.Scratch.Set "registration_link" $e.registration_link -}}
           {{- end -}}
         {{- else -}}
-          {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) | absURL ) -}}
+          {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) ) -}}
       {{- end -}}
       <div class = "col-auto  offset-1 offset-md-0 welcome-page-cta">
         <a href="{{ $.Scratch.Get "registration_link" }}" class="btn jssocials-share-link event-cta-button" role="button" aria-pressed="true">Register</a>
@@ -24,12 +24,12 @@
           {{- if and (ge now (time $e.registration_date_start)) (le now (time $e.registration_date_end)) -}}
             {{- if $e.registration_link -}}
               {{- if eq $e.registration_link "" -}}
-                {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) | absURL ) -}}
+                {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) ) -}}
               {{- else -}}
                 {{- $.Scratch.Set "registration_link" $e.registration_link -}}
               {{- end -}}
             {{- else -}}
-              {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) | absURL ) -}}
+              {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) ) -}}
             {{- end -}}
             {{- if $e.registration_closed -}}
               {{- if ne $e.registration_closed "true" -}}
@@ -54,12 +54,12 @@
       {{- if and (ge now (time $e.cfp_date_start)) (le now (time $e.cfp_date_end)) -}}
         {{- if $e.cfp_link -}}
           {{- if eq $e.cfp_link "" -}}
-            {{- $.Scratch.Set "cfp_link" ((printf "/events/%s/propose" $e.name) | absURL ) -}}
+            {{- $.Scratch.Set "cfp_link" ((printf "/events/%s/propose" $e.name) ) -}}
           {{- else -}}
             {{- $.Scratch.Set "cfp_link" $e.cfp_link -}}
           {{- end -}}
         {{- else -}}
-          {{- $.Scratch.Set "cfp_link" ((printf "/events/%s/propose" $e.name) | absURL ) -}}
+          {{- $.Scratch.Set "cfp_link" ((printf "/events/%s/propose" $e.name) ) -}}
         {{- end -}}
       <div class = "col-auto offset-1 offset-md-0 welcome-page-cta">
         <a href="{{ $.Scratch.Get "cfp_link" }}" class="btn jssocials-share-link event-cta-button" role="button" aria-pressed="true">Propose</a>

--- a/themes/devopsdays-theme/layouts/partials/events/event_metadata.html
+++ b/themes/devopsdays-theme/layouts/partials/events/event_metadata.html
@@ -5,13 +5,13 @@
 {{- if (where (readDir "static/events") "Name" $e.name) -}}
 
   {{- if (where (readDir ($.Scratch.Get "contentdir")) "Name" "logo.jpg") -}}
-    {{- $.Scratch.Set "image_url" ((printf "events/%s/logo.jpg" $e.name) | absURL) -}}
+    {{- $.Scratch.Set "image_url" ((printf "/events/%s/logo.jpg" $e.name) ) -}}
   {{- else -}}
-    {{- $.Scratch.Set "image_url" ((printf "events/%s/logo.png" $e.name) | absURL) -}}
+    {{- $.Scratch.Set "image_url" ((printf "/events/%s/logo.png" $e.name) ) -}}
   {{- end -}}
 
 {{- else -}}
-    {{- $.Scratch.Set "image_url" ("img/event-logo-square.jpg" | absURL) -}}
+    {{- $.Scratch.Set "image_url" ("/img/event-logo-square.jpg" ) -}}
 {{- end -}}
 
 
@@ -30,7 +30,7 @@
     "name": "devopsdays {{ $e.city }} {{ $e.year }}",
     "startDate": "{{ $e.startdate }}",
     "endDate": "{{ $e.enddate }}",
-    "url": "{{ .Permalink | absURL }}",
+    "url": "{{ .Permalink  }}",
     "image": "{{ $.Scratch.Get "image_url" }}",
     "location": {
       "@type": "Place",

--- a/themes/devopsdays-theme/layouts/partials/events/event_navbar.html
+++ b/themes/devopsdays-theme/layouts/partials/events/event_navbar.html
@@ -3,7 +3,7 @@
   <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbar2">
       <span class="navbar-toggler-icon"></span>
   </button>
-  <a href="{{ (printf "events/%s" $e.name) | absURL }}" class="nav-link">{{ $e.city }}</a>
+  <a href="{{ (printf "/events/%s" $e.name) }}" class="nav-link">{{ $e.city }}</a>
   <div class="navbar-collapse collapse" id="navbar2">
       <ul class="navbar-nav">
           {{- if $e.nav_elements -}}
@@ -11,7 +11,7 @@
               {{- if .url -}}
                 {{- $.Scratch.Set "url" .url -}}
               {{- else }}
-                {{- $.Scratch.Set "url" ((printf "/events/%s/%s" $e.name .name ) | absURL) -}}
+                {{- $.Scratch.Set "url" ((printf "/events/%s/%s" $e.name .name )) -}}
               {{- end -}}
               {{- if eq .name "propose" -}}
                 {{- if $e.cfp_link -}}

--- a/themes/devopsdays-theme/layouts/partials/footer.html
+++ b/themes/devopsdays-theme/layouts/partials/footer.html
@@ -48,7 +48,7 @@
       {{- range sort $.Site.Data.events "startdate" -}}
         {{- if .cfp_date_end -}}
           {{- if and (ge now (time .cfp_date_start)) (ge (time .cfp_date_end) now) -}}
-            <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "footer-content">{{ .city }}</a><br />
+            <a href = "{{ (printf "/events/%s" .name) }}" class = "footer-content">{{ .city }}</a><br />
           {{- end -}} {{/* end: date is now or afterwards */}}
         {{- end -}} {{/* end: if .cfp_date_end */}}
       {{- end -}} {{/* end: range sort $.Site.Data.events "startdate" */}}
@@ -63,7 +63,7 @@
     <br />
     <br />
     <a href="https://www.netlify.com">
-      <img src="{{ "img/netlify-light.png" | absURL }}" alt="Deploys by Netlify">
+      <img src="{{ "/img/netlify-light.png" }}" alt="Deploys by Netlify">
     </a>
 </div>
     </div>

--- a/themes/devopsdays-theme/layouts/partials/footer_scripts.html
+++ b/themes/devopsdays-theme/layouts/partials/footer_scripts.html
@@ -4,14 +4,8 @@
   {{-  $.Scratch.Set "sharing_title" "devopsdays" -}}
 {{- end -}}
 
-<!-- set strutured metadata -->
-{{- if .IsPage -}}
-  {{- if or (eq .Type "welcome") (eq .Type "event") -}}
-    {{- partial "events/event_metadata.html" . -}}
-  {{- end -}}
-{{- end -}}
 <!-- end metadata -->
-<script src={{"js/devopsdays-min.js" | absURL}}></script>
+<script src={{"/js/devopsdays-min.js"}}></script>
 {{- if .IsPage -}}
 
   {{ if eq (index (split (.Permalink | relURL) "/") 1) "events" }}

--- a/themes/devopsdays-theme/layouts/partials/future.html
+++ b/themes/devopsdays-theme/layouts/partials/future.html
@@ -20,18 +20,18 @@
       {{- end -}}
       {{- if or (ne (time .startdate).Month (time .enddate).Month) (ne (time .startdate).Day (time .enddate).Day) -}}
         {{- if eq (time .startdate).Month (time .enddate).Month -}}
-          <a href = "{{ (printf "events/%s" .name ) | absURL }}" class = "left-nav-event">
+          <a href = "{{ (printf "/events/%s" .name ) }}" class = "left-nav-event">
         {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2" .enddate }}:
         {{ .city }}
           </a><br />
         {{- else -}}
-      <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "left-nav-event">
+      <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">
         {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2" .enddate }}:
         {{ .city }}
       </a><br />
         {{- end -}}
       {{- else -}}
-      <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "left-nav-event">
+      <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">
         {{ dateFormat "Jan 2" .startdate }}:
         {{ .city }}
       </a><br />
@@ -42,6 +42,6 @@
 <h3 class="left-nav-year">TBD</h3>
 {{- range $.Site.Data.events -}}
   {{- if not .startdate -}}
-    <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "left-nav-event">{{ .city }}</a><br />
+    <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">{{ .city }}</a><br />
   {{- end -}}
 {{- end -}}

--- a/themes/devopsdays-theme/layouts/partials/global_navbar.html
+++ b/themes/devopsdays-theme/layouts/partials/global_navbar.html
@@ -5,13 +5,13 @@
     <span class="navbar-toggler-icon"></span>
   </button>
   <a class="navbar-brand" href="/">
-  <img src="{{ "img/devopsdays-brain.png" | absURL }}" height="30" class="d-inline-block align-top" alt="devopsdays Logo">
+  <img src="{{ "/img/devopsdays-brain.png" }}" height="30" class="d-inline-block align-top" alt="devopsdays Logo">
   {{ .Site.Title}}
 </a>
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       {{- range .Site.Menus.main -}}
-          <li class="nav-item global-navigation"><a class = "nav-link" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+          <li class="nav-item global-navigation"><a class = "nav-link" href="{{ .URL }}">{{ .Name }}</a></li>
       {{- end -}}
     </ul>
   </div>

--- a/themes/devopsdays-theme/layouts/partials/head.html
+++ b/themes/devopsdays-theme/layouts/partials/head.html
@@ -46,5 +46,4 @@
     {{- end -}}
   {{ $.Scratch.Get "title" }}
 </title>
-<link rel="canonical" href="{{ .Permalink | absURL }}">
 {{- partial "head_includes.html" . -}}

--- a/themes/devopsdays-theme/layouts/partials/head/seo/open_graph.html
+++ b/themes/devopsdays-theme/layouts/partials/head/seo/open_graph.html
@@ -5,22 +5,22 @@
   <meta property="og:description" content="{{ if .Description }}{{ .Description }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ end }}{{ end }}" />
 {{- end -}}
 <meta property="og:type" content="{{ if .Params.type }}{{ .Params.type }}{{ else }}website{{ end }}" />
-<meta property="og:url" content="{{ .Permalink | absURL }}" />
+<meta property="og:url" content="{{ .Permalink | relURL }}" />
 {{- if or (eq .Type "welcome") (eq .Type "event") (eq .Type "speaker") (eq .Type "speakers") (eq .Type "talk") (eq .Type "program") -}}
   {{- $e := (index $.Site.Data.events (index (split (.Permalink | relURL) "/") 2)) -}}
   {{- $.Scratch.Set "contentdir" (printf "static/events/%s/" $e.name) -}}
   {{- if (where (readDir "static/events") "Name" $e.name) -}}
     {{- if (where (readDir ($.Scratch.Get "contentdir")) "Name" "sharing.jpg") -}}
-      {{- $.Scratch.Set "sharing_url" ((printf "events/%s/sharing.jpg" $e.name ) | absURL) -}}
+      {{- $.Scratch.Set "sharing_url" ((printf "events/%s/sharing.jpg" $e.name ) ) -}}
     {{- else -}}
-      {{- $.Scratch.Set "sharing_url" ("img/sharing.jpg" | absURL ) -}}
+      {{- $.Scratch.Set "sharing_url" ("/img/sharing.jpg" ) -}}
     {{- end -}}
   {{- end -}}
 {{- else -}}
   {{- with .Params.sharing_image -}}
-    {{- $.Scratch.Set "sharing_url" ( . | absURL ) -}}
+    {{- $.Scratch.Set "sharing_url" ( . ) -}}
   {{- else -}}
-    {{- $.Scratch.Set "sharing_url" ("img/sharing.jpg" | absURL ) -}}
+    {{- $.Scratch.Set "sharing_url" ("/img/sharing.jpg" ) -}}
   {{- end -}}
 {{- end -}}
 <meta property="og:image" content="{{ $.Scratch.Get "sharing_url" }}" />

--- a/themes/devopsdays-theme/layouts/partials/head/seo/schema.html
+++ b/themes/devopsdays-theme/layouts/partials/head/seo/schema.html
@@ -7,12 +7,12 @@
 {{- if or (eq .Type "welcome") (eq .Type "event") (eq .Type "speaker") (eq .Type "speakers") (eq .Type "talk") (eq .Type "program") -}}
   {{- $path := split ( .Permalink | relURL) "/" -}}
   {{- $event_slug := index $path 2 -}}
-  <meta itemprop="image" content="{{ (printf "events/%s/sharing.jpg" $event_slug) | absURL}}" />
+  <meta itemprop="image" content="{{ (printf "/events/%s/sharing.jpg" $event_slug) }}" />
 {{- else -}}
   {{- with .Params.sharing_image -}}
-    <meta itemprop="image" content="{{ . | absURL }}" />
+    <meta itemprop="image" content="{{ . }}" />
   {{- else -}}
-    <meta itemprop="image" content="{{ "img/sharing.jpg" | absURL }}" />
+    <meta itemprop="image" content="{{ "/img/sharing.jpg" }}" />
   {{- end -}}
 {{- end -}}
 {{- if .IsPage -}}

--- a/themes/devopsdays-theme/layouts/partials/head/seo/twitter_cards.html
+++ b/themes/devopsdays-theme/layouts/partials/head/seo/twitter_cards.html
@@ -13,16 +13,16 @@
   {{- end -}}
   {{- if (where (readDir "static/events") "Name" $e.name) -}}
     {{- if (where (readDir ($.Scratch.Get "contentdir")) "Name" "sharing.jpg") -}}
-      {{- $.Scratch.Set "sharing_url" ((printf "events/%s/sharing.jpg" $e.name ) | absURL) -}}
+      {{- $.Scratch.Set "sharing_url" (printf "/events/%s/sharing.jpg" $e.name ) -}}
     {{- else -}}
-      {{- $.Scratch.Set "sharing_url" ("img/sharing.jpg" | absURL ) -}}
+      {{- $.Scratch.Set "sharing_url" ("/img/sharing.jpg" ) -}}
     {{- end -}}
   {{- end -}}
 {{- else -}}
   {{- with .Params.sharing_image -}}
-    {{- $.Scratch.Set "sharing_url" ( . | absURL ) -}}
+    {{- $.Scratch.Set "sharing_url" ( . ) -}}
   {{- else -}}
-    {{- $.Scratch.Set "sharing_url" ("img/sharing.jpg" | absURL ) -}}
+    {{- $.Scratch.Set "sharing_url" ("/img/sharing.jpg" ) -}}
   {{- end -}}
 {{- end -}}
 <meta name="twitter:card" content="summary_large_image" />

--- a/themes/devopsdays-theme/layouts/partials/head_includes.html
+++ b/themes/devopsdays-theme/layouts/partials/head_includes.html
@@ -1,40 +1,40 @@
 {{ partial "google_analytics.html" . }}
-<link href="{{ "css/site.css" | absURL }}" rel="stylesheet">
+<link href="{{ "/css/site.css" }}" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700" rel="stylesheet">
-<link href="{{ "css/googlemaps.css" | absURL }}" rel="stylesheet">
+<link href="{{ "/css/googlemaps.css" }}" rel="stylesheet">
 
-<link rel="apple-touch-icon" sizes="57x57" href="{{"apple-icon-57x57.png" | absURL }}">
-<link rel="apple-touch-icon" sizes="60x60" href="{{"apple-icon-60x60.png" | absURL }}">
-<link rel="apple-touch-icon" sizes="72x72" href="{{"apple-icon-72x72.png" | absURL }}">
-<link rel="apple-touch-icon" sizes="76x76" href="{{"apple-icon-76x76.png" | absURL }}">
-<link rel="apple-touch-icon" sizes="114x114" href="{{"apple-icon-114x114.png" | absURL }}">
-<link rel="apple-touch-icon" sizes="120x120" href="{{"apple-icon-120x120.png" | absURL }}">
-<link rel="apple-touch-icon" sizes="144x144" href="{{"apple-icon-144x144.png" | absURL }}">
-<link rel="apple-touch-icon" sizes="152x152" href="{{"apple-icon-152x152.png" | absURL }}">
-<link rel="apple-touch-icon" sizes="180x180" href="{{"apple-icon-180x180.png" | absURL }}">
-<link rel="icon" type="image/png" sizes="192x192"  href="{{"android-icon-192x192.png" | absURL }}">
-<link rel="icon" type="image/png" sizes="32x32" href="{{"favicon-32x32.png" | absURL }}">
-<link rel="icon" type="image/png" sizes="96x96" href="{{"favicon-96x96.png" | absURL }}">
-<link rel="icon" type="image/png" sizes="16x16" href="{{"favicon-16x16.png" | absURL }}">
-<link rel="manifest" href="{{"manifest.json" | absURL }}">
+<link rel="apple-touch-icon" sizes="57x57" href="{{"/apple-icon-57x57.png" }}">
+<link rel="apple-touch-icon" sizes="60x60" href="{{"/apple-icon-60x60.png" }}">
+<link rel="apple-touch-icon" sizes="72x72" href="{{"/apple-icon-72x72.png" }}">
+<link rel="apple-touch-icon" sizes="76x76" href="{{"/apple-icon-76x76.png" }}">
+<link rel="apple-touch-icon" sizes="114x114" href="{{"/apple-icon-114x114.png" }}">
+<link rel="apple-touch-icon" sizes="120x120" href="{{"/apple-icon-120x120.png" }}">
+<link rel="apple-touch-icon" sizes="144x144" href="{{"/apple-icon-144x144.png" }}">
+<link rel="apple-touch-icon" sizes="152x152" href="{{"/apple-icon-152x152.png" }}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{"/apple-icon-180x180.png" }}">
+<link rel="icon" type="image/png" sizes="192x192"  href="{{"/android-icon-192x192.png" }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{"/favicon-32x32.png" }}">
+<link rel="icon" type="image/png" sizes="96x96" href="{{"/favicon-96x96.png" }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{"/favicon-16x16.png" }}">
+<link rel="manifest" href="{{"/manifest.json" }}">
 <meta name="msapplication-TileColor" content="#ffffff">
-<meta name="msapplication-TileImage" content="{{"ms-icon-144x144.png" | absURL }}">
+<meta name="msapplication-TileImage" content="{{"/ms-icon-144x144.png" }}">
 <meta name="theme-color" content="#ffffff">
 
 {{ if .IsPage }}
   {{ if eq .Type "blog" }}
-    <link href="{{ "blog/index.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="{{ "blog/index.xml" | absURL }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ "/blog/index.xml" }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ "/blog/index.xml" }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
   {{ else }}
     {{ if eq .Type "speaking" }}
-      <link href="{{ "speaking/index.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-      <link href="{{ "speaking/index.xml" | absURL }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+      <link href="{{ "/speaking/index.xml" }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+      <link href="{{ "/speaking/index.xml" }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ else }}
-      <link href="{{ "events/index.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-      <link href="{{ "events/index.xml" | absURL }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+      <link href="{{ "/events/index.xml" }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+      <link href="{{ "/events/index.xml" }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
   {{ end }}
 {{ else }}
-  <link href="{{ "events/index.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ "events/index.xml" | absURL }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ "/events/index.xml" }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ "/events/index.xml" }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{ end }}

--- a/themes/devopsdays-theme/layouts/partials/map.html
+++ b/themes/devopsdays-theme/layouts/partials/map.html
@@ -77,4 +77,4 @@ function initialize() {
 </script>
 
 <script type="text/javascript" src="https://maps-api-ssl.google.com/maps/api/js?key=AIzaSyC1bvNK9qFJGEhoWNbQuojmJJ1Tg0DoOew"></script>
-<script type="text/javascript" src="{{ "js/googlemaps_label-min.js" | absURL }}"></script>
+<script type="text/javascript" src="{{ "/js/googlemaps_label-min.js" }}"></script>

--- a/themes/devopsdays-theme/layouts/partials/past.html
+++ b/themes/devopsdays-theme/layouts/partials/past.html
@@ -34,7 +34,7 @@ Chomping .year has the nice effect of turning an int into string. */}}
     {{- if .startdate -}}
       {{- if eq ( print (chomp (dateFormat "2006" .startdate))) (print (chomp ($.Scratch.Get "the_year"))) -}}
         {{- $.Scratch.Set "citydisplay" .city -}}
-        <a href="{{ (printf "events/%s" .name) | absURL }}" class = "events-page-event">{{ $.Scratch.Get "citydisplay" }}</a>
+        <a href="{{ (printf "/events/%s" .name) }}" class = "events-page-event">{{ $.Scratch.Get "citydisplay" }}</a>
         <br/>
       {{- end -}}
 

--- a/themes/devopsdays-theme/layouts/partials/sponsors.html
+++ b/themes/devopsdays-theme/layouts/partials/sponsors.html
@@ -23,7 +23,7 @@
                   {{- with $e.sponsor_link -}}
                     <a href = "{{ . }}" class="sponsor-cta">
                   {{- else -}}
-                    <a href = "{{ (printf "events/%s/sponsor" $e.name) | absURL }}" class="sponsor-cta">
+                    <a href = "{{ (printf "/events/%s/sponsor" $e.name) }}" class="sponsor-cta">
                   {{- end -}}
                     <i>Become a {{ $level.label }} Sponsor!</i>
                   </a>

--- a/themes/devopsdays-theme/layouts/partials/welcome.html
+++ b/themes/devopsdays-theme/layouts/partials/welcome.html
@@ -28,7 +28,7 @@
             height: 100%;
             z-index: -1;
             opacity: 0.2;
-            background-image: url('{{ (printf "events/%s/%s" $e.name $e.masthead_background) | absURL}}');
+            background-image: url('{{ (printf "/events/%s/%s" $e.name $e.masthead_background) }}');
             background-repeat: no-repeat;
             background-position: 50% 0;
             -ms-background-size: cover;
@@ -92,7 +92,7 @@
                     {{- $.Scratch.Set "past-counter" 1 -}}
                   {{- end -}}
                   {{- if ne .startdate $e.startdate -}}
-                    <a href = "{{ (printf "events/%s" .name) | absURL }}" class="welcome-page-masthead-link">{{ dateFormat "2006" .startdate }}</a> &nbsp;&nbsp;
+                    <a href = "{{ (printf "/events/%s" .name) }}" class="welcome-page-masthead-link">{{ dateFormat "2006" .startdate }}</a> &nbsp;&nbsp;
                   {{- end -}}
               {{- end -}}
             {{- else -}}
@@ -103,7 +103,7 @@
                   {{- $.Scratch.Set "past-counter" 1 -}}
                 {{- end -}}
                 {{- if ne .startdate $e.startdate -}}
-                  <a href = "{{ (printf "events/%s" .name) | absURL }}" class="welcome-page-masthead-link">{{ dateFormat "2006" .startdate }}</a> &nbsp;&nbsp;
+                  <a href = "{{ (printf "/events/%s" .name) }}" class="welcome-page-masthead-link">{{ dateFormat "2006" .startdate }}</a> &nbsp;&nbsp;
                 {{- end -}}
               {{- end -}}
               {{- end -}}

--- a/themes/devopsdays-theme/layouts/program/single.html
+++ b/themes/devopsdays-theme/layouts/program/single.html
@@ -117,7 +117,7 @@
                               {{- if .custom_url -}}
                                 <a href="{{ .custom_url | safeURL }}">{{ $.Scratch.Get (printf "%s-speaker" .title) }} - {{ $.Scratch.Get .title }}</a><br/>
                               {{- else -}}
-                                <a href="{{ (printf "events/%s/program/%s" $e.name .title) | absURL }}">{{ $.Scratch.Get (printf "%s-speaker" .title) }} - {{ $.Scratch.Get .title }}</a><br/>
+                                <a href="{{ (printf "/events/%s/program/%s" $e.name .title) }}">{{ $.Scratch.Get (printf "%s-speaker" .title) }} - {{ $.Scratch.Get .title }}</a><br/>
                               {{- end -}}
                               {{- if eq  ($.Scratch.Get "icons")  "TRUE" -}}
                                 {{- with ($.Scratch.Get (printf "%s-video_link" .title)) -}}&nbsp;<a href="{{ . }}"><i class="fa fa-video-camera" aria-hidden="true"></i></a>&nbsp;{{- end -}}
@@ -161,7 +161,7 @@
                                 {{- if .custom_url -}}
                                   <a href="{{ .custom_url | safeURL }}">{{ .title }}</a><br/>
                                 {{- else -}}
-                                  <a href="{{ "open-space-format/" | absURL }}">{{ .title }}</a><br/>
+                                  <a href="{{ "/open-space-format/" }}">{{ .title }}</a><br/>
                                 {{- end -}}
                               {{- else -}}
                                 {{ .title }}

--- a/themes/devopsdays-theme/layouts/section/blog.rss.xml
+++ b/themes/devopsdays-theme/layouts/section/blog.rss.xml
@@ -1,7 +1,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <link>{{ .Permalink | absURL }}</link>
+    <link>{{ .Permalink  }}</link>
     <description>Recent blogs {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
@@ -9,14 +9,14 @@
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
-    <atom:link href="{{ .Permalink | absURL }}" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
     {{ range .Data.Pages }}
     <item>
       <title>{{ .Title }}</title>
-      <link>{{ .Permalink | absURL }}</link>
+      <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
-      <guid>{{ .Permalink | absURL }}</guid>
+      <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | htmlEscape }}</description>
     </item>
     {{ end }}

--- a/themes/devopsdays-theme/layouts/section/events.rss.xml
+++ b/themes/devopsdays-theme/layouts/section/events.rss.xml
@@ -9,8 +9,8 @@
      xmlns:media="http://search.yahoo.com/mrss/">
 <channel>
 <title>Upcoming devopsdays events</title>
-<atom:link href="{{"events/index.xml" | absURL }}" rel="self" type="application/rss+xml" />
-<link>{{ .Permalink | absURL }}</link>
+<atom:link href="{{"/events/index.xml" }}" rel="self" type="application/rss+xml" />
+<link>{{ .Permalink }}</link>
     <description>Upcoming devopsdays events</description>
 <lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</lastBuildDate>
 <sy:updatePeriod>hourly</sy:updatePeriod>
@@ -27,8 +27,8 @@
       {{- else -}}
         <title>devopsdays {{ .city }} {{ .year }} is coming! {{ dateFormat "Monday, January 2, 2006" .startdate }} - {{ dateFormat "Monday, January 2, 2006" .enddate }}</title>
       {{- end -}}
-      <link>{{ (printf "events/%s" .name) | absURL }}</link>
-      <guid>{{ (printf "events/%s" .name) | absURL }}</guid>
+      <link>{{ (printf "/events/%s" .name) }}</link>
+      <guid>{{ (printf "/events/%s" .name) }}</guid>
       <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</pubDate>
       {{- if .description -}}
         <description>{{.description | markdownify | htmlEscape}}</description>

--- a/themes/devopsdays-theme/layouts/section/speaking.rss.xml
+++ b/themes/devopsdays-theme/layouts/section/speaking.rss.xml
@@ -9,8 +9,8 @@
      xmlns:media="http://search.yahoo.com/mrss/">
 <channel>
 <title>devopsdays events with open CFP's</title>
-<atom:link href="{{ "events/index.xml" | absURL }}" rel="self" type="application/rss+xml" />
-<link>{{ .Permalink | absURL }}</link>
+<atom:link href="{{ "events/index.xml" }}" rel="self" type="application/rss+xml" />
+<link>{{ .Permalink }}</link>
     <description>devopsdays events with open CFP's</description>
 <lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</lastBuildDate>
 <sy:updatePeriod>hourly</sy:updatePeriod>
@@ -25,8 +25,8 @@
         {{ if ge (time .cfp_date_end) now }}
         <item>
           <title>devopsdays {{ .city }} {{ .year }}</title>
-          <link>{{ (printf "events/%s" .name) | absURL }}</link>
-          <guid>{{ (printf "events/%s" .name) | absURL }}</guid>
+          <link>{{ (printf "events/%s" .name) }}</link>
+          <guid>{{ (printf "events/%s" .name) }}</guid>
           <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</pubDate>
           {{ if .description }}
             <description>{{.description }}</description>

--- a/themes/devopsdays-theme/layouts/shortcodes/event_link.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/event_link.html
@@ -1,5 +1,5 @@
 {{- $e := (index $.Site.Data.events (index (split ($.Page.Permalink | relURL) "/") 2)) -}}
-{{- $url := index $e (.Get "url-key") | default (printf "events/%s/%s" $e.name (.Get "page")) | absURL -}}
+{{- $url := index $e (.Get "url-key") | default (printf "/events/%s/%s" $e.name (.Get "page")) -}}
 {{- $txt := index $e (.Get "text-key") | default (.Get "text") -}}
 
 <a href = "{{ $url }}">{{ $txt }}</a>

--- a/themes/devopsdays-theme/layouts/shortcodes/event_location.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/event_location.html
@@ -1,2 +1,2 @@
 {{- $e := (index $.Site.Data.events (index (split ($.Page.Permalink | relURL) "/") 2)) -}}
-<a href = "{{ (printf "events/%s/location" $e.name) | absURL}}">{{$e.location}}</a>
+<a href = "{{ (printf "/events/%s/location" $e.name) }}">{{$e.location}}</a>

--- a/themes/devopsdays-theme/layouts/shortcodes/event_logo.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/event_logo.html
@@ -6,5 +6,5 @@
   {{- else -}}
     {{- $.Scratch.Set "logo" "logo.png" -}}
   {{- end -}}
-  <img alt="devopsdays {{ $e.city }} {{ $e.year }}" src="{{ (printf "events/%s/%s" $e.name ($.Scratch.Get "logo")) | absURL }}" class="welcome-page-event-logo"/>
+  <img alt="devopsdays {{ $e.city }} {{ $e.year }}" src="{{ (printf "/events/%s/%s" $e.name ($.Scratch.Get "logo")) }}" class="welcome-page-event-logo"/>
 {{- end -}}

--- a/themes/devopsdays-theme/layouts/shortcodes/list_organizers.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/list_organizers.html
@@ -13,7 +13,7 @@
               {{ end }}
             </div>
             {{- if .image -}}
-              <img class="card-img-top organizer-image" src="{{ (printf "events/%s/organizers/%s" $e.name .image) | absURL }}" alt="{{ .name }}">
+              <img class="card-img-top organizer-image" src="{{ (printf "/events/%s/organizers/%s" $e.name .image) }}" alt="{{ .name }}">
             {{- end -}}
             <div class = "card-block">
               {{- if .employer -}}

--- a/themes/devopsdays-theme/layouts/shortcodes/program_entry.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/program_entry.html
@@ -10,7 +10,7 @@
     {{- with .Get "presenter" -}}
       {{- $fname := . -}}
       {{- $s := index $.Site.Data.speakers (print (chomp $e.year)) (substr $e.name 5) . -}}
-      -- <a href="{{ (printf "events/%s/program/%s" $e.name $fname) | absURL }}">{{ $s.name }}</a>
+      -- <a href="{{ (printf "/events/%s/program/%s" $e.name $fname) }}">{{ $s.name }}</a>
     {{- end -}}
   </div>
 </div> <!-- end timeslot div -->

--- a/themes/devopsdays-theme/layouts/shortcodes/program_link.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/program_link.html
@@ -1,2 +1,2 @@
 {{- $e := (index $.Site.Data.events (index (split ($.Page.Permalink | relURL) "/") 2)) -}}
-<a href = "{{ (printf "events/%s/program/%s" $e.name (.Get "speaker") ) | absURL}}">{{ .Get "title" }}</a>
+<a href = "{{ (printf "/events/%s/program/%s" $e.name (.Get "speaker") ) }}">{{ .Get "title" }}</a>

--- a/themes/devopsdays-theme/layouts/speaker/single.html
+++ b/themes/devopsdays-theme/layouts/speaker/single.html
@@ -24,7 +24,7 @@
                   {{- end -}}
                 {{- end -}}
                 {{- if eq ($.Scratch.Get "display") "true" -}}
-                  <a href = "{{ .Permalink | absURL }}" class= "list-group-item list-group-item-action">{{ .Title }}</a>
+                  <a href = "{{ .Permalink }}" class= "list-group-item list-group-item-action">{{ .Title }}</a>
                   {{ $.Scratch.Set "display" "false" }}
                 {{- end -}}
             {{- end -}} <!-- end range where -->
@@ -34,10 +34,10 @@
   <div class = "col-md-3 offset-md-1">
     {{- with .Params.image -}}
       {{- if ne . "" -}}
-        <img src = "{{ (printf "events/%s/speakers/%s" $e.name .) |absURL }}" class="img-fluid" alt="{{ $.Title }}"/><br />
+        <img src = "{{ (printf "/events/%s/speakers/%s" $e.name .) }}" class="img-fluid" alt="{{ $.Title }}"/><br />
       {{- end -}}
       {{- else -}}
-        <img src = {{ "img/speaker-default.jpg" | absURL }} class="img-fluid"  alt="{{ .Title }}"/><br />
+        <img src = {{ "/img/speaker-default.jpg"}} class="img-fluid"  alt="{{ .Title }}"/><br />
     {{- end -}}
     {{- if isset .Params "twitter" -}}
       {{- if ne .Params.twitter "" -}}

--- a/themes/devopsdays-theme/layouts/speakers/single.html
+++ b/themes/devopsdays-theme/layouts/speakers/single.html
@@ -9,13 +9,13 @@
     <!-- Now we can display stuff! -->
     <div class="col-lg-3 col-md-6">
 
-      <a href = "{{ .Permalink | absURL }}">
+      <a href = "{{ .Permalink }}">
         {{- with .Params.image -}}
           {{- if ne . "" -}}
-            <img src = "{{ (printf "events/%s/speakers/%s" $e.name .) | absURL}}" class="speakers-page img-fluid" alt="{{ $.Title }}"/><br />
+            <img src = "{{ (printf "/events/%s/speakers/%s" $e.name .) }}" class="speakers-page img-fluid" alt="{{ $.Title }}"/><br />
           {{- end -}}
           {{- else -}}
-            <img src = "{{"img/speaker-default.jpg" | absURL }}" class="speakers-page img-fluid"  alt="{{ .Title }}"/><br />
+            <img src = "{{"/img/speaker-default.jpg" }}" class="speakers-page img-fluid"  alt="{{ .Title }}"/><br />
         {{- end -}}
       </a>
 
@@ -44,10 +44,10 @@
     {{- range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (substr $e.name 5) -}}
       <div class="row">
         <div class="col-md-12 col-lg-3">
-            <img alt = "{{ $s.name }}" src = "{{ (printf "events/%s/speakers/%s.jpg" $e.name $fname) | absURL }}" class="speakers-page old-speaker">
+            <img alt = "{{ $s.name }}" src = "{{ (printf "/events/%s/speakers/%s.jpg" $e.name $fname) }}" class="speakers-page old-speaker">
         </div>
         <div class= "col-md-12 col-lg-9 old-speaker-bio speakers-page">
-          <h3><a href="{{ (printf "events/%s/program/%s" $e.name $fname) | absURL}}">{{ $s.name }}</a></h3>
+          <h3><a href="{{ (printf "/events/%s/program/%s" $e.name $fname) }}">{{ $s.name }}</a></h3>
           {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
           {{ if $s.website }}Website: <a href="{{ $s.website }}">{{ $s.website }}</a><br>{{ end }}
           {{ if $s.pronouns }}Pronouns: {{ $s.pronouns }}{{ end }}

--- a/themes/devopsdays-theme/layouts/talk/single.html
+++ b/themes/devopsdays-theme/layouts/talk/single.html
@@ -117,12 +117,12 @@
     {{- with $p -}}
        {{- if isset .Params "image" -}}
           {{- if ne .Params.image "" -}}
-            <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
+            <img src = "{{ (printf "/events/%s/speakers/%s" $e.name .Params.image)  }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
           {{- end -}}
           {{- else -}}
-            <img src = "{{"img/speaker-default.jpg" | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
+            <img src = "{{"/img/speaker-default.jpg"  }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
         {{- end -}}
-          <h4 class="talk-page"><a href = "{{ (printf "events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) | absURL }}">
+          <h4 class="talk-page"><a href = "{{ (printf "/events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) }}">
             {{ .Title }}
           </a></h4>
         {{- if isset .Params "twitter" -}}
@@ -158,7 +158,7 @@
     <br />
           <span class="talk-page content-text">
           {{- if ge (countrunes .Content ) 200 -}}
-            {{ .Content | markdownify | truncate 200 " "}}<a href = "{{ .Permalink | absURL }}">...</a>
+            {{ .Content | markdownify | truncate 200 " "}}<a href = "{{ .Permalink }}">...</a>
           {{- else -}}
             {{ .Content | markdownify }}
           {{- end -}}
@@ -173,7 +173,7 @@
   {{- if in ($.LinkTitle | urlize) $fname -}}
 <div class="row">
    <div class="col-md-12">
-       <img alt = "{{ $s.name }}" src = "{{ (printf "events/%s/speakers/%s.jpg" $e.name $fname) | absURL }}" class="img-responsive" width = "250px">
+       <img alt = "{{ $s.name }}" src = "{{ (printf "/events/%s/speakers/%s.jpg" $e.name $fname) }}" class="img-responsive" width = "250px">
    </div>
 </div>
 <div class = "row">


### PR DESCRIPTION
This is a fairly major change to the theme, but it will stop us using absolute URLs which should help build times in deploy previews.