### PR TITLE
[Zürich 2020] Adding event group for Zürich

### DIFF
--- a/data/events/2017-zurich.yml
+++ b/data/events/2017-zurich.yml
@@ -2,6 +2,7 @@ name: "2017-zurich" # The name of the event. Four digit year with the city name 
 year: "2017" # The year of the event. Make sure it is in quotes.
 city: "Zürich" # The city name of the event. Capitalize it.
 event_twitter: "DevOpsZH"
+event_group: "Zürich"
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate: 2017-05-03T00:00:00+02:00

--- a/data/events/2018-zurich.yml
+++ b/data/events/2018-zurich.yml
@@ -2,6 +2,7 @@ name: "2018-zurich" # The name of the event. Four digit year with the city name 
 year: "2018" # The year of the event. Make sure it is in quotes.
 city: "Zürich" # The city name of the event. Capitalize it.
 event_twitter: "DevOpsZH"
+event_group: "Zürich"
 
 # All dates are in unquoted 2017-MM-DD, like this:   variable: 2016-01-05
 startdate: 2018-05-02T00:00:00+02:00

--- a/data/events/2019-zurich.yml
+++ b/data/events/2019-zurich.yml
@@ -2,6 +2,7 @@ name: "2019-zurich" # The name of the event. Four digit year with the city name 
 year: "2019" # The year of the event. Make sure it is in quotes.
 city: "Zürich" # The city name of the event. Capitalize it.
 event_twitter: "DevOpsZH"
+event_group: "Zürich"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-zurich.yml
+++ b/data/events/2020-zurich.yml
@@ -4,6 +4,7 @@ city: "Zürich (Winterthur)" # The displayed city name of the event. Capitalize 
 event_twitter: "DevOpsZH" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "DevOpsDays is coming to Zürich!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Zürich"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2020-09-08T00:00:00+02:00


### PR DESCRIPTION
Hi, @RomanoRoth - as you've altered the city's display name for 2020, we need to use an event group to ensure that past events are linked properly.