### PR TITLE
[2020] Updating Portland, ME email scheme

### DIFF
--- a/content/events/2020-portland-me/propose.md
+++ b/content/events/2020-portland-me/propose.md
@@ -27,7 +27,7 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_proposals >}}] with the following information
+<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
 <ol>
 	<li>Type (presentation, panel discussion, ignite)</li>
 	<li>Proposal Title (can be changed later)</li>

--- a/data/events/2020-portland-me.yml
+++ b/data/events/2020-portland-me.yml
@@ -63,8 +63,7 @@ team_members: # Name is the only required field for team members.
   - name: "Casey Rosenthal"
     twitter: "caseyrosenthal"
 
-organizer_email: "organizers-portland-me-2020@devopsdays.org"
-proposal_email: "proposals-portland-me-2020@devopsdays.org"
+organizer_email: "portland-me@devopsdays.org"
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
The old email aliases will all still work, but we're standardizing on the city name so you won't need to get a new alias created each year. @jlbutler please pull in from upstream/master before next time you update - thanks!
 