### PR TITLE
[BLN-2019] Add xMatters as sponsor for Berlin

### DIFF
--- a/data/events/2019-berlin.yml
+++ b/data/events/2019-berlin.yml
@@ -118,6 +118,8 @@ sponsors:
     level: partner
   - id: stickermule
     level: partner
+  - id: xmatters
+    level: platinum
   - id: redgate
     level: platinum
   - id: oracle-linux


### PR DESCRIPTION
Adding xMatters as a sponsor for Berlin 2019. Logo already exists, as they're also sponsoring a bunch of other cities.