### PR TITLE
List cities accepting sponsors

### DIFF
--- a/content/page/sponsor.md
+++ b/content/page/sponsor.md
@@ -58,3 +58,8 @@ If you want to collect leads, you'll have to talk directly with individuals and 
 New cities start a devopsdays event each year, and some cities run regularly. When planning out your sponsorship budget for the year, it's a good idea to assume that at least one or two must-sponsor devopsdays will crop up after you've already starting reaching out and sponsoring the early announcers.
 
 If one hasn't happened near you, and you wish it would, you can always look into [running your own event](/pages/organizing)!
+
+## Which events have sponsorship opportunities available right now?
+
+These upcoming events are advertising that sponsorships are accepted. Check their pages for a prospectus. (This list may be incomplete/inaccurate, as not every event may have updated their details.)
+

--- a/themes/devopsdays-theme/layouts/partials/sponsors-accepted.html
+++ b/themes/devopsdays-theme/layouts/partials/sponsors-accepted.html
@@ -1,0 +1,16 @@
+{{- $.Scratch.Add "events" "<table id = 'cfp-list' class = 'table table-condensed'><thead><tr><th>City</th><th>&nbsp;&nbsp;&nbsp;&nbsp;Event Starts</th></tr></thead><tbody>" -}}
+{{- range sort $.Site.Data.events "startdate" -}}
+  {{- if (and .sponsors_accepted .startdate) -}}
+    {{- if ge (time .enddate) now -}}
+      {{- $.Scratch.Add "events" "<tr><td><a href = '/events/" -}}
+      {{- $.Scratch.Add "events" .name -}}
+      {{- $.Scratch.Add "events" "/'>" -}}
+      {{- $.Scratch.Add "events" .city -}}
+      {{- $.Scratch.Add "events" "</a></td><td>&nbsp;&nbsp;" -}}
+      {{- $.Scratch.Add "events" (dateFormat "2006-01-02" .startdate) -}}
+      {{- $.Scratch.Add "events" "</td></tr>" -}}
+    {{- end }} {{/* end: date is now or afterwards */}}
+  {{- end }} {{/* end: if sponsors and date */}}
+{{ end }} {{/* end: range sort $.Site.Data.events "startdate" */}}
+{{- $.Scratch.Add "events" "</tbody></table>" -}}
+{{ $.Scratch.Get "events" | safeHTML }}

--- a/themes/devopsdays-theme/layouts/sponsor/single.html
+++ b/themes/devopsdays-theme/layouts/sponsor/single.html
@@ -6,4 +6,6 @@
     {{- partial "heading_link.html" .Content -}}
 </div>
 
+{{- partial "sponsors-accepted.html" . -}}
+
 {{  end }}


### PR DESCRIPTION
First attempt at https://github.com/devopsdays/devopsdays-web/issues/8683. I noticed that only one city (Vitoria) of all the upcoming cities had commented out the default-on `sponsors_accepted` item, so it's possible that this really isn't going to accomplish much: https://github.com/devopsdays/devopsdays-web/blob/master/utilities/examples/data/events/yyyy-city.yml#L74

In an effort to make it a little more useful, I have it showing the date the event starts. Presumably most events will stop accepting sponsorships at that point if not before.