### PR TITLE
More clarity in links

### DIFF
--- a/themes/devopsdays-theme/layouts/_default/baseof.html
+++ b/themes/devopsdays-theme/layouts/_default/baseof.html
@@ -28,7 +28,7 @@
                   {{- block "main" . }} {{- end -}}
               </div>
               <div class="col-md-2 order-md-1">
-                  <a href = "{{ "/events" }}" class="left-nav-navs">PAST EVENTS</a><br />
+                  <a href = "{{ "/events" }}" class="left-nav-navs">ALL EVENTS</a><br />
                   {{- partial "future.html" . -}}
               </div>
             {{- end -}}
@@ -37,7 +37,7 @@
                 {{- block "main" . }} {{- end -}}
             </div>
             <div class="col-md-2 order-md-1">
-                <a href = "{{ "/events"}}" class="left-nav-navs">PAST EVENTS</a><br />
+                <a href = "{{ "/events"}}" class="left-nav-navs">ALL EVENTS</a><br />
                 {{- partial "future.html" . -}}
             </div>
         {{- end -}}

--- a/themes/devopsdays-theme/layouts/partials/footer.html
+++ b/themes/devopsdays-theme/layouts/partials/footer.html
@@ -52,7 +52,7 @@
           {{- end -}} {{/* end: date is now or afterwards */}}
         {{- end -}} {{/* end: if .cfp_date_end */}}
       {{- end -}} {{/* end: range sort $.Site.Data.events "startdate" */}}
-      <br />Propose a talk at an event near you!<br />
+      <br /><a href="https://devopsdays.org/speaking">Propose a talk</a> at an event near you!<br />
   </div>
   <div class="col-md-6 col-lg-3 footer-nav-col">
     <h3 class="footer-nav">About</h3>


### PR DESCRIPTION
"Past events" was a mislabel based on past usage - the link now leads to all events. 

"Propose a talk" needed a link - otherwise, the cities are linked, but overall speaking info is not.