### PR TITLE
Improve Google Slides embed size

### DIFF
--- a/themes/devopsdays-theme/layouts/talk/single.html
+++ b/themes/devopsdays-theme/layouts/talk/single.html
@@ -84,7 +84,7 @@
       {{- if isset .Params "googleslides" -}}
         {{- if ne .Params.googleslides "" -}}
         <div class="row">
-          <div class = "col" style="max-width:100%">
+          <div class = "embed-responsive embed-responsive-16by9">
             <iframe src="https://docs.google.com/presentation/d/{{ .Params.googleslides }}/embed?start=false&loop=false" allowfullscreen="true">
             </iframe>
           </div>


### PR DESCRIPTION
Fixes https://github.com/devopsdays/devopsdays-web/issues/8077
https://getbootstrap.com/docs/4.0/utilities/embed/

I selected `16by9` as I assume that's the most popular aspect ratio for
slides.

This seems to work well with my testing.