### PR TITLE
[Dallas 2019] Fixing Dallas reg layout

### DIFF
--- a/content/events/2019-dallas/registration.md
+++ b/content/events/2019-dallas/registration.md
@@ -4,26 +4,4 @@ Type = "event"
 Description = "Registration for devopsdays Dallas 2019"
 +++
 
-<div id="eventbrite-widget-container-60290377141"></div>
-
-<script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
-
-<script type="text/javascript">
-    var exampleCallback = function() {
-        console.log('Order complete!');
-    };
-
-    window.EBWidgets.createWidget({
-        // Required
-        widgetType: 'checkout',
-        eventId: '60290377141',
-        iframeContainerId: 'eventbrite-widget-container-60290377141',
-
-        // Optional
-        iframeContainerHeight: 425,  // Widget height in pixels. Defaults to a minimum of 425px if not provided
-        onOrderComplete: exampleCallback  // Method called when an order has successfully completed
-    });
-</script>
-
-</div></div>
-</div>
+<div style="width:100%; text-align:left;"><iframe src="//eventbrite.com/tickets-external?eid=60290377141&ref=etckt" frameborder="0" height="478" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:12px; padding:10px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #ADB0B6; text-decoration: none;" target="_blank" href="http://www.eventbrite.com/">Powered by Eventbrite</a></div></div>


### PR DESCRIPTION
The Dallas registration page has major layout issues with how the sponsors were displayed:

<img width="1251" alt="Screen Shot 2019-08-11 at 2 00 18 PM" src="https://user-images.githubusercontent.com/2104453/62838445-ca091600-bc41-11e9-895f-6df84addf4f8.png">

This PR fixes it. (cc @MikeRosTX)