### PR TITLE
[Phoenix 2018] Blank speaker files generate errors

### DIFF
--- a/content/events/2018-phoenix/program/fail-stories.md
+++ b/content/events/2018-phoenix/program/fail-stories.md
@@ -4,7 +4,7 @@ Talk_start_time = ""
 Talk_end_time = ""
 Title = "Fail Stories"
 Type = "talk"
-Speakers = ["fail-stories"]
+Speakers = [""]
 +++
 
 Case Studies / Fail Stories: Fifteen minute sessions for people of all experience ranges where speakers share technical or cultural anecdotes where they succeeded or failed in a DevOps related domain. Failure is fun. People love to know that other people fail on occasion.


### PR DESCRIPTION
The theme doesn't support entirely blank speaker files.