### PR TITLE
[DFW-2019] Clearing up confusion on Sponsor page

### DIFF
--- a/content/events/2019-dallas/sponsor.md
+++ b/content/events/2019-dallas/sponsor.md
@@ -137,7 +137,7 @@ Please email the organizers at <a href="mailto:organizers-dallas-2019@devopsdays
       <td><img src = "/events/2019-dallas/half-boot.png"><strong><br>1-minute</strong></td>
     </tr>
     <tr>
-      <td colspan="2">20% Discount code to share with your community</td>
+      <td colspan="2">20% Discount code provided to share with your client community</td>
       <td colspan="2"><img src = "/events/2019-dallas/boot.png"><strong><br>(50) tickets</strong></td>
       <td><strong><img src = "/events/2019-dallas/half-boot.png"><strong><br>(10) tickets</strong></td>
       <td><img src = "/events/2019-dallas/half-boot.png"><strong><br>(10) tickets</strong></td>
@@ -341,4 +341,4 @@ Please email the organizers at <a href="mailto:organizers-dallas-2019@devopsdays
 <br><br>
 Sponsors are responsible for providing high-res logos for use on the website and in promotional materials.  The preferred file formats are EPS or AI.
 <br><br>
-<b>All sponsors attendees must be registered to attend</b>. We offer sponsors 20% off all additional registrations.
+<b>All sponsors attendees must be registered to attend</b>. We offer sponsors 20% off for any additional sponsor registration requests after <i>Tickets Included</i> have been consumed.

--- a/content/events/2019-dallas/sponsor.md
+++ b/content/events/2019-dallas/sponsor.md
@@ -20,7 +20,7 @@ Any attendee also has the opportunity to demonstrate products or projects as par
 <br><br>
 The best thing to do is send engineers to interact with the experts at DevOpsDays on their own terms.
 <br><br>
-Please email the organizers at <a href="mailto:organizers-dallas-2019@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Dallas%202019"><strong>organizers-dallas-2019@devopsdays.org</strong></a> with any questions you may have about sponsoring the event.
+Please email the organizers at <a href="mailto:organizers-dallas-2019@devopsdays.org?subject=General%20Questions%20Regarding%20Sponsorship%20of%20DevOpsDays%20Dallas%202019"><strong>organizers-dallas-2019@devopsdays.org</strong></a> with any questions you may have about sponsoring the event.
 <br><br>
 <h2>Sponsorship Packages</h2>
 
@@ -337,7 +337,7 @@ We are excited to have you sponsor our event. We also understand that there are 
  <li><i class="fa-li fa fa-check-square"></i>Between June 2 and July 31, 2019 - 75% refund is available.</li>
  <li><i class="fa-li fa fa-check-square"></i>After August 1, 2019 - No refund is available.</li>
 <br>
-Please email the organizers at <a href="mailto:organizers-dallas-2019@devopsdays.org?subject=Interested%20in%20Community%20Sponsorship%20DevOpsDays%20Dallas%202019">organizers-dallas-2019@devopsdays.org</a> with any questions you may have about sponsoring the event or requesting a refund.
+Please email the organizers at <a href="mailto:organizers-dallas-2019@devopsdays.org?subject=General%20Questions%20Regarding%20Sponsorship%20of%20DevOpsDays%20Dallas%202019">organizers-dallas-2019@devopsdays.org</a> with any questions you may have about sponsoring the event or requesting a refund.
 <br><br>
 Sponsors are responsible for providing high-res logos for use on the website and in promotional materials.  The preferred file formats are EPS or AI.
 <br><br>


### PR DESCRIPTION
Signed-off-by: Mike Rosado <MikeRosTX@att.net>

Changed the Subject line confusion when potential sponsors email asking general questions by removing Community from Subject line.