### PR TITLE
Fix grammar for becoming a sponsor.

### DIFF
--- a/themes/devopsdays-theme/layouts/partials/sponsors.html
+++ b/themes/devopsdays-theme/layouts/partials/sponsors.html
@@ -25,7 +25,7 @@
                   {{- else -}}
                     <a href = "{{ (printf "/events/%s/sponsor" $e.name) }}" class="sponsor-cta">
                   {{- end -}}
-                    <i>Become a {{ $level.label }} Sponsor!</i>
+                    <i>Become a{{ if in "a e i o u" (substr $level.label 0 1) }}n{{ end }} {{ $level.label }} Sponsor!</i>
                   </a>
                 {{- end -}}
               {{- end -}}


### PR DESCRIPTION
Boston recently added an a-la-carte sponsorship type. The framework duly creates a grammatically incorrect "Become a a la carte sponsor" link on our page.

This change makes vowels form grammatically correct sentences. The solution is not perfect - it will screw up on things like "Become an one-day sponsor," but is generally more often correct than not.

Before:
![Screenshot from 2019-06-19 01-41-44](https://user-images.githubusercontent.com/8206137/59739912-67dcf780-9234-11e9-9321-f3034ddd1bcf.png)

After:
![Screenshot from 2019-06-19 01-41-55](https://user-images.githubusercontent.com/8206137/59739918-6ad7e800-9234-11e9-9ef9-75ea9b0d542f.png)
