### PR TITLE
[BLN-2019] Add Oracle Linux as sponsor for Berlin

### DIFF
--- a/data/events/2019-berlin.yml
+++ b/data/events/2019-berlin.yml
@@ -113,6 +113,8 @@ sponsors:
     level: partner
   - id: sparheld
     level: partner
+  - id: oracle-linux
+    level: platinum
   - id: polarsquad
     level: platinum
   - id: 2016-idealo


### PR DESCRIPTION
Adding Oracle Linux as a sponsor for Berlin 2019. Logo already exists, as they're also sponsoring London this year.