### PR TITLE
Adding years to upcoming events

### DIFF
--- a/themes/devopsdays-theme/layouts/events/single.html
+++ b/themes/devopsdays-theme/layouts/events/single.html
@@ -5,7 +5,7 @@
 </div>
 <div class = "row">
   <div class = "col-md-12">
-    <h2>Future</h2>
+    <h2>Upcoming</h2>
   </div>
 </div>
 <div class = "row">
@@ -17,8 +17,8 @@
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}
       {{- end -}}
-      {{- if ne ($.Scratch.Get "month") (dateFormat "January" .startdate ) -}}
-        {{- $.Scratch.Set "month" (dateFormat "January" .startdate ) -}}
+      {{- if ne ($.Scratch.Get "month") (dateFormat "January 2006" .startdate ) -}}
+        {{- $.Scratch.Set "month" (dateFormat "January 2006" .startdate ) -}}
         {{- $.Scratch.Set "month-displayed" "false" -}}
       {{- end -}}
       {{- if ne ($.Scratch.Get "month-displayed") "true" -}}
@@ -26,7 +26,7 @@
         </div>
       {{- end -}}
       <div class = "col-md-6 col-lg-3 events-page-col">
-        <h4 class="events-page-months">{{ dateFormat "January" .startdate }}</h4>
+        <h4 class="events-page-months">{{ dateFormat "January 2006" .startdate }}</h4>
         {{- $.Scratch.Set "month-displayed" "true" -}}
         {{- $.Scratch.Set "close-tag" "true" -}}
       {{- end -}}


### PR DESCRIPTION
Changing the events page so upcoming events include years; I'm noticing that since there are lots of 2019 and also a bunch of 2020 events coming up, this makes more sense.