### PR TITLE
[Columbus 2019] Fix on location page: Removing old location

### DIFF
--- a/content/events/2019-columbus/location.md
+++ b/content/events/2019-columbus/location.md
@@ -4,7 +4,6 @@ Type = "event"
 Description = "Location for devopsdays Columbus 2019"
 +++
 
-The Bluestone, 583 E Broad St, Columbus, OH 43215
 Fawcett Event Center, 2400 Olentangy River Rd, Columbus, OH 43210
 
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3055.9128018738497!2d-83.02319918397376!3d40.01039527941449!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x88388e9bc7fbee59%3A0x8d9f3d1564b659a7!2sFawcett+Event+Center!5e0!3m2!1sen!2sus!4v1551827594559" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>


### PR DESCRIPTION
Apparently I had both the old and new location on the page...oops.