### PR TITLE
Removing redundant header

### DIFF
--- a/content/events/2019-berlin/contact.md
+++ b/content/events/2019-berlin/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2019-chattanooga/contact.md
+++ b/content/events/2019-chattanooga/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2019-galway/contact.md
+++ b/content/events/2019-galway/contact.md
@@ -10,7 +10,6 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}
 

--- a/content/events/2019-macapa/contact.md
+++ b/content/events/2019-macapa/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group** 
 
 {{< list_core >}} 

--- a/content/events/2019-moscow/contact.md
+++ b/content/events/2019-moscow/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2019-recife/contact.md
+++ b/content/events/2019-recife/contact.md
@@ -11,6 +11,5 @@ Se você quiser entrar em contato conosco: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2019-shanghai/contact.md
+++ b/content/events/2019-shanghai/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2019-tel-aviv/contact.md
+++ b/content/events/2019-tel-aviv/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2019-warsaw/contact.md
+++ b/content/events/2019-warsaw/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-amsterdam/contact.md
+++ b/content/events/2020-amsterdam/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-atlanta/contact.md
+++ b/content/events/2020-atlanta/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-austin/contact.md
+++ b/content/events/2020-austin/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-bogota/contact.md
+++ b/content/events/2020-bogota/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-boise/contact.md
+++ b/content/events/2020-boise/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-caceres/contact.md
+++ b/content/events/2020-caceres/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-cairo/contact.md
+++ b/content/events/2020-cairo/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-charlotte/contact.md
+++ b/content/events/2020-charlotte/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-denver/contact.md
+++ b/content/events/2020-denver/contact.md
@@ -12,6 +12,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-edinburgh/contact.md
+++ b/content/events/2020-edinburgh/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-geneva/contact.md
+++ b/content/events/2020-geneva/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers subject="Info - DevOp
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-guadalajara/contact.md
+++ b/content/events/2020-guadalajara/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-houston/contact.md
+++ b/content/events/2020-houston/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-madison/contact.md
+++ b/content/events/2020-madison/contact.md
@@ -11,6 +11,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-medellin/contact.md
+++ b/content/events/2020-medellin/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-new-york-city/contact.md
+++ b/content/events/2020-new-york-city/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-portland-me/contact.md
+++ b/content/events/2020-portland-me/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-portugal/contact.md
+++ b/content/events/2020-portugal/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-poznan/contact.md
+++ b/content/events/2020-poznan/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-prague/contact.md
+++ b/content/events/2020-prague/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-saint-louis/contact.md
+++ b/content/events/2020-saint-louis/contact.md
@@ -11,6 +11,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-salt-lake-city/contact.md
+++ b/content/events/2020-salt-lake-city/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-santiago/contact.md
+++ b/content/events/2020-santiago/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-seattle/contact.md
+++ b/content/events/2020-seattle/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-tampa/contact.md
+++ b/content/events/2020-tampa/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-tokyo/contact.md
+++ b/content/events/2020-tokyo/contact.md
@@ -11,6 +11,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-vitoria/contact.md
+++ b/content/events/2020-vitoria/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-zaragoza/contact.md
+++ b/content/events/2020-zaragoza/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}

--- a/content/events/2020-zurich/contact.md
+++ b/content/events/2020-zurich/contact.md
@@ -10,6 +10,5 @@ If you'd like to contact us by email: {{< email_organizers >}}
 
 {{< list_organizers >}}
 
-**The core devopsdays organizer group**
 
 {{< list_core >}}


### PR DESCRIPTION
In https://github.com/devopsdays/devopsdays-web/pull/8431 I refactored how contact pages for individual cities were displayed. I removed the list of core team members in favor of a link to the `/about` page. Given that, the header of `**The core devopsdays organizer group**` is redundant since the following line is just a link, not a list of people.