### PR TITLE
[2020] Updating Houston email scheme

### DIFF
--- a/content/events/2020-houston/propose.md
+++ b/content/events/2020-houston/propose.md
@@ -27,7 +27,7 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
+<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
 <ol>
 	<li>Type (presentation, panel discussion, ignite)</li>
 	<li>Proposal Title (can be changed later)</li>

--- a/data/events/2020-houston.yml
+++ b/data/events/2020-houston.yml
@@ -110,8 +110,7 @@ team_members: # Name is the only required field for team members.
     image: "svetlana-kryukova.jpg"
     bio: "Svetlana is a software development leader with over 20 years of experience in enterprise software. Passionate about building teams, creating new products and solving problems. Co-organizer of Houston DevOps Meetup since June 2018."
 
-organizer_email: "organizers-houston-2020@devopsdays.org" # Put your organizer email address here
-proposal_email: "proposals-houston-2020@devopsdays.org" # Put your proposal email address here
+organizer_email: "houston@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
The old email aliases will all still work, but we're standardizing on the city name so you won't need to get a new alias created each year. @rchillard @madblkman please pull in from upstream/master before next time you update - thanks!

