### PR TITLE
[LDN-2019] Pagerduty have confirmed as Silver sponsors

### DIFF
--- a/data/events/2019-london.yml
+++ b/data/events/2019-london.yml
@@ -97,6 +97,8 @@ sponsors:
     # Silver
   - id: datadog
     level: silver
+  - id: pagerduty
+    level: silver
   - id: tecknuovo
     level: silver
     # Community


### PR DESCRIPTION
Simple change to add pagerduty as silver sponsors as they've paid now.

Signed-off-by: Chris M <me@christophermills.co.uk>