### PR TITLE
Add anchor links to headers

### DIFF
--- a/content/page/sponsor.md
+++ b/content/page/sponsor.md
@@ -4,6 +4,7 @@ Description = ""
 Tags = []
 Date = "2016-05-03T13:04:25-05:00"
 Title = "Sponsor devopsdays"
+type = "sponsor"
 
 +++
 

--- a/themes/devopsdays-theme/layouts/partials/heading_link.html
+++ b/themes/devopsdays-theme/layouts/partials/heading_link.html
@@ -1,0 +1,1 @@
+{{ . | replaceRE "(<h[2-9] id=\"([^\"]+)\".+)(</h[2-9]+>)" "${1}&nbsp;<a class=\"headline-hash\" href=\"#${2}\">#</a> ${3}" | safeHTML }}

--- a/themes/devopsdays-theme/layouts/sponsor/single.html
+++ b/themes/devopsdays-theme/layouts/sponsor/single.html
@@ -1,0 +1,9 @@
+{{ define "main" }}
+
+<h1>{{ .Title }}</h1>
+
+<div>
+    {{- partial "heading_link.html" .Content -}}
+</div>
+
+{{  end }}


### PR DESCRIPTION
Taken from https://discourse.gohugo.io/t/adding-anchor-next-to-headers/1726/9?u=kaushalmodi

My second attempt at https://github.com/devopsdays/devopsdays-web/pull/8451
Fixes https://github.com/devopsdays/devopsdays-web/issues/8494

It doesn't look amazing, and it's only on the sponsor page. But it's a start.
