### PR TITLE
Clarify logo square stretching

### DIFF
--- a/utilities/README.md
+++ b/utilities/README.md
@@ -26,7 +26,7 @@ If you have set up a Google Analytics account for tracking your specific event, 
 
 ### Event Square Logo
 
-To customize the logo that appears on the root of devopsdays.org, place a square file (jpg format only) in `static/events/yyyy-city`. It must be named `logo-square.jpg` and should be at minimum 300px x 300px, but optimally should be 600px x 600px.
+To customize the logo that appears on the root of devopsdays.org, place a square file (jpg format only) in `static/events/yyyy-city`. It must be named `logo-square.jpg` and should be at minimum 300px x 300px, but optimally should be 600px x 600px. Note that in the preview (without gulp processing), non-square files will appear to be okay. However, once processed for production, they will be stretched to be square.
 
 ### Reference Content
 


### PR DESCRIPTION
The simplest resolution to https://github.com/devopsdays/devopsdays-theme/issues/590: let people know that logo-square will be made square, possibly at the expense of your aspect ratio.