### PR TITLE
[DC-2019] use https in Chef's URL

### DIFF
--- a/data/events/2019-washington-dc.yml
+++ b/data/events/2019-washington-dc.yml
@@ -317,7 +317,7 @@ sponsors:
     level: platinum
   - id: chef
     level: platinum
-    url: "http://chef.io/?utm_source=doddc"
+    url: "https://chef.io/?utm_source=doddc"
   - id: circleci
     level: gold
   - id: devopsdc-meetup


### PR DESCRIPTION
Because S is better.