### PR TITLE
[Buffalo 2020] Fixing organizer email address

### DIFF
--- a/data/events/2020-buffalo.yml
+++ b/data/events/2020-buffalo.yml
@@ -73,7 +73,7 @@ team_members: # Name is the only required field for team members.
     twitter: "kaleidoscopeads"
     image: "stephanie.jpg"
 
-organizer_email: "organizers-buffalo-2019@devopsdays.org" # Put your organizer email address here
+organizer_email: "buffalo@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
Hi, @aspleenic! I noticed that https://github.com/devopsdays/devopsdays-web/pull/8658 was merged with incorrect contact email info - sorry about that! For 2020 and beyond, we're not creating email addresses that are year-specific. Your email that includes all your organizers is `buffalo@devopsdays.org`.

