### PR TITLE
Removing blank area on front page

### DIFF
--- a/themes/devopsdays-theme/layouts/index.html
+++ b/themes/devopsdays-theme/layouts/index.html
@@ -47,12 +47,4 @@
             {{- end -}}
         </div>
         <!-- <div id="share"></div> -->
-
-        <div class="row">
-            <div class="col-md-12">
-                <div class="embed-responsive embed-responsive-16by9">
-                    <div id="map_canvas" class="embed-responsive-item"></div>
-                </div>
-            </div>
-        </div>
 {{- end -}}


### PR DESCRIPTION
We currently have a blank area where the map was. Taking that off the front page while we consider [resolving the map issue](https://github.com/devopsdays/devopsdays-web/issues/6918).