### PR TITLE
[MSP-2019] Add mesosphere and gitlab, remove google

### DIFF
--- a/data/events/2019-minneapolis.yml
+++ b/data/events/2019-minneapolis.yml
@@ -170,11 +170,11 @@ sponsors:
     level: silver
   - id: keyva
     level: silver
-  - id: googlecloud
-    level: gold
-  - id: googlecloud
-    level: alacarte
   - id: logzio
+    level: gold
+  - id: gitlab
+    level: gold
+  - id: mesosphere
     level: gold
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link


### PR DESCRIPTION
Mesosphere and gitlab are new sponsors. I goofed when I added google. We
are still waiting for payment.

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*
