### PR TITLE
[2020] Updating Madrid email scheme

### DIFF
--- a/data/events/2020-madrid.yml
+++ b/data/events/2020-madrid.yml
@@ -51,8 +51,7 @@ team_members: # Name is the only required field for team members.
   - name: "Christian Melendez"
 
 
-organizer_email: "organizers-madrid-2020@devopsdays.org" # Put your organizer email address here
-proposal_email: "proposals-madrid-2020@devopsdays.org" # Put your proposal email address here
+organizer_email: "madrid@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
The old email aliases will all still work, but we're standardizing on the city name so you won't need to get a new alias created each year. @xavierportillaedo please pull in from upstream/master before next time you update - thanks!


