### PR TITLE
[MV 2019] no cfp dates without event dates

### DIFF
--- a/data/events/2019-montevideo.yml
+++ b/data/events/2019-montevideo.yml
@@ -10,9 +10,9 @@ startdate:  # The start date of your event. Leave blank if you don't have a venu
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-03-17T00:00:00-03:00 # start accepting talk proposals.
-cfp_date_end: 2019-06-01T23:59:59-03:00 # close your call for proposals.
-cfp_date_announce: 2019-06-17T00:00:00-03:00 # inform proposers of status
+#cfp_date_start: 2019-03-17T00:00:00-03:00 # start accepting talk proposals.
+#cfp_date_end: 2019-06-01T23:59:59-03:00 # close your call for proposals.
+#cfp_date_announce: 2019-06-17T00:00:00-03:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdaysmvd2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.


### PR DESCRIPTION
Hi, @andresantoniuk and @jantoniuk - we made an error by merging https://github.com/devopsdays/devopsdays-web/pull/6608 - we do not list CFP dates until the event dates are published. The reason for this is people cannot realistically determine whether they can submit a talk until they know when your event is.

We discovered this when @jakubjakubik worked on troubleshooting the issue I opened: https://github.com/devopsdays/devopsdays-web/issues/6625

Although the failure mode was a bit confusing, we do not want to display CFP dates when there is no event date. So, please add your event dates when they are confirmed, and then we will be happy to have your CFP dates added back to the site.

I hope that makes sense. Thanks!