### PR TITLE
[DC 2019] add Red Hat's campaign ID for this year's sponsorship

### DIFF
--- a/data/events/2019-washington-dc.yml
+++ b/data/events/2019-washington-dc.yml
@@ -312,5 +312,6 @@ sponsors:
     level: platinum
   - id: redhatgov
     level: platinum
+    url: "https://go.redhat.com/public-sector?sc_cid=701f2000001OIyfAAG"
   - id: circleci
     level: gold


### PR DESCRIPTION
[Because you can](https://github.com/devopsdays/devopsdays-web/blob/master/themes/devopsdays-theme/REFERENCE.md#sponsor-fields)!