### PR TITLE
[DC-2019] add Capital One as a platinum sponsor

### DIFF
--- a/data/events/2019-washington-dc.yml
+++ b/data/events/2019-washington-dc.yml
@@ -334,6 +334,8 @@ sponsors:
     level: platinum
   - id: split-software
     level: platinum
+  - id: capitalone
+    level: platinum
   - id: circleci
     level: gold
   - id: sts


### PR DESCRIPTION
@nathenharvey @xzilla 

Adding CapOne, reusing past sponsorship data and assets.