### PR TITLE
Moving comment for datetime line

### DIFF
--- a/data/events/2019-ghent.yml
+++ b/data/events/2019-ghent.yml
@@ -23,7 +23,7 @@ cfp_open: "true"
 cfp_link: "https://cfp.devopsdays.gent/2019/cfp" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2019-05-01T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2019-10-28T23:59:59+01:00# close registration. Leave blank if registration is not open yet.
+registration_date_end: 2019-10-28T23:59:59+01:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.


### PR DESCRIPTION
The tests run a little differently when running from a branch directly on the repo instead of from a fork, and I noticed this in a PR of @mattstratton's; I moved the `#` to prevent us from seeing this error (which I don't _think_ is evident otherwise):

<i>
11:27:23 AM: ERROR 2019/05/31 16:27:23 Unable to locate template for shortcode 'param' in page propose
11:27:24 AM: ERROR 2019/05/31 16:27:24 theme/partials/meta.html template: "theme/partials/meta.html" is an incomplete or empty template
11:29:17 AM: ERROR 2019/05/31 16:29:17 theme/partials/events/cta.html template: theme/partials/events/cta.html:24:73: executing "theme/partials/events/cta.html" at <time $e.registration...>: error calling time: Could not parse Date/Time format: Unable to parse date: 2019-10-28T23:59:59+01:00# close registration. Leave blank if registration is not open yet.
</i>


