### PR TITLE
[AUS-2020] Adding DevOpsDays Austin 2020 Base Site and Event Info

### DIFF
--- a/content/events/2020-austin/conduct.md
+++ b/content/events/2020-austin/conduct.md
@@ -1,0 +1,35 @@
++++
+Title = "Conduct"
+Type = "event"
+Description = "Code of conduct for devopsdays Austin 2019"
++++
+
+## ANTI-HARASSMENT POLICY
+
+Devopsdays is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers.
+
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+
+If a participant engages in harassing behavior, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately.
+
+Conference staff can be identified by distinct staff badges. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+We expect participants to adhere to the code of conduct at all conference venues and conference-related social events.
+
+## CODE OF CONDUCT
+
+I. I am an attendee at devopsdays, learning from and sharing with other devopsdays attendees in an effort to better myself and my industry. I co-create the experience with fellow attendees. I am prepared to give my energy, presence and sensitivity to creating the best possible experience for myself and others.
+
+II. I am coming to devopsdays to interact with people. I understand that imagery and language which is suggestive or derogatory will offend and make people uncomfortable. I also understand that people may have boundaries and sensibilities different from my own. I will accept without question when informed that something is offensive or unacceptable in the context of the devopsdays event.
+
+III. I will never intentionally harass or offend another attendee regardless of gender, sexual orientation, disability, appearance, size, race or religion and will not abide another attendee being harassed or offended. If I am aware that anyone is uncomfortable or unsafe, I will notify those giving offense and the devopsdays event organizers.
+
+IV. If I am offended or harassed, I will inform people around me who make me feel safe and the event organizers. If I feel safe, at my discretion, I will inform those giving offense of the specific actions with the hope that the other party is well-intentioned and ignorant, but I am under no obligation to do so.
+
+V. I understand that people are different and I attempt to be forgiving of others actions at the level of their sincere intent, but my priority is protecting my safety and the safety of others. I will act without hesitation or reservation until there are no question of the safety of all parties.
+
+VI. I trust the devopsdays organizers and attendees will co-create the best possible experience for everyone involved, as I will. I believe devopsdays is about empowering people and I will not forget I am empowered to create a safe and nurturing environment. If I or any other attendee violates this aspect of the event, I expect the conference organizers to protect the attendees by direct action, including expelling those in violation and contacting the proper authorities.

--- a/content/events/2020-austin/contact.md
+++ b/content/events/2020-austin/contact.md
@@ -1,0 +1,15 @@
++++
+Title = "Contact"
+Type = "event"
+Description = "Contact Information for DevOpsDays Austin 2019"
++++
+
+If you'd like to contact us by email: {{< email_organizers >}}
+
+**Our local team**
+
+{{< list_organizers >}}
+
+**The core devopsdays organizer group**
+
+{{< list_core >}}

--- a/content/events/2020-austin/location.md
+++ b/content/events/2020-austin/location.md
@@ -1,0 +1,11 @@
++++
+Title = "Location"
+Type = "event"
+Description = "Location for DevOpsDays Austin 2019"
++++
+
+[The Westin at the Domain](https://www.marriott.com/hotels/travel/ausdw-the-westin-austin-at-the-domain/)
+
+<!-- Uncomment this only if you have set the coordinates for your location in the config yaml. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html -->
+{{< event_map >}}
+

--- a/content/events/2020-austin/propose.md
+++ b/content/events/2020-austin/propose.md
@@ -1,0 +1,25 @@
++++
+Title = "Propose"
+Type = "event"
+Description = "Propose a talk for devopsdays austin 2019"
++++
+  {{< cfp_dates >}}
+
+<hr>
+
+### How Do I Submit a Talk?
+
+<a href="https://www.papercall.io/devopsdays-austin-2019" class="btn btn-info">Submit a Proposal via Papercall!</a>
+
+### Theme
+
+The theme for devopsdaus Austin 2019 is **Pragmatic DevOps**. We want to hear your stories of how you succeeded or failed along your journey. Help us learn through your experiences. Preference will be shown to DevOps practitioners talking about their stories, their problems, and their approaches. The best kind of talk says “as an X, I had the problem Y, and here’s how I addressed it, and here’s the results both good and bad.”
+
+### Formats
+
+The three types of talk format we are accepting this year are:
+
+* Regular. This is a 35 minute talk. We are looking for talks by those that can share pragmatic steps or advice as well as discuss their own journey. One of the two content tracks will be Regular talks.
+* Conversation (**new**). This is a 20 minute presentation in the morning AND an open space you host on the topic that same afternoon. This abridged format takes the Q&A and in depth technical demo portions of a talk that are problematic in a large crowd to the open space and furthers the conversation with highly engaged attendees. We hope you will try this out! The second content track will be Conversations, and we can fit 2x as many of these in as we can fit Regular talks.
+* Lightning Talk. This is a 20-slide, auto-advancing, 5 minute talk. Tons of fun and a huge audience favorite. We squeeze in as many of these as we can!
+

--- a/content/events/2020-austin/registration.md
+++ b/content/events/2020-austin/registration.md
@@ -1,0 +1,8 @@
++++
+Title = "Registration"
+Type = "event"
+Description = "Registration for devopsdays austin 2019"
++++
+<div style="width:100%; text-align:left;"><iframe src="//eventbrite.com/tickets-external?eid=55177080132&ref=etckt" frameborder="0" height="360" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:12px; padding:10px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #ADB0B6; text-decoration: none;" target="_blank" href="http://www.eventbrite.com/">Powered by Eventbrite</a></div></div>
+
+<p><a href="https://www.eventbrite.com/e/devopsdays-austin-2019-tickets-55177080132?ref=ebtnebtckt" class="btn btn-large" target="_blank">Buy Tickets from Eventbrite</a></p>

--- a/content/events/2020-austin/schedule.md
+++ b/content/events/2020-austin/schedule.md
@@ -1,0 +1,7 @@
++++
+Title = "Schedule"
+Type = "event"
+Description = "Speakers, sessions, ignites, meals"
++++
+
+<iframe src="https://devopsdaysaustin2019.sched.com" frameborder="0" height="3000" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe>

--- a/content/events/2020-austin/sponsor.md
+++ b/content/events/2020-austin/sponsor.md
@@ -1,0 +1,85 @@
++++
+Title = "Sponsor"
+Type = "event"
+Description = "Sponsor devopsdays austin 2019"
++++
+
+
+
+### Sponsorship Info Coming Soon
+
+<!--
+<a href="https://drive.google.com/file/d/136ifKhcqWX8pfKsOryN4Kh4MkNpdYzM-/view" class="btn btn-info">Download the DevOpsDays Austin Summit 2019 Sponsor Prospectus</a>
+
+Event dates: {{< event_start >}} - {{< event_end >}}
+
+Austin hosts one of the leading annual DevOpsDays events, now in its **eighth** year. Every year Austin is one of the best attended and reviewed DevOpsDays events. Sponsoring DevOpsDays connects your company to local technical and business minds who influence decisions in security, monitoring, operations, engineering, quality, and product development.
+
+Feel free to contact us at [{{< email_organizers >}}] with any questions.
+
+![Sponsor Matrix 2019](sponsor-matrix-2019.png "DevOpsDays Austin Sponsor Matrix 2019")
+
+### Happy Hour ($8000)
+
+**Sold out!**
+
+<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VWDJU8D6SF3DC" class="btn btn-info" style="display:none">Pay Now to Sponsor the Happy Hour!</a>
+
+This year, DevOpsDays Austin is planning a special Happy Hour at the end of Day 1. The Happy Hour event will be hosted on the main level of the event and will have food and alcoholic beverages. We have opportunities for two sponsors to have signage and space specifically dedicated to them for the duration of the happy hour and the opportunity to make announcements at the happy hour.
+
+### Platinum Sponsor ($7000)
+
+**Sold out!**
+
+<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=E7JGQEEB6XTRU" class="btn btn-info" style="display:none">Pay Now to be a Plantinum Sponsor!</a>
+
+In past years, sponsors have inquired about using the luxury boxes within the venue for discussion areas, consulting / solution areas, and similar uses. This year, we are opening up opportunities for sponsors to utilize the rooms. These boxes are located upstairs of the main stage area - in the same "loft" space as the Open Spaces part of the program. 
+
+The rooms will be set up with tables and chairs. Sponsors can put standup signage around the outside and set up tables for demos / displays. Everything must fit and be free-standing - nothing can go on the walls / ceilings.
+
+Platinum sponsors will have access to the rooms all day on both days and are free to schedule activities at any time during - as long as those events stay within their room and are publicized by sponsors themselves.
+
+Open Spaces events and Happy Hour are scheduled in other rooms in the same upstairs area, but there are no DevOpsDays Austin events scheduled in the upstairs area during keynotes, talks, or meals.
+
+### Lanyard Sponsor ($5000)
+
+**Sold out!**
+
+<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NDK4B5PHD99LN" class="btn btn-info" style="display:none">Pay Now to Put Your Logo on the Lanyard!</a>
+
+What better way to get your branding in front of attendees than to have everyone carrying it around attached to the one thing they absolutely must have, their badge?  We only have one lanyard sponsor, and they get their logo (co-branded with the DevOpsDays logo) on all the lanyards for the event.  DevOpsDays Austin takes care of making and distributing the lanyard.
+
+Lanyard sponsorships come with two complimentary event tickets.
+
+### Gold Sponsor ($5000)
+
+**Sold out!**
+
+<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZUXRLSZNKH7GG" class="btn btn-info" style="display:none">Pay Now to be a Gold Sponsor!</a>
+
+Gold packages are the most popular DevOpsDays Austin sponsorship package.This is the package with a table in the vendor area of our event. We locate food service in the sponsor area and otherwise take effort to drive attendee foot traffic into and through the area.
+
+Please be aware these are not full conference booths like at a major tech conference - no backdrops, things fastened to the ceiling, etc. can be accommodated.  You can bring a tablecloth / table cover and will have room behind your table for a couple people and stand-up sign banner or two.  Each table has a power strip to it and a couple chairs. The Gold sponsorship comes with four tickets.
+
+Gold sponsors also get comprehensive branding and shout-outs throughout the show, and have the opportunity to do one minute pitches to the full conference audience between the all-hands sessions.
+
+### Silver Sponsor ($3000)
+
+<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MEANYQYT9UBQA" class="btn btn-info">Pay Now to be a Silver Sponsor!</a>
+
+Silver sponsorship packages are designed for sponsors who do not want to staff a table, but who would still like to sponsor the event and have prominent branding. The silver sponsorship receives access to put materials on unattended tables shared with the other Silver level sponsors of the event along with brand inclusion on conference slides, signs, website, and social media.
+
+A Silver sponsorship comes with two complimentary event tickets.
+
+### Meal/Snack Add-On (+$1000)
+
+<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=M8EJUXHNAUMPE" class="btn btn-info" style="display:none">Pay Now for a Meal/Snack Add-On!</a>
+
+The "Meal/Snack" sponsorship options are opportunities to show attendees that you sponsored the event by providing the opportunity to associate your brand with a high-visibility, food-centered activity during the event. There will be signage on the food tables, up-front announcements of these events, social media and website promotion.
+
+View the [sponsor prospectus](https://drive.google.com/file/d/136ifKhcqWX8pfKsOryN4Kh4MkNpdYzM-/view) for more details about the meal/snack add-on.
+
+![Sponsor Add-Ons 2019](sponsor-add-on-2019.png "DevOpsDays Austin Sponsor Add-Ons 2019")
+
+Sponsors can optionally extend their visibility at the event by sponsoring individual meals or snacktimes. These are available to all levels of sponsorship. Please contact us at {{< email_organizers >}} if you are interested.
+-->

--- a/content/events/2020-austin/welcome.md
+++ b/content/events/2020-austin/welcome.md
@@ -1,0 +1,77 @@
++++
+Title = "DevOpsDays Austin 2020"
+Type = "welcome"
+aliases = ["/events/2020-austin/"]
+Description = "DevOpsDays Austin 2020"
++++
+
+<!-- <div style="text-align:center;">
+  {{< event_logo >}}
+</div> -->
+
+<div class="row">
+    <div class="col-md-6">
+        <div style="text-align:center;">
+          {{< event_logo >}}
+        </div>
+    </div>
+    <div class="col-md-6"> 
+        <div class="row">
+            <div class="col-md-2"><strong>Dates</strong></div>
+            <div class="col-md-8">{{< event_start >}} - {{< event_end >}}</div>
+        </div>
+        <div class="row">
+            <div class="col-md-2"><strong>Location</strong></div>
+            <div class="col-md-8">{{< event_location >}}</div>
+        </div>
+        <!--<div class="row">
+            <div class="col-md-2"><strong>Schedule</strong></div>
+            <div class="col-md-8">{{< event_link page="schedule" text="View the schedule!" >}}</div>
+        </div> -->
+        <!-- <div class="row">
+          <div class="col-md-2"><strong>Talks</strong></div>
+          <div class="col-md-8">{{< event_link page="propose" text="Propose a talk!" >}}</div>
+        </div> -->
+        <!-- <div class="row">
+          <div class="col-md-2"><strong>Register</strong></div>
+          <div class="col-md-8">{{< event_link page="registration" text="Join the waiting list!" >}}</div>
+        </div> -->
+        <!-- <div class = "row">
+          <div class = "col-md-2">
+            <strong>Program</strong>
+          </div>
+          <div class = "col-md-8">
+            View the {{< event_link page="program" text="program." >}}
+          </div>
+        </div>
+        <div class = "row">
+          <div class = "col-md-2">
+            <strong>Speakers</strong>
+          </div>
+          <div class = "col-md-8">
+            Check out the {{< event_link page="speakers" text="speakers!" >}}
+          </div>
+        </div> -->
+        <!-- <div class="row">
+          <div class="col-md-2"><strong>Sponsors</strong></div>
+          <div class="col-md-8">{{< event_link page="sponsor" text="Become a sponsor!" >}}</div>
+        </div> -->
+        <div class="row">
+          <div class="col-md-2"><strong>Contact</strong></div>
+          <div class="col-md-8">{{< event_link page="contact" text="Get in touch with the organizers" >}}</div>
+        </div>
+        <div class="row">
+          <div class="col-md-2"></div>
+          <div class="col-md-8">{{< event_twitter >}}</div>
+        </div>
+    </div>
+</div>
+
+<hr/>
+
+
+Join Us in Austin for Our 9th  Year!
+===
+
+DevOpsDays will be returning to Austin May 4th and 5th, 2020 for the **ninth year**. 
+We'll be adding dates for talk proposals and registration soon.

--- a/data/events/2020-austin.yml
+++ b/data/events/2020-austin.yml
@@ -1,0 +1,162 @@
+name: "2020-austin" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
+year: "2020" # The year of the event. Make sure it is in quotes.
+city: "Austin" # The displayed city name of the event. Capitalize it.
+event_twitter: "DoDAustin" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
+description: "DevOpsDays Austin's 9th Year!" # Edit this to suit your preferences
+
+ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+
+# All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2020-05-04T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2020-05-05T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+
+# Leave CFP dates blank if you don't know yet, or set all three at once.
+cfp_date_start:  # start accepting talk proposals.
+cfp_date_end:  # close your call for proposals.
+cfp_date_announce:  # inform proposers of status
+
+cfp_open: "false"
+# https://www.papercall.io/devopsdays-austin-2019
+cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+
+registration_date_start: # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: # close registration. Leave blank if registration is not open yet.
+
+registration_closed: "" #set this to true if you need to manually close registration before your registration end date
+registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
+
+# Location
+#
+coordinates: "30.399345,-97.724531" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+location: "Westin Hotel and Conference Center at the Domain" # Defaults to city, but you can make it the venue name.
+location_address: "11301 Domain Drive, Austin, Texas 78758" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+
+nav_elements: # List of pages you want to show up in the navigation of your page.
+  - name: location
+ # - name: schedule
+ # - name: registration
+ # - name: program
+ # - name: speakers
+ # - name: sponsor
+  - name: contact
+  - name: conduct
+ # - name: propose
+# - name: example
+#   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/
+#   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
+
+
+team_members: # Name is the only required field for team members.
+  - name: "Ernest Mueller"
+    twitter: "ernestmueller"
+    employer: "AlienVault"
+    bio: "Ernest Mueller is Lean Systems Manager at AlienVault in Austin, TX. He organizes the CloudAustin user group, the Agile Austin DevOps SIG, and the DevOpsDays Austin conference, now in its sixth year. Along with his coauthor James, he wrote the DevOps Fundamentals course on lynda.com."
+    github: "ernestm"
+    facebook: ""
+    linkedin: "https://www.linkedin.com/in/ernestmueller/"
+    image: ""
+  - name: "James Wickett"
+    twitter: "wickett"
+    employer: "Signal Sciences"
+    bio: ""
+    github: "wickett"
+    facebook: ""
+    linkedin: "https://www.linkedin.com/in/wickett/"
+    image: ""
+  - name: "Karthik Gaekwad"
+    twitter: "iteration1"
+    employer: "Oracle"
+    bio: "I live in Austin, write @golang, and know stuff about burgers, containers and cloud. I organize @dodaustin, @container_days, @cloud_austin and DockerAustin."
+    github: "karthequian"
+    facebook: ""
+    linkedin: "https://www.linkedin.com/in/kgaekwad/"
+    image: ""
+  - name: "Ian Richardson"
+  - name: "Scott Baldwin"
+    twitter: "scottsbaldwin"
+    employer: "Oracle"
+    bio: "Scott has helped organize DevOps Days Austin since it started in 2012. His primary responsibility is the web site, although he has helped with sponsors in the past. He is currently hacking on Kubernetes at Oracle. He loves teams that care about happiness, vulnerability, and empathy. And he loves tennis."
+    github: "scottsbaldwin"
+    facebook: ""
+    linkedin: "https://www.linkedin.com/in/scottsbaldwin/"
+    image: ""
+  - name: "Dan Zentgraf"
+    twitter: "danzentgraf"
+    employer: "Datical"
+    bio: "Dan is a long time DevOps evangelist working with very large enterprises. He has been involved in the Agile / Lean / DevOps movement in a number of management, product management, and process consulting roles. In addition to the work stuff, he is active in the Austin community as a DevOpsDays organizer for the last 4 years as well as with the AgileAustin community as a program lead."
+    github: ""
+    facebook: ""
+    linkedin: "https://www.linkedin.com/in/zentgraf/"
+    image: ""
+  - name: "Chris Casey"
+  - name: "Boyd Hemphill"
+    twitter: "behemphi"
+    employer: "Victory CTO"
+    bio: "Boyd Hemphill is a DevOps raconteur and thought leader in the silicon hills of Austin Texas. Boyd founded Austin DevOps when he learned this thing he was doing had a name. Boyd also assists with the organization of DevOps Days Austin. In his professional life, Boyd has been a developer (PL/SQL and PHP), DBA (Oracle and MySQL), and system administrator.  He has even been a Director of DevOps and would enjoy you coming to poke fun at him for it."
+    github: "behemphi"
+    facebook: ""
+    linkedin: "https://www.linkedin.com/in/boydhemphill/"
+    image: ""
+  - name: "Lee Thompson"
+    twitter: "stagr_lee"
+    employer: "Precision Autonomy"
+    bio: "Lee has been an organizer/volunteer for DevOpsDays Austin since its founding and participated in the organization of the first US DevOpsDays event in Mountain View in 2010.  He keeps coming back to DevOpsDays because he still hasn't figured it all out yet.  When not messing with distributed applications, he's messing around with 240Z's and Airstreams."
+    github: "stagrlee"
+    facebook: ""
+    linkedin: "https://www.linkedin.com/in/leewthompson/"
+    image: ""
+  - name: "Richard Boyd"
+    twitter: "richardboydii"
+    employer: "Amazon Web Services"
+    bio: "Richard is active in the Austin DevOps community and speaks at Meetups and conferences. In his spare time he enjoys camping and the checking out the local brewery scene."
+    github: "richardboydii"
+    facebook: ""
+    linkedin: "https://www.linkedin.com/in/richardboydii/"
+    image: ""
+  - name: "Laura Wickett"
+  - name: "Carl Perry"
+  - name: "Daria Ilic"
+  - name: "Tom Hall"
+  - name: "Peco Karayanev"
+  - name: "Asif Ahmad"
+  - name: "Bailey Moore"
+organizer_email: "organizers-austin-2020@devopsdays.org" # Put your organizer email address here
+proposal_email: "proposals-austin-2020@devopsdays.org" # Put your proposal email address here
+
+# List all of your sponsors here along with what level of sponsorship they have.
+# Check data/sponsors/ to use sponsors already added by others.
+sponsors:
+  
+
+sponsors_accepted : "false" # Whether you want "Become a XXX Sponsor!" link
+
+# In this section, list the level of sponsorships and the label to use.
+# You may optionally include a "max" attribute to limit the number of sponsors per level. For
+# unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
+# sponsorship for a specific level, it is best to remove the level.
+sponsor_levels:
+  - id: happyhour
+    label: Happy Hour
+    max: 2
+  - id: platinum
+    label: Platinum
+    max: 3
+  - id: lanyard
+    label: Lanyard
+    max: 1
+  - id: gold
+    label: Gold
+    max: 20
+  - id: silver
+    label: Silver
+    max: 10
+  - id: media
+    label: Media
+    max: 1
+  - id: mealandsnack
+    label: Meal and Snack
+    max: 10


### PR DESCRIPTION
Closes #8620

Copypasta from 2019-austin and removed / hid a bunch of stuff. ch of stuff. Ran hugo serve locally and tested.

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*
