### PR TITLE
[KC-2019] split 'special' sponsors into distinct labels

### DIFF
--- a/data/events/2019-kansas-city.yml
+++ b/data/events/2019-kansas-city.yml
@@ -183,7 +183,7 @@ sponsors:
   - id: circleci
     level: premium
   - id: tgs
-    level: special
+    level: breakfast
  #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
   - id: arresteddevops
     level: community
@@ -205,9 +205,16 @@ sponsor_levels:
   - id: premium
     label: Premium
 #    max: 10
-  - id: special
-    label: Special
-    max: 0 # This is the same as omitting the max limit.
+  - id: lanyard
+    label: Lanyard
+  - id: breakfast
+    label: Breakfast
+  - id: lunch
+    label: Lunch
+  - id: social
+    label: Evening Social
+  - id: coffee
+    label: Coffee
   - id: supporting
     label: Supporting
   - id: community


### PR DESCRIPTION
It looks like we'll sell out of all of our additional sponsorships, so let's split them up on the site