### PR TITLE
[VCP-2019] Add Globo and NewRelic as sponsors

### DIFF
--- a/data/events/2019-campinas.yml
+++ b/data/events/2019-campinas.yml
@@ -104,6 +104,10 @@ proposal_email: "proposals-campinas-2019@devopsdays.org" # Put your proposal ema
 sponsors:
   - id: aws
     level: gold
+  - id: newrelic
+    level: gold
+  - id: globo
+    level: bronze
   - id: infoq
     level: community
   - id: elastic


### PR DESCRIPTION
This PR adds two new sponsors to DevOpsDays Campinas:
- Globo.com
- NewRelic