### PR TITLE
[Kraków 2020] Update team_members

### DIFF
--- a/data/events/2020-krakow.yml
+++ b/data/events/2020-krakow.yml
@@ -59,7 +59,6 @@ team_members: # Name is the only required field for team members.
   - name: "Michał Różycki"
   - name: "Paulina Wędrychowska"
   - name: "Piotr Godowski"
-  - name: "Piotr Szwed"
   - name: "Sylwia Zając"
   - name: "Tomasz Szymański"
 

--- a/data/events/2020-krakow.yml
+++ b/data/events/2020-krakow.yml
@@ -51,16 +51,16 @@ nav_elements: # List of pages you want to show up in the navigation of your page
 
 
 team_members: # Name is the only required field for team members.
-  - name: "Adam Kozłowski"
-  - name: "Jacek Suchenia"
   - name: "Jakub Barć"
+  - name: "Piotr Godowski"
   - name: "Konrad Gądek"
+  - name: "Adam Kozłowski"
   - name: "Marcin Lewandowski"
   - name: "Michał Różycki"
-  - name: "Paulina Wędrychowska"
-  - name: "Piotr Godowski"
-  - name: "Sylwia Zając"
+  - name: "Jacek Suchenia"
   - name: "Tomasz Szymański"
+  - name: "Paulina Wędrychowska"
+  - name: "Sylwia Zając"
 
 organizer_email: "krakow@devopsdays.org" # Put your organizer email address here
 


### PR DESCRIPTION
* remove Piotr Szwed
* sort all `team_members` by surnames (as it should be)

> If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.

Mail will be sent briefly.