### PR TITLE
[HFD-2019] Add Henry Quinn as an Organizer

### DIFF
--- a/data/events/2019-hartford.yml
+++ b/data/events/2019-hartford.yml
@@ -89,6 +89,13 @@ team_members: # Name is the only required field for team members.
     website: ""
     image: ""
     bio: ""
+  - name: "Henry Quinn"
+    twitter: ""
+    employer: ""
+    github: ""
+    website: ""
+    image: ""
+    bio: ""
 organizer_email: "organizers-hartford-2019@devopsdays.org" # Put your organizer email address here
 proposal_email: "proposals-hartford-2019@devopsdays.org" # Put your proposal email address here
 


### PR DESCRIPTION
Email to follow adding Henry as an Organizer for DevOpsDays Hartford. His information will be updated.