### PR TITLE
[DC-2019] Sponsor cleanup and updates

### DIFF
--- a/content/events/2019-washington-dc/sponsor.md
+++ b/content/events/2019-washington-dc/sponsor.md
@@ -19,6 +19,8 @@ DevOpsDays on their own terms.
 Please email the organizers at {{< email_organizers >}} with any questions
 you may have about sponsoring the event.
 
+Have questions about sponsoring or about your organization's sponsorship? Checkout out our [sponsor FAQ](https://docs.google.com/document/d/1dbeMc-crgauwC5F1JnwKLSpDqx4oubsnpuGvNIA7eEc/edit?usp=sharing).
+
 The following chart outlines our sponsorship packages.
 
 <style>
@@ -88,7 +90,7 @@ The following chart outlines our sponsorship packages.
     <td class="yes">&#9989;</td>
     <td class="no"> </td>
     <td class="no"> </td>
-    <td class="yes">&#9989;</td>
+    <td class="no"></td>
   </tr>
     <td>Full table for swag/marketing during conference</td>
     <td class="no"> </td>

--- a/content/events/2019-washington-dc/sponsor.md
+++ b/content/events/2019-washington-dc/sponsor.md
@@ -19,7 +19,7 @@ DevOpsDays on their own terms.
 Please email the organizers at {{< email_organizers >}} with any questions
 you may have about sponsoring the event.
 
-Have questions about sponsoring or about your organization's sponsorship? Checkout out our [sponsor FAQ](https://docs.google.com/document/d/1dbeMc-crgauwC5F1JnwKLSpDqx4oubsnpuGvNIA7eEc/edit?usp=sharing).
+Have questions about sponsoring or about your organization's sponsorship? Check out our [sponsor FAQ](https://docs.google.com/document/d/1dbeMc-crgauwC5F1JnwKLSpDqx4oubsnpuGvNIA7eEc/edit?usp=sharing).
 
 The following chart outlines our sponsorship packages.
 

--- a/data/events/2019-washington-dc.yml
+++ b/data/events/2019-washington-dc.yml
@@ -313,5 +313,11 @@ sponsors:
   - id: redhatgov
     level: platinum
     url: "https://go.redhat.com/public-sector?sc_cid=701f2000001OIyfAAG"
+  - id: dlt
+    level: platinum
   - id: circleci
     level: gold
+  - id: arresteddevops
+    level: media
+  - id: foodfight
+    level: media

--- a/data/sponsors/dlt.yml
+++ b/data/sponsors/dlt.yml
@@ -1,2 +1,3 @@
-name: dlt
-url: http://www.dlt.com/
+name: DLT Solutions
+url: https://www.dlt.com/
+twitter:  DLTSolutions

--- a/data/sponsors/foodfight.yml
+++ b/data/sponsors/foodfight.yml
@@ -1,3 +1,3 @@
-
 name: "Food Fight"
 url: "http://foodfightshow.org"
+twitter:  "FoodFightShow"

--- a/data/sponsors/pyramid-systems.yml
+++ b/data/sponsors/pyramid-systems.yml
@@ -1,2 +1,3 @@
 name: Pyramid Systems
 url: https://pyramidsystems.com/
+twitter:  PyramidSystems


### PR DESCRIPTION
* Add link to Sponsor FAQ
* Happy Hour sponsors get a full table
* DLT is a platinum sponsor
* Arrested DevOps is a media sponsor
* Food Fight Show is a media sponsor
* Update DLT company name and twitter
* Add twitter for Food Fight Show
* Add twitter for PyramidSystems

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>
