### PR TITLE
Revert "Patch to speaking page bug"

### DIFF
--- a/content/speaking/speaking.md
+++ b/content/speaking/speaking.md
@@ -10,5 +10,5 @@ type = "speaking"
 
 The call for participation for a devopsdays event helps each city's local organizers find speakers for their event. Follow the talk proposal submission process for a given city if you'd like to submit an idea to their CFP!
 
-<!-- These are the cities which currently have an open call for participation.-->
+These are the cities which currently have an open call for participation.
 

--- a/themes/devopsdays-theme/layouts/speaking/single.html
+++ b/themes/devopsdays-theme/layouts/speaking/single.html
@@ -6,5 +6,6 @@
       {{ .Content }}
 </div>
 
+{{- partial "speaking.html" . -}}
 
 {{ end }}


### PR DESCRIPTION
Reverts devopsdays/devopsdays-web#6624

I can revert this now that https://github.com/devopsdays/devopsdays-web/pull/6637 is merged. 