### PR TITLE
[Austin 2020] Fixing organizer email address

### DIFF
--- a/data/events/2020-austin.yml
+++ b/data/events/2020-austin.yml
@@ -124,8 +124,7 @@ team_members: # Name is the only required field for team members.
   - name: "Peco Karayanev"
   - name: "Asif Ahmad"
   - name: "Bailey Moore"
-organizer_email: "organizers-austin-2020@devopsdays.org" # Put your organizer email address here
-proposal_email: "proposals-austin-2020@devopsdays.org" # Put your proposal email address here
+organizer_email: "austin@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
Hi, @richardboydii! I noticed that https://github.com/devopsdays/devopsdays-web/pull/8621 was merged with incorrect contact email info - sorry about that! For 2020 and beyond, we're not creating email addresses that are year-specific. Your email that includes all your organizers is `austin@devopsdays.org`. We're happy to offer limited-scope email lists if needed for your talk proposals, etc; if such is needed, please let us know who should be on them by emailing `info@devopsdays.org`. Thanks!