### PR TITLE
Patch to speaking page bug

### DIFF
--- a/content/speaking/speaking.md
+++ b/content/speaking/speaking.md
@@ -10,5 +10,5 @@ type = "speaking"
 
 The call for participation for a devopsdays event helps each city's local organizers find speakers for their event. Follow the talk proposal submission process for a given city if you'd like to submit an idea to their CFP!
 
-These are the cities which currently have an open call for participation.
+<!-- These are the cities which currently have an open call for participation.-->
 

--- a/themes/devopsdays-theme/layouts/speaking/single.html
+++ b/themes/devopsdays-theme/layouts/speaking/single.html
@@ -6,6 +6,5 @@
       {{ .Content }}
 </div>
 
-{{- partial "speaking.html" . -}}
 
 {{ end }}


### PR DESCRIPTION
Temporary patch (affects theme) to temporarily remove this error while we debug it:

Bridgets-MacBook:devopsdays-web bridget$ hugo --theme=devopsdays-theme --buildDrafts=false --baseURL="https://www.devopsdays.org/"
Total in 84512 ms
Error: Error building site: failed to render pages: render of "page" failed: execute of template failed: template: speaking/single.html:9:4: executing "main" at <partial "speaking.ht...>: error calling partial: "/Users/bridget/github/devopsdays/devopsdays-web/themes/devopsdays-theme/layouts/partials/speaking.html:12:34": execute of template failed: template: partials/speaking.html:12:34: executing "partials/speaking.html" at <dateFormat "2006-01-...>: error calling dateFormat: unable to cast <nil> of type <nil> to Time
