### PR TITLE
[BOS-2019] Add sponsorship descriptions.

### DIFF
--- a/content/events/2019-boston/sponsor.md
+++ b/content/events/2019-boston/sponsor.md
@@ -1,66 +1,177 @@
 +++
 Title = "Sponsor"
 Type = "event"
-Description = "Sponsor devopsdays Boston 2019"
+Description = "Sponsor DevOpsDays Boston 2019"
 +++
 
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
-
-<hr>
-
-devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
-<p>
-Gold sponsors get a full table and Silver sponsors a shared table where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.
-<p>
-The best thing to do is send engineers to interact with the experts at devopsdays on their own terms.
-<p>
-
-<!--
 <hr/>
+<div class="container-fluid">
+  <div class="row justify-content-start">
+    <div class="col-md-9">
+      <div>
+      <h3>Join the community</h3>
+<p>devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.</p>
+<p>Gold sponsors get a full table and Silver sponsors a shared table where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.</p>
+<p>The best thing to do is send engineers to interact with the experts at devopsdays on their own terms.</p>
 
-<div style="width:590px">
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>packages</i></th>
-    <th><center><b><u>Bronze<br />1000 usd</u></center></b></th>
-    <th><center><b><u>Silver<br />3000 usd</u></center></b></th>
-    <th><center><b><u>Gold<br />5000 usd</u></center></b></th>
-    <th></th>
-  </tr>
-<tr><td>2 included tickets</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on event website</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on shared slide, rotating during breaks</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on all email communication</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on its own slide, rotating during breaks</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>1 minute pitch to full audience (including streaming audience)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr></tr>
-<tr><td>2 additional tickets (4 in total)</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>4 additional tickets (6 in total)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>shared table for swag</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>booth/table space</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-</table>
-<hr/>
-There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
-<br/>
-<br/>
 
-<br>
-<br>
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>Sponsor FAQ</i></th>
-    <th><center><b>Answers to questions frequently asked by sponsors&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</center></b></th>
-    <th></th>
-  </tr>
-<tr><td>What dates/times can we set up and tear down?</td><td></td></tr>
-<tr><td>How do we ship to the venue?</td><td></td></tr>
-<tr><td>How do we ship from the venue?</td><td></td></tr>
-<tr><td>Whom should we send?</td><td></td></tr>
-<tr><td>What should we expect regarding electricity? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>What should we expect regarding WiFi? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>How do we order additional A/V equipment?</td><td></td></tr>
-<tr><td>Additional important details</td><td></td></tr>
-</table>
+      </div>
+      <h3>Sponsorship Packages</h3>
+      <div class="table-responsive">
+      <table class="table table-bordered table-hover table-responsive-md">
+        <thead class="thead-light">
+          <tr>
+            <th scope="col">
+              <i>Packages</i>
+            </th>
+            <th scope="col">
+              <center>Gold</center>
+            </th>
+            <th scope="col">
+              <center>Platinum</center>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Pricing</th>
+            <td>
+              <center>$5,500</center>
+            </td>
+            <td>
+              <center>$8,000</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">&nbsp;</th>
+            <th>
+              <center><span class="badge badge-success">Available</span></center>
+            </th>
+            <th>
+              <center><span class="badge badge-success">Available</span></center>
+            </th>
+          </tr>
+          <tr>
+            <th scope="row"># of conference passes</th>
+            <td>
+              <center>2</center>
+            </td>
+            <td>
+              <center>4</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Table Size</th>
+            <td>
+              <center>4' x 4'</center>
+            </td>
+            <td>
+              <center>6' x 2.5'</center>
+            </td>
+
+          </tr>
+          <tr>
+            <th scope="row">Company logo on digital signage</th>
+            <td>
+              <center>Medium</center>
+            </td>
+            <td>
+              <center>Large</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Minutes on stage during conference</th>
+            <td>
+              <center>-</center>
+            </td>
+            <td>
+              <center>2</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Additional, a la carte sponsorships</th>
+            <th>
+              <center># Available</center>
+            </th>
+            <th>
+              <center>Cost</center>
+            </th>
+          </tr>
+          <tr>
+            <th scope="row">Evening Event</th>
+            <td>
+              <center>1</center>
+            </td>
+            <td>
+              <center>$12,500</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Live Captioning</th>
+            <td>
+              <center>1</center>
+            </td>
+            <td>
+              <center>$8,000</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Media (photography, videography)</th>
+            <td>
+              <center>2</center>
+            </td>
+            <td>
+              <center>$5,000</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Wi-Fi</th>
+            <td>
+              <center>1</center>
+            </td>
+            <td>
+              <center>$5,000</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Badges & Lanyards</th>
+            <td>
+              <center>1</center>
+            </td>
+            <td>
+              <center>$3,500</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Breaks</th>
+            <td>
+              <center>4</center>
+            </td>
+            <td>
+              <center>$2,000</center>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Start-up Alley</th>
+            <td>
+              <center>4</center>
+            </td>
+            <td>
+              <center>$1,500</center>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+<div>
+
+<p>If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].</p>
+
+
 </div>
+    </div>
+    </div>
+    <div class="col-md-3 col-sm-12">
+      <a href="https://assets.devopsdays.org/events/2019/boston/devopsdays-boston-2019-brochure.pdf"><img src="https://assets.devopsdays.org/events/2019/boston/thumbnail.png" class="img-fluid"></a>
+    </div>
 
--->
-<hr/>
+  </div>


### PR DESCRIPTION
Adding sponsorship descriptions and a link to the sponsorship prospectus.

Depends on devopsdays/devopsdays-assets#64.