### PR TITLE
Adding redirection

### DIFF
--- a/utilities/add_new_event.sh
+++ b/utilities/add_new_event.sh
@@ -49,6 +49,15 @@ twitter=$(echo $twitter | sed 's/@//')
 # We use the term event_slug in the hugo files too
 event_slug=$year-$city_slug
 
+# Update the redirection for a previous year of this event to the desired year
+if grep -q $city_slug "../static/_redirects";
+then
+    SEDCMD "s/.\{4\}-$city_slug/$event_slug/" "../static/_redirects"
+else
+# If a previous-year event does not exist, create the redirection for the desired year
+  echo "/$city_slug/*            /events/$event_slug/:splat           302" >> "../static/_redirects"
+fi
+
 # Create default event datafile
 eventdatafile="../data/events/$event_slug.yml"
 cp examples/data/events/yyyy-city.yml $eventdatafile


### PR DESCRIPTION
This will add aliasing as described in https://github.com/devopsdays/devopsdays-web/issues/8195 for new or returning cities to have the short url of https://devopsdays.org/minneapolis (or whatever their city name is) point to the year they're setting up.