### PR TITLE
Add support for embedded slides from Notist

### DIFF
--- a/content/events/2019-chicago/program/karissa-peth.md
+++ b/content/events/2019-chicago/program/karissa-peth.md
@@ -5,7 +5,7 @@ Talk_end_time = ""
 Title = "Document Like a Scientist"
 Type = "talk"
 Speakers = ["karissa-peth"]
-slides = "https://noti.st/karissapeth/g3vUiw/document-like-a-scientist"
+notist = "karissapeth/g3vUiw"
 +++
 
 Learn how scientists document their work and are able to pick up new experimental protocols quickly. Apply the concepts of scientific protocols to your documentation to make them more useful to yourself and your users.

--- a/themes/devopsdays-theme/REFERENCE.md
+++ b/themes/devopsdays-theme/REFERENCE.md
@@ -264,6 +264,7 @@ Pages of the type `talk` (which can include workshops, ignites, or talks) have a
 | `slideshare`  | No       | The URL to the talk on Slideshare. Use the full URL                                                                                                                                                             | "http://www.slideshare.net/mattstratton/the-five-love-languages-of-devops-54549536" |
 | `googleslides` | No      | The ID of the talk on Google Slides (not the full URL).                                                                                                                                                         | "1QnakgUC8AaNydPZCmKGYYja8gs2WoHbHRSjioIVdD9g" |
 | `pdf`          | No      | The URL to the PDF. Use the full URL.                                                                                                                                                                           | "http://www.mattstratton.com/my-slides.pdf" |
+| `notist`      | No      | The ID of the deck on Notist, including the username. | "mattstratton/jLwszn" |
 | `slides`      | No       | If the slides are available on a service other than Speakerdeck or Slideshare, enter the URL here.                                                                                                              | "http://www.mattstratton.com/my-slides"                                             |
 
 ### Speaker Page Fields

--- a/themes/devopsdays-theme/layouts/program/single.html
+++ b/themes/devopsdays-theme/layouts/program/single.html
@@ -34,6 +34,9 @@
     {{- with .Params.pdf -}}
       {{- $.Scratch.Set (printf "%s-slides_link" ($.Scratch.Get "base_file_name")) . }}
     {{- end -}}
+    {{- with .Params.notist -}}
+      {{- $.Scratch.Set (printf "%s-slides_link" ($.Scratch.Get "base_file_name")) (printf "https://noti.st/%s" .) }}
+    {{- end -}}
     {{- with .Params.slides -}}
       {{- $.Scratch.Set (printf "%s-slides_link" ($.Scratch.Get "base_file_name")) . }}
     {{- end -}}

--- a/themes/devopsdays-theme/layouts/talk/single.html
+++ b/themes/devopsdays-theme/layouts/talk/single.html
@@ -87,6 +87,16 @@
         {{- end -}}
       {{- end -}}
 
+      {{- if isset .Params "notist" -}}
+        {{- if ne .Params.notist "" -}}
+        <div class = "row">
+          <div class = "col">
+            <p data-notist="{{ .Params.notist }}">View <a href="https://noti.st/{{ .Params.notist }}">{{ .Title }}</a> on Notist.</p><script async src="https://on.notist.cloud/embed/002.js"></script>
+          </div>
+        </div>
+        {{- end -}}
+      {{- end -}}
+
       {{- if isset .Params "slides" -}}
         {{- if ne .Params.slides "" -}}
         <div class = "row">


### PR DESCRIPTION
This PR updates the talk and program pages to allow embedding of slides from Notist.

I have also updated the REFERENCE file with documentation.

NOTE: This PR includes a content push for 2019-Chicago, for purposes of testing (the content is not test content; but I wanted to have a talk page that included Notist)

Fixes #8070 	
