### PR TITLE
[GHENT2019] Change the propose page to link to pretalx

### DIFF
--- a/content/events/2019-ghent/propose.md
+++ b/content/events/2019-ghent/propose.md
@@ -27,9 +27,5 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+<strong>How to submit a proposal:</strong> use our Pretalx instance at <a href="https://cfp.devopsdays.gent/2019/cfp">https://cfp.devopsdays.gent/2019/cfp</a>
+


### PR DESCRIPTION
[GHENT2019] Change the propose page to link to pretalx

So the propose page is not really visible, however if you link directly to that, it still show older mail cfp data in place of the updated dodgent-pretalx link