### PR TITLE
[Columbus-2019] Adding JP Morgan Chase as a sponsor.

### DIFF
--- a/data/events/2019-columbus.yml
+++ b/data/events/2019-columbus.yml
@@ -108,6 +108,8 @@ sponsors:
     level: gold
   - id: redhat
     level: gold
+  - id: jpmc
+    level: gold
   - id: datarobot
     level: gold
   - id: newrelic


### PR DESCRIPTION
Simple sponsor add... apparently was already there, almost added it a second time due to the odd name of the files.