### PR TITLE
[BLN-2019] Add Redgate as sponsor for Berlin

### DIFF
--- a/data/events/2019-berlin.yml
+++ b/data/events/2019-berlin.yml
@@ -113,6 +113,8 @@ sponsors:
     level: partner
   - id: sparheld
     level: partner
+  - id: redgate
+    level: platinum
   - id: oracle-linux
     level: platinum
   - id: polarsquad


### PR DESCRIPTION
Adding Redgate as a sponsor for Berlin 2019. Logo already exists, as they're also sponsoring a bunch of other cities.