### PR TITLE
[Sydney 2019] Adding links

### DIFF
--- a/content/events/2019-sydney/welcome.md
+++ b/content/events/2019-sydney/welcome.md
@@ -17,8 +17,8 @@ Description = "devopsdays sydney 2019"
       Back in 2010, it was one of the first DevOpsDays events. Today it's a part of a huge global chain of community events world wide.
     </p>
     <p>
-      Come and join us for two days of talks, ignites and open spaces. Learn what's new, share ideas stories and
-      meet you colleauge.
+      Come and join us for two days of talks, ignites and open spaces. Learn what's new, share ideas and stories and
+      meet your colleagues.
     </p>
     <hr/>
     <div class="row">
@@ -29,6 +29,7 @@ Description = "devopsdays sydney 2019"
         {{< event_start >}} - {{< event_end >}}
       </div>
     </div>
+<!--
     <div class="row">
       <div class="col-md-2">
         <strong>Propose</strong>
@@ -37,6 +38,7 @@ Description = "devopsdays sydney 2019"
         {{< event_link url-key="cfp_link" text="Propose a talk!" >}}
       </div>
     </div>
+-->
     <div class="row">
       <div class="col-md-2">
         <strong>Sponsors</strong>

--- a/data/events/2019-sydney.yml
+++ b/data/events/2019-sydney.yml
@@ -26,10 +26,16 @@ location_address: "488 George St, Sydney NSW 2000" #Optional - use the street ad
 nav_elements: # List of pages you want to show up in the navigation of your page.
  - name: registration
  - name: location
- - name: propose
+# - name: propose
+ - name: program
+   url: https://www.devopsdayssydney.org/agenda/
+ - name: speakers
+   url: https://www.devopsdayssydney.org/speakers/
  - name: sponsor
  - name: contact
  - name: conduct
+ - name: devopsdayssydney.org
+   url: https://www.devopsdayssydney.org/
 
 team_members:
   - name: "Artem Yakimenko"


### PR DESCRIPTION
Hi, @m1keil - adding links to elements of your program; the global site generates a lot of traffic and also preserves history. (It's recommended to archive your speakers and program there, so we don't have to use the wayback machine later, but I've told archive.org to save your current URLs.)