### PR TITLE
[CPT-2019] Adding link for Cape Town prospectus

### DIFF
--- a/content/events/2019-cape-town/sponsor.md
+++ b/content/events/2019-cape-town/sponsor.md
@@ -4,7 +4,7 @@ Type = "event"
 Description = "Sponsor devopsdays Cape Town 2019"
 +++
 
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please please check out our <a href="https://assets.devopsdays.org/events/2019/cape-town/2019-cape-town-devopsdays-prospectus.pdf" target="_blank">prospectus</a> or drop us an email at [{{< email_organizers >}}].
+We greatly value sponsors for this open event.  If you are interested in sponsoring, please check out our <a href="https://assets.devopsdays.org/events/2019/cape-town/2019-cape-town-devopsdays-prospectus.pdf" target="_blank">prospectus</a> or drop us an email at [{{< email_organizers >}}].
 
 <hr>
 

--- a/content/events/2019-cape-town/sponsor.md
+++ b/content/events/2019-cape-town/sponsor.md
@@ -6,6 +6,8 @@ Description = "Sponsor devopsdays Cape Town 2019"
 
 We greatly value sponsors for this open event.  If you are interested in sponsoring, please please check out our <a href="https://assets.devopsdays.org/events/2019/cape-town/2019-cape-town-devopsdays-prospectus.pdf" target="_blank">prospectus</a> or drop us an email at [{{< email_organizers >}}].
 
+<hr>
+
 devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
 <p>
 Gold sponsors get a full table and Silver sponsors a shared table where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.

--- a/content/events/2019-cape-town/sponsor.md
+++ b/content/events/2019-cape-town/sponsor.md
@@ -4,9 +4,7 @@ Type = "event"
 Description = "Sponsor devopsdays Cape Town 2019"
 +++
 
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
-
-<hr>
+We greatly value sponsors for this open event.  If you are interested in sponsoring, please please check out our <a href="https://assets.devopsdays.org/events/2019/cape-town/2019-cape-town-devopsdays-prospectus.pdf" target="_blank">prospectus</a> or drop us an email at [{{< email_organizers >}}].
 
 devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
 <p>


### PR DESCRIPTION
Ready to be merged, just adding a link to our sponsor prospectus (devopsdays-assets hosted, already merged: https://github.com/devopsdays/devopsdays-assets/pull/57)
