### PR TITLE
[SLC-2019] Sponsor logo change.

### DIFF
--- a/data/events/2019-salt-lake-city.yml
+++ b/data/events/2019-salt-lake-city.yml
@@ -127,7 +127,7 @@ sponsors:
       level: gold
     - id: sonatype
       level: gold
-    - id: splunk
+    - id: victorops
       level: gold
     - id: circleci
       level: silver


### PR DESCRIPTION
easy PR
-VictorOps/Splunk wanted the vicops logo listed instead.