### PR TITLE
[2020] Updating Geneva email scheme 

### DIFF
--- a/content/events/2020-geneva/propose.md
+++ b/content/events/2020-geneva/propose.md
@@ -9,7 +9,7 @@ Description = "Propose a talk for DevOpsDays Geneva 2020"
 <hr>
 
 <!--
-<strong>How to submit a proposal:</strong> Fill the <a href='https://goo.gl/forms/3Rstd0c1PJR1kDcl2' target='_blank'>Google Form</a> or send an e-mail to {{< email_proposals >}} with the following information:
+<strong>How to submit a proposal:</strong> Fill the <a href='https://goo.gl/forms/3Rstd0c1PJR1kDcl2' target='_blank'>Google Form</a> or send an e-mail to {{< email_organizers >}} with the following information:
 <ol>
 <li>A title of less than 250 characters (can be tweeted)</li>
 <li>A summary of 100-150 words max. (will be in the program and the website)</li>

--- a/data/events/2020-geneva.yml
+++ b/data/events/2020-geneva.yml
@@ -85,8 +85,7 @@ team_members: # Name is the only required field for team members.
     bio: "Sen, de formation hôtelière, a 12 ans d’expérience dans l’organisation d’événements. Ses qualités sont la connaissance des grandes villes européennes qu’il a sillonnées tout au long de ces dernières années, ainsi qu’un réseau de partenaires de confiance. Fort de son expérience dans le domaine pharmaceutique, il saura répondre à vos problématiques de compliance. Avec son humour et sa bonne humeur, il saura vous écouter et trouver la solution correspondant à vos attentes."
 
 
-organizer_email: "organizers-geneva-2020@devopsdays.org" # Put your organizer email address here
-proposal_email: "organizers-geneva-2020+proposals@devopsdays.org" # Put your proposal email address here
+organizer_email: "geneva@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
The old email aliases will all still work, but we're standardizing on the city name so you won't need to get a new alias created each year. @deniger please pull in from upstream/master before next time you update - thanks!