### PR TITLE
[MSP-2019] Add netapp as silver and alacarte

### DIFF
--- a/content/events/2019-minneapolis/sponsor.md
+++ b/content/events/2019-minneapolis/sponsor.md
@@ -20,7 +20,7 @@ Additional à la carte sponsorships are available:
 <li>Day 1 all-day coffee ($3000) - 1 slot available - signage by the coffee displays with your logo throughout the day
 <li>Day 1 breakfast ($2500) - 2 slots available - signage by the breakfast service with your logo in the morning before sessions
 <li>Day 1 lunch ($3500) - 1 slot available - signage by the lunch service with your logo during lunch
-<li>Day 1 afternoon break ($1000) - 2 slots available - signage by the snack area with your logo during the afternoon when snacks are available
+<li>Day 1 afternoon break ($1000) - 1 slots available - signage by the snack area with your logo during the afternoon when snacks are available
 <li>Day 1 evening happy hour ($4000) - 1 slot available - signage at the evening happy hour
 </ul>
 
@@ -28,7 +28,7 @@ Additional à la carte sponsorships are available:
 <li>Day 2 all-day coffee ($3000) - 1 slot available - signage by the coffee displays with your logo throughout the day
 <li>Day 2 breakfast ($2500) - 2 slots available - signage by the breakfast service with your logo in the morning before sessions
 <li>Day 2 lunch ($3500) - 2 slots available - signage by the lunch service with your logo during lunch
-<li>Day 2 afternoon break ($1000) - 1 slot available - signage by the snack area with your logo during the afternoon when snacks are available
+<li><strike>Day 2 afternoon break ($1000)</strike> - <b>SOLD OUT</b></li>
 </ul>
 
 These may be purchased in addition to (or in lieu of) the platinum, gold, and silver sponsorships in the prospectus. An à la carte sponsorship by itself does not come with a table; you must have a platinum, gold, or silver sponsorship to be assigned a table you can staff.

--- a/data/events/2019-minneapolis.yml
+++ b/data/events/2019-minneapolis.yml
@@ -180,6 +180,10 @@ sponsors:
     level: gold
   - id: victorops
     level: gold
+  - id: netapp
+    level: silver
+  - id: netapp
+    level: alacarte
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Also updates the sponsor page to indicate only 1 slot left for day 1
afternoon break and day 2 is sold out.

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*
