### PR TITLE
[2020] Updating Prague email scheme

### DIFF
--- a/data/events/2020-prague.yml
+++ b/data/events/2020-prague.yml
@@ -76,8 +76,7 @@ team_members: # Name is the only required field for team members.
   - name: "Ľubomír Kováč"
     bio: "For more than a decade, I've been crafting the ability of introducing sophisticated bugs into the software for future generations to resolve. That led me to an idea to share this art with community on MeetUps and spread the joy of software engineering."
     image: "l_kovac.jpg"
-organizer_email: "organizers-prague-2020@devopsdays.org" # Put your organizer email address here
-proposal_email: "proposals-prague-2020@devopsdays.org" # Put your proposal email address here
+organizer_email: "prague@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
The old email aliases will all still work, but we're standardizing on the city name so you won't need to get a new alias created each year. @a-vorobiev please pull in from upstream/master before next time you update - thanks!