### PR TITLE
[2020] Updating New York City email scheme

### DIFF
--- a/content/events/2020-new-york-city/propose.md
+++ b/content/events/2020-new-york-city/propose.md
@@ -27,7 +27,7 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
+<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
 <ol>
 	<li>Type (presentation, panel discussion, ignite)</li>
 	<li>Proposal Title (can be changed later)</li>

--- a/data/events/2020-new-york-city.yml
+++ b/data/events/2020-new-york-city.yml
@@ -94,8 +94,7 @@ team_members: # Name is the only required field for team members.
     image: "stephen-thomas.jpg"
   - name: "Matthew Titmus"
 
-organizer_email: "organizers-new-york-city-2020@devopsdays.org" # Put your organizer email address here
-proposal_email: "proposals-new-york-city-2020@devopsdays.org" # Put your proposal email address here
+organizer_email: "new-york-city@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
The old email aliases will all still work, but we're standardizing on the city name so you won't need to get a new alias created each year. @jaydestro please pull in from upstream/master before next time you update - thanks!