### PR TITLE
[NYC 2019] Dates should be unquoted

### DIFF
--- a/data/events/2019-new-york-city.yml
+++ b/data/events/2019-new-york-city.yml
@@ -13,13 +13,13 @@ masthead_background: "nyc-masthead.jpg"
 #   variable: 2019-01-05T23:59:59+02:00
 # Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-startdate: "2019-01-24T00:00:00-05:00"  # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: "2019-01-25T23:59:59-05:00"  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2019-01-24T00:00:00-05:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2019-01-25T23:59:59-05:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  "2018-09-14T00:00:00-04:00" # start accepting talk proposals.
-cfp_date_end:  "2018-10-30T23:59:59-04:00" # close your call for proposals.
-cfp_date_announce:  "2018-12-03T23:59:59-05:00" # inform proposers of status
+cfp_date_start:  2018-09-14T00:00:00-04:00 # start accepting talk proposals.
+cfp_date_end:  2018-10-30T23:59:59-04:00 # close your call for proposals.
+cfp_date_announce:  2018-12-03T23:59:59-05:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/dodnyc2019" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.


### PR DESCRIPTION
I know cities tend to use their past data files again, so I want to correct this error.