### PR TITLE
Organizer refactor

### DIFF
--- a/content/page/about.md
+++ b/content/page/about.md
@@ -22,8 +22,7 @@ The devopsdays global core team guides local organizers in hosting their own dev
 
 **Core Organizers**
 
-<em>Active</em><br>
-{{< list_core >}}
+{{< list_core_active >}}
 
 {{< list_core_advisory >}}
 

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -22,6 +22,7 @@ The devopsdays global core team guides local organizers in hosting their own dev
 
 **Core Organizers**
 
+<em>Active</em><br>
 {{< list_core >}}
 
 {{< list_core_advisory >}}

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -18,7 +18,7 @@ The first devopsdays was held in Ghent, Belgium in 2009. Since then, devopsdays 
 
 
 ### About the organization
-The devopsdays global core team guides local organizers in hosting their own devopsdays events worldwide.
+The devopsdays global core team guides local organizers in hosting their own devopsdays events worldwide. Active core organizers onboard and guide events, answer questions, and maintain the website. Advisory core organizers are less involved day-to-day but weigh in on important matters and assist as needed. Emeritus core organizers are no longer involved in the core team; we thank them for their past efforts.
 
 **Core Organizers**
 

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -24,7 +24,11 @@ The devopsdays global core team guides local organizers in hosting their own dev
 
 {{< list_core >}}
 
-If you have questions about hosting your own event or about potential future events you don't see listed, [email the core organizers](mailto:info@devopsdays.org). The core organizers cannot answer questions about sponsorships or registration for individual cities.
+{{< list_core_advisory >}}
+
+{{< list_core_emeritus >}}
+
+If you have questions about hosting your own event or about potential future events you don't see listed, [email the active and advisory core organizers](mailto:info@devopsdays.org). The core organizers cannot answer questions about sponsorships or registration for individual cities.
 
 ### Contact a specific event
 

--- a/data/core.toml
+++ b/data/core.toml
@@ -7,7 +7,6 @@ active = [
 "Rafael Gomes",
 "Nathen Harvey",
 "Mine Heck",
-"Matthew Jones",
 "Dan Maher",
 "Adrian Moisey",
 "Ken Mugrage",
@@ -18,7 +17,11 @@ active = [
 "John Willis"
 ]
 
-historic = [
+advisory = [
+"Matthew Jones"
+]
+
+emeritus = [
 "Patrick Debois (founder)",
 "Damon Edwards",
 "Anthony Goddard",

--- a/themes/devopsdays-theme/layouts/shortcodes/list_core.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/list_core.html
@@ -1,4 +1,3 @@
-<em>Active</em><br>
 {{- $len := (len $.Site.Data.core.active) -}}
 {{- range $index, $organizer := $.Site.Data.core.active -}}
   {{- if ne (add $index 1) $len -}}
@@ -7,5 +6,4 @@
     {{ $organizer }}
   {{- end -}}
 {{- end -}}
-<br>
 <br>

--- a/themes/devopsdays-theme/layouts/shortcodes/list_core.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/list_core.html
@@ -1,9 +1,1 @@
-{{- $len := (len $.Site.Data.core.active) -}}
-{{- range $index, $organizer := $.Site.Data.core.active -}}
-  {{- if ne (add $index 1) $len -}}
-    {{ $organizer }},&nbsp;
-  {{- else -}}
-    {{ $organizer }}
-  {{- end -}}
-{{- end -}}
-<br>
+<em>The global <a href="/about/">core organizers</a> support local teams.</em>

--- a/themes/devopsdays-theme/layouts/shortcodes/list_core_active.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/list_core_active.html
@@ -1,0 +1,11 @@
+<em>Active</em><br>
+{{- $len := (len $.Site.Data.core.active) -}}
+{{- range $index, $organizer := $.Site.Data.core.active -}}
+  {{- if ne (add $index 1) $len -}}
+    {{ $organizer }},&nbsp;
+  {{- else -}}
+    {{ $organizer }}
+  {{- end -}}
+{{- end -}}
+<br>
+<br>

--- a/themes/devopsdays-theme/layouts/shortcodes/list_core_advisory.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/list_core_advisory.html
@@ -1,6 +1,6 @@
-<em>Active</em><br>
-{{- $len := (len $.Site.Data.core.active) -}}
-{{- range $index, $organizer := $.Site.Data.core.active -}}
+<em>Advisory</em><br>
+{{- $len := (len $.Site.Data.core.advisory) -}}
+{{- range $index, $organizer := $.Site.Data.core.advisory -}}
   {{- if ne (add $index 1) $len -}}
     {{ $organizer }},&nbsp;
   {{- else -}}

--- a/themes/devopsdays-theme/layouts/shortcodes/list_core_emeritus.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/list_core_emeritus.html
@@ -1,6 +1,6 @@
-<em>Active</em><br>
-{{- $len := (len $.Site.Data.core.active) -}}
-{{- range $index, $organizer := $.Site.Data.core.active -}}
+<em>Emeritus</em><br>
+{{- $len := (len $.Site.Data.core.emeritus) -}}
+{{- range $index, $organizer := $.Site.Data.core.emeritus -}}
   {{- if ne (add $index 1) $len -}}
     {{ $organizer }},&nbsp;
   {{- else -}}

--- a/utilities/examples/content/events/yyyy-city/contact.md
+++ b/utilities/examples/content/events/yyyy-city/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}


### PR DESCRIPTION
Problem:
- Some organizers aren't directly working with new events, but haven't entirely retired. Adding a new level "Advisory", to ensure organizers can be listed accurately.
- The way we've previously listed inactive past members of the core team looks clunky, confusingly listing them on the contact pages of every event, when they aren't associated with the events or familiar to the newer city teams.
- The name "Historic" also is a bit odd/confusing.

Solution:
- Changing "Historic" to the more clear "Emeritus".
- Separating out core team members who are just advising core, not actively working on website or onboarding events, and calling them "Advisory".
- Listing Advisory and Emeritus core members on the "About" page but not individual event pages.

Moving @geekle to be the first "Advisory" member per discussion with him. Let's re-evaluate to make sure people are listed at the level where they're participating.