### PR TITLE
[DC-2019] One less redirect

### DIFF
--- a/data/sponsors/stsi.yml
+++ b/data/sponsors/stsi.yml
@@ -1,3 +1,3 @@
 name: stsi
-url: http://www.stsiinc.com/
+url: https://stsiinc.com/
 twitter: stsiinc


### PR DESCRIPTION
The STSI URL was redirecting to https://stsiinc.com/, let's just skip the redirect and send folks to the proper destination.

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>
