### PR TITLE
[VAN-2020] Add one organizer and add link for event twitter

### DIFF
--- a/content/events/2020-vancouver/welcome.md
+++ b/content/events/2020-vancouver/welcome.md
@@ -82,6 +82,6 @@ Description = "devopsdays Vancouver 2020"
 </div>
 
 <!-- Uncomment if you added your city twitter name -->
-<!--
+
 {{< event_twitter >}}
--->
+

--- a/data/events/2020-vancouver.yml
+++ b/data/events/2020-vancouver.yml
@@ -70,6 +70,7 @@ team_members: # Name is the only required field for team members.
   - name: "Kyle Young"
     twitter: "ksgyoung"
   - name: "Alicja Raszkowska"
+    twitter: "mamrotynka"
     #  - name: "John Doe"
     # - name: "Jane Smith"
     # twitter: "devopsdays"

--- a/data/events/2020-vancouver.yml
+++ b/data/events/2020-vancouver.yml
@@ -69,6 +69,7 @@ team_members: # Name is the only required field for team members.
   - name: "Samantha Toner"
   - name: "Kyle Young"
     twitter: "ksgyoung"
+  - name: "Alicja Raszkowska"
     #  - name: "John Doe"
     # - name: "Jane Smith"
     # twitter: "devopsdays"


### PR DESCRIPTION
One organizer is added and the link for twitter is no longer commented out.