### PR TITLE
[DC-2019] No need for a redirect to https

### DIFF
--- a/data/sponsors/onyx-point.yml
+++ b/data/sponsors/onyx-point.yml
@@ -1,3 +1,3 @@
 name: "Onyx Point"
-url: "http://www.onyxpoint.com/"
+url: "https://www.onyxpoint.com/"
 twitter: onyxpoint


### PR DESCRIPTION
OnyxPoint's http url redirects to https.  Let's just link there.

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>
