### PR TITLE
[PHILLY 2019] Remove logz.io as a sponsor.

### DIFF
--- a/data/events/2019-philadelphia.yml
+++ b/data/events/2019-philadelphia.yml
@@ -77,8 +77,6 @@ sponsors:
     level: platinum
   - id: appdynamics
     level: gold
-  - id: logz
-    level: gold
   - id: arresteddevops
     level: community
 


### PR DESCRIPTION
On the tin.