### PR TITLE
[KC-2019] add dell technologies as sponsor, tweak delltechnologies.yml

### DIFF
--- a/data/events/2019-kansas-city.yml
+++ b/data/events/2019-kansas-city.yml
@@ -230,6 +230,8 @@ sponsors:
     level: premium
   - id: vmlyr
     level: premium
+  - id: delltechnologies
+    level: premium
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 

--- a/data/sponsors/delltechnologies.yml
+++ b/data/sponsors/delltechnologies.yml
@@ -1,3 +1,3 @@
-name: "delltechnologies"
+name: "Dell Technologies"
 url: "https://www.dell.com/"
 twitter: "DellTech"


### PR DESCRIPTION
The current name in `delltechnolpagies.yml` looks silly when you hover over the image, so I split it out
