### PR TITLE
Correcting event groups

### DIFF
--- a/data/events/2010-europe.yml
+++ b/data/events/2010-europe.yml
@@ -1,8 +1,7 @@
 name: "2010-europe" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: 2010 # The year of the event. Make sure it is in quotes.
 city: "Hamburg" # The city name of the event. Capitalize it.
-friendly: "2010-europe" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "past" # Options are "past" or "current". Use "current" for upcoming.
+event_group: "Hamburg"
 
 # All dates are in unquoted 2010-MM-DD, like this:   variable: 2016-01-05
 startdate: 2010-10-15T00:00:00+02:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
@@ -15,7 +14,7 @@ cfp_date_announce: 2016-01-01T00:00:00+02:00 # inform proposers of status
 # Location
 #
 coordinates: "41.882219, -87.640530" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
-location: "europe" # Defaults to city, but you can make it the venue name.
+location: "Hamburg" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.

--- a/data/events/2012-italy.yml
+++ b/data/events/2012-italy.yml
@@ -1,8 +1,7 @@
 name: "2012-italy" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: 2012 # The year of the event. Make sure it is in quotes.
 city: "Rome" # The city name of the event. Capitalize it.
-friendly: "2012-italy" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "past" # Options are "past" or "current". Use "current" for upcoming.
+event_group: "Rome"
 
 # All dates are in unquoted 2012-MM-DD, like this:   variable: 2016-01-05
 startdate: 2012-10-05T00:00:00+02:00  # The start date of your event. Leave blank if you don't have a venue reserved yet.
@@ -15,7 +14,7 @@ cfp_date_announce: 2016-01-01T00:00:00+02:00 # inform proposers of status
 # Location
 #
 coordinates: "41.882219, -87.640530" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
-location: "italy" # Defaults to city, but you can make it the venue name.
+location: "Rome" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.

--- a/data/events/2013-portland.yml
+++ b/data/events/2013-portland.yml
@@ -1,8 +1,7 @@
 name: "2013-portland" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: 2013 # The year of the event. Make sure it is in quotes.
 city: "Portland" # The city name of the event. Capitalize it.
-friendly: "2013-portland" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "past" # Options are "past" or "current". Use "current" for upcoming.
+event_group: "Portland, OR"
 
 # All dates are in unquoted 2013-MM-DD, like this:   variable: 2016-01-05
 startdate: 2013-11-04T00:00:00-08:00

--- a/data/events/2016-oslo.yml
+++ b/data/events/2016-oslo.yml
@@ -1,9 +1,6 @@
 name: "2016-oslo" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2016" # The year of the event. Make sure it is in quotes.
 city: "Oslo" # The city name of the event. Capitalize it.
-friendly: "2016-oslo" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "past" # Options are "past" or "current". Use "current" for upcoming.
-event_group: "Oslo"
 
 # All dates are in unquoted 2016-MM-DD, like this:   variable: 2016-01-05
 startdate: 2016-09-05  # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2016-portland.yml
+++ b/data/events/2016-portland.yml
@@ -1,8 +1,8 @@
 name: 2016-portland # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: 2016 # The year of the event. Make sure it is in quotes.
 city: "Portland" # The city name of the event. Capitalize it.
-friendly: "2016-portland" # Four digit year and the city name in lower-case. Don't forget the dash!
-status: "past" # Options are "past" or "current".
+event_group: "Portland, OR"
+
 startdate: 2016-08-09T00:00:00-07:00
 enddate: 2016-08-10T23:59:59-07:00
 cfp_date_start: 2016-03-15
@@ -11,7 +11,6 @@ cfp_date_announce: 2016-07-01
 coordinates: "45.528562, -122.663028" # The corrodinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "The Oregon Convention Center" # The name of your location
 nav_elements:
- 
   - name: location
   - name: registration
     url: https://devopsdayspdx2016.busyconf.com/bookings/new

--- a/data/events/2017-oslo.yml
+++ b/data/events/2017-oslo.yml
@@ -3,8 +3,6 @@ year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Oslo" # The city name of the event. Capitalize it.
 event_twitter: "devopsdaysoslo"
 description: "DevopsDays is coming to Oslo!"
-status: "past"
-event_group: "Oslo"
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2017-01-05
 startdate: 2017-11-01  # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2017-portland.yml
+++ b/data/events/2017-portland.yml
@@ -2,7 +2,8 @@ name: "2017-portland" # The name of the event. Four digit year with the city nam
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Portland" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdayspdx"
-friendly: "2017-portland"
+event_group: "Portland, OR"
+
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate: 2017-08-01T00:00:00-07:00

--- a/data/events/2018-cairo.yml
+++ b/data/events/2018-cairo.yml
@@ -4,7 +4,6 @@ city: "Cairo" # The displayed city name of the event. Capitalize it.
 event_twitter: "" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Please stay tuned for more information about DevOpsDays Cairo 2018!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
-event_group: ""
 
 # All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
 startdate: 2018-09-17T00:00:00+02:00

--- a/data/events/2018-florianopolis.yml
+++ b/data/events/2018-florianopolis.yml
@@ -4,7 +4,6 @@ city: "Florianópolis"
 event_twitter: "devopsdaysfln"
 description: "A revolução já começou!"
 ga_tracking_id: ""
-event_group: "Florianópolis"
 
 # All dates are in unquoted 2018-MM-DD, like this:   variable: 2016-01-05
 startdate: 2018-11-24T00:00:00-02:00

--- a/data/events/2018-oslo.yml
+++ b/data/events/2018-oslo.yml
@@ -5,8 +5,6 @@ event_twitter: "devopsdaysoslo" # Change this to the twitter handle for your eve
 description: "Devopsdays is coming to Oslo!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_logo: "logo-square.jpg"
-status: "past"
-event_group: "Oslo"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
 startdate: 2018-10-29T00:00:00+02:00

--- a/data/events/2018-portland.yml
+++ b/data/events/2018-portland.yml
@@ -4,6 +4,7 @@ city: "Portland" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdayspdx" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "DevOpsDays is coming to Portland!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Portland, OR"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
 startdate: 2018-09-11T00:00:00-07:00

--- a/data/events/2019-cairo.yml
+++ b/data/events/2019-cairo.yml
@@ -4,7 +4,6 @@ city: "Cairo" # The displayed city name of the event. Capitalize it.
 event_twitter: "" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Welcome to DevOpsDays Cairo 2019!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
-event_group: ""
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2019-florianopolis.yml
+++ b/data/events/2019-florianopolis.yml
@@ -4,7 +4,6 @@ city: "Florianópolis"
 event_twitter: "devopsdaysfln"
 description: "A revolução já começou!"
 ga_tracking_id: ""
-event_group: "Florianópolis"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
 startdate: 2019-07-27T00:00:00-03:00

--- a/data/events/2019-goiania.yml
+++ b/data/events/2019-goiania.yml
@@ -4,7 +4,6 @@ city: "Goiânia" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysgyn" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "DevOpsDays está chegando em Goiânia!" # Edit this to suit your preferences
 ga_tracking_id: "UA-139150829-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
-event_group: "Goiânia"
 
 # All dates are in unquoted 2019-MM-DD, like this:   variable: 2016-01-05
 startdate: 2019-08-03T08:00:00-03:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2019-oslo.yml
+++ b/data/events/2019-oslo.yml
@@ -5,7 +5,6 @@ event_twitter: "devopsdaysoslo" # Change this to the twitter handle for your eve
 description: "Devopsdays is coming to Oslo!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_logo: "logo.png"
-event_group: "Oslo"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2019-portland.yml
+++ b/data/events/2019-portland.yml
@@ -4,6 +4,7 @@ city: "Portland" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdayspdx" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "DevOpsDays is back in Portland!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Portland, OR"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2019-portugal.yml
+++ b/data/events/2019-portugal.yml
@@ -4,6 +4,7 @@ city: "Portugal" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdayspt" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "devopsdays is coming to Portugal for the first time!" # Edit this to suit your preferences
 ga_tracking_id: "UA-133818809-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Portugal"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-cairo.yml
+++ b/data/events/2020-cairo.yml
@@ -4,7 +4,6 @@ city: "Cairo" # The displayed city name of the event. Capitalize it.
 event_twitter: "" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Welcome to DevOpsDays Cairo 2020!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
-event_group: ""
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-madrid.yml
+++ b/data/events/2020-madrid.yml
@@ -4,7 +4,6 @@ city: "Madrid" # The displayed city name of the event. Capitalize it.
 event_twitter: "DevOpsDaysMad" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "DevOpsDays is coming to Madrid!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
-event_group: "Madrid"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-portugal.yml
+++ b/data/events/2020-portugal.yml
@@ -4,6 +4,7 @@ city: "Portugal" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdayspt" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "devopsdays is returning to Portugal!" # Edit this to suit your preferences
 ga_tracking_id: "UA-133818809-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Portugal"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00


### PR DESCRIPTION
The `event_group` is valuable in cases where the event city name varies (but not used when the city name doesn't change). In checking on data from the past I found a number of inconsistencies and potential points of confusion that I'm clearing up with this PR.  