### PR TITLE
Correct end-date handling

### DIFF
--- a/themes/devopsdays-theme/layouts/events/single.html
+++ b/themes/devopsdays-theme/layouts/events/single.html
@@ -30,18 +30,11 @@
         {{- $.Scratch.Set "month-displayed" "true" -}}
         {{- $.Scratch.Set "close-tag" "true" -}}
       {{- end -}}
-      {{- if ne .startdate .enddate }}
-      {{- if eq (time .startdate).Month (time .enddate).Month -}}
+      {{- if or (ne (time .startdate).Month (time .enddate).Month) (ne (time .startdate).Day (time .enddate).Day) -}}
         <a href = "{{ (printf "/events/%s" .name) }}" class = "events-page-event">
       {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2" .enddate }}:
       {{ .city }}
         </a><br />
-      {{- else -}}
-    <a href = "{{ (printf "/events/%s" .name) }}" class = "events-page-event">
-      {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2" .enddate }}:
-      {{ .city }}
-    </a><br />
-      {{- end -}}
       {{- else -}}
       <a href = "{{ (printf "/events/%s" .name) }}" class = "events-page-event">
         {{ dateFormat "Jan 2" .startdate }}:

--- a/themes/devopsdays-theme/layouts/index.html
+++ b/themes/devopsdays-theme/layouts/index.html
@@ -7,7 +7,7 @@
         {{- range sort $.Site.Data.events "startdate" -}}
         {{- if .startdate -}}
 <!-- Subtracting a day is a patch for https://github.com/devopsdays/devopsdays-theme/issues/656 -->
-        {{- if ge (time .enddate) (now.AddDate 0 0 -1) -}}
+        {{- if ge (time .enddate) now -}}
         {{- $.Scratch.Set "city" .city -}}
         {{- $.Scratch.Set "year" .year -}}
         {{- $.Scratch.Set "logo" "unset" -}}

--- a/themes/devopsdays-theme/layouts/partials/future.html
+++ b/themes/devopsdays-theme/layouts/partials/future.html
@@ -1,6 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (time .enddate) (now.AddDate 0 0 -1) -}}
+    {{- if ge (time .enddate) now -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}


### PR DESCRIPTION
This corrects our end-date handling (as if we have proper datetime strings, we should no longer need to keep events on the main page until the day after they end). It also ensures that we're sorting events on the events page accurately (based on full datetime strings), which in testing seems to eliminate the sort-order changing for events with the "same" date.