### PR TITLE
fix program HTML titles

### DIFF
--- a/themes/devopsdays-theme/layouts/partials/head.html
+++ b/themes/devopsdays-theme/layouts/partials/head.html
@@ -6,7 +6,7 @@
       {{ $.Scratch.Set "title" "devopsdays" }}
     {{- else -}}
       {{- if .IsPage -}}
-        {{- if or (eq .Type "welcome") (eq .Type "event") (eq .Type "speakers") (eq .Type "talk") (eq .Type "speaker") -}}
+        {{- if or (eq .Type "welcome") (eq .Type "event") (eq .Type "speakers") (eq .Type "talk") (eq .Type "speaker") (eq .Type "program") -}}
           {{- $e := (index $.Site.Data.events (index (split (.Permalink | relURL) "/") 2)) -}}
           {{- if eq (lower .Title) "welcome" -}}
             {{- $.Scratch.Set "title" (printf "devopsdays %s %s" $e.city (chomp $e.year)) -}}


### PR DESCRIPTION
The logic for setting the HTML titles on pages was missing the "program" page type.

Test it at https://deploy-preview-8747--devopsdays-web.netlify.com/events/2019-cape-town/program
