### PR TITLE
[2020] Updating Cáceres email scheme

### DIFF
--- a/content/events/2020-caceres/propose.md
+++ b/content/events/2020-caceres/propose.md
@@ -27,7 +27,7 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
+<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
 <ol>
 	<li>Type (presentation, panel discussion, ignite)</li>
 	<li>Proposal Title (can be changed later)</li>

--- a/data/events/2020-caceres.yml
+++ b/data/events/2020-caceres.yml
@@ -60,8 +60,7 @@ team_members: # Name is the only required field for team members.
   - name: "María Jesús Ruiz Suero"
   - name: "Jesús Santiesteban Fernández"
   - name: "Javier Núñez Berrocoso"
-organizer_email: "organizers-caceres-2020@devopsdays.org" # Put your organizer email address here
-proposal_email: "proposals-caceres-2020@devopsdays.org" # Put your proposal email address here
+organizer_email: "caceres@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
The old email aliases will all still work, but we're standardizing on the city name so you won't need to get a new alias created each year. @curratore please pull in from upstream/master before next time you update - thanks!
