### PR TITLE
[CHI-2020] Update email address on Chi sponsor page

### DIFF
--- a/content/events/2020-chicago/sponsor.md
+++ b/content/events/2020-chicago/sponsor.md
@@ -4,8 +4,7 @@ Type = "event"
 Description = "Sponsor devopsdays Chicago 2020"
 +++
 
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
-
+We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at <a href="mailto:chicago-sponsors@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Chicago%202019">send us an email</a>
 <hr>
 
 devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.


### PR DESCRIPTION
Change to us chicago-sponsors@devopsdays.org as the email address for interested sponsors.
