### PR TITLE
[DC-2019] add Split Software as platinum sponsor

### DIFF
--- a/data/events/2019-washington-dc.yml
+++ b/data/events/2019-washington-dc.yml
@@ -278,11 +278,7 @@ team_members: # Name is the only required field for team members.
 organizer_email: "organizers-washington-dc-2019@devopsdays.org" # Put your organizer email address here
 proposal_email: "organizers-washington-dc-2019@devopsdays.org" # Put your proposal email address here
 
-# List all of your sponsors here along with what level of sponsorship they have.
-# Check data/sponsors/ to use sponsors already added by others.
-sponsors:
-  - id: arresteddevops
-    level: community
+# Sponsoring!
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_link: "https://devopsdaysdc2019.busyconf.com/bookings/new?discount=SPONSOR"
@@ -307,6 +303,8 @@ sponsor_levels:
   - id: media
     label: Media
 
+# List all of your sponsors here along with what level of sponsorship they have.
+# Check data/sponsors/ to use sponsors already added by others.
 sponsors:
   - id: pyramid-systems
     level: platinum
@@ -333,6 +331,8 @@ sponsors:
   - id: googlecloud
     level: platinum
   - id: signalfx
+    level: platinum
+  - id: split-software
     level: platinum
   - id: circleci
     level: gold


### PR DESCRIPTION
@nathenharvey @xzilla 

Also remove vestigial sponsor stanza earlier in the data; that's not where we're listing them.

Confirmed to reuse existing sponsor data and image.