### PR TITLE
[CPT-2020] Adding sponsors and propose pages

### DIFF
--- a/content/events/2020-cape-town/propose.md
+++ b/content/events/2020-cape-town/propose.md
@@ -3,13 +3,15 @@ Title = "Propose"
 Type = "event"
 Description = "Propose a talk for devopsdays Cape Town 2020"
 +++
-  {{< cfp_dates >}}
+
+{{< cfp_dates >}}
 
 <hr>
 
 There are three ways to propose a topic at devopsdays:
 <ol>
   <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
+  <li><strong><em>A lightning talk</em></strong> presented during the Ignite / Lightning sessions (scheduling varies). These are 5-10 minutes slots to showcase something you find interesting and think others would as well.</li>
   <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
   <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
 </ol>
@@ -27,9 +29,4 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+<strong>How to submit a proposal:</strong> Submit using <a href="https://sessionize.com/devopsdays-cape-town-2020" target="_blank">Sessionize</a>

--- a/content/events/2020-cape-town/sponsor.md
+++ b/content/events/2020-cape-town/sponsor.md
@@ -1,66 +1,164 @@
 +++
-Title = "Sponsor"
+Title = "sponsor"
 Type = "event"
 Description = "Sponsor devopsdays Cape Town 2020"
 +++
-
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
+<div class = "row">
+<div class = "col-md-8 col-sm-12">
+We greatly value sponsors for this community event.  If you are interested in sponsoring, please check out our <a href="https://assets.devopsdays.org/events/2020/cape-town/2020-cape-town-devopsdays-prospectus.pdf" target="_blank">prospectus</a> or <a href="{{< email_organizers >}}">send us an email</a>..
 
 <hr>
 
-devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
-<p>
-Gold sponsors get a full table and Silver sponsors a shared table where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.
-<p>
-The best thing to do is send engineers to interact with the experts at devopsdays on their own terms.
-<p>
-
-<!--
-<hr/>
-
-<div style="width:590px">
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>packages</i></th>
-    <th><center><b><u>Bronze<br />1000 usd</u></center></b></th>
-    <th><center><b><u>Silver<br />3000 usd</u></center></b></th>
-    <th><center><b><u>Gold<br />5000 usd</u></center></b></th>
-    <th></th>
-  </tr>
-<tr><td>2 included tickets</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on event website</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on shared slide, rotating during breaks</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on all email communication</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on its own slide, rotating during breaks</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>1 minute pitch to full audience (including streaming audience)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr></tr>
-<tr><td>2 additional tickets (4 in total)</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>4 additional tickets (6 in total)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>shared table for swag</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>booth/table space</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-</table>
-<hr/>
-There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
-<br/>
-<br/>
-
+DevOpsDays is a self-organizing conference for practitioners that
+depends on sponsorships. We do not have large vendor booths or sell product
+presentations. Sponsors have the opportunity to have short elevator
+pitches during the program and will get recognition on the website
+and social media before, during and after the event. Sponsors are
+encouraged to represent themselves by actively participating and
+engaging with the attendees as peers. Any attendee also has the
+opportunity to demo products/projects as part of an open space
+session, but this is not 'that kind of conference' and heavy
+marketing will probably work against you when trying to make a good
+impression on the attendees.
+<br><br>
+The best thing to do is send engineers to interact with the experts at DevOpsDays on their own terms.
 <br>
-<br>
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>Sponsor FAQ</i></th>
-    <th><center><b>Answers to questions frequently asked by sponsors&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</center></b></th>
-    <th></th>
-  </tr>
-<tr><td>What dates/times can we set up and tear down?</td><td></td></tr>
-<tr><td>How do we ship to the venue?</td><td></td></tr>
-<tr><td>How do we ship from the venue?</td><td></td></tr>
-<tr><td>Whom should we send?</td><td></td></tr>
-<tr><td>What should we expect regarding electricity? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>What should we expect regarding WiFi? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>How do we order additional A/V equipment?</td><td></td></tr>
-<tr><td>Additional important details</td><td></td></tr>
+<br><br>
+<h2>Sponsorship Packages</h2>
+
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th scope="col">THE GOODS</th>
+      <th scope="col">PLATINUM</th>
+      <th scope="col">GOLD</th>
+      <th scope="col">SILVER</th>
+      <th scope="col">BASIC</th>
+      <th scope="col">SUPPORTER</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Price</td>
+      <td>R70,000</td>
+      <td>R60,000</td>
+      <td>R50,000</td>
+      <td>R40,000</td>
+      <td>R2,000</td>
+    </tr>
+    <tr>
+      <td>Tickets Included</td>
+      <td>5</td>
+      <td>4</td>
+      <td>3</td>
+      <td>2</td>
+      <td>0†</td>
+    </tr>
+    <tr>
+      <td>Social media shout-out</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+    </tr>
+    <tr>
+      <td>Logo on DevOpsDays Cape Town website</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Logo on email communication</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Branded items for goodie bag</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Logo on delegate’s name tag</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Branded poster at the event (provided by the sponsor)</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Logo on event T-shirt</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Table space</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Logo on lanyard</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>5 minute slot after keynote to full audience</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Optional room bookings*</td>
+      <td><i class="fa fa-check fa-2x" aria-hidden="true"></i></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
 </table>
+
+<div class = "row">
+<div class = "col-12">
+  <br/>
+  <br/>
+  * Please note that room bookings for platinum sponsors are an optional extra billed at R 5,000 per room for both days of the conference.
+  <br/>
+  † Supporter is a type of ticket available at registration. We recognise that it may be impractical for some companies to invest in a full sponsorship package. Additionally, we have seen that more individuals, such as those self-employed, wish to support the conference. When buying a Supporter ticket, additional information is collected at checkout so we can properly thank the purchaser.
+  <br/>
+  <br/>
+  Sponsors are responsible for providing high-res logos for use on the website and in promotional materials.  The preferred file formats are EPS or AI.
+  <br/>
 </div>
-
--->
-<hr/>
+</div>
+</div>
+<div class = "col-md-4 col-sm-12">
+</div>
+</div>

--- a/data/events/2020-cape-town.yml
+++ b/data/events/2020-cape-town.yml
@@ -14,11 +14,11 @@ startdate: 2020-09-17T00:00:00+02:00
 enddate: 2020-09-18T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:  # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_start: 2019-12-05T00:00:00+02:00 # start accepting talk proposals.
+cfp_date_end: 2020-05-31T23:59:59+02:00 # close your call for proposals.
+cfp_date_announce:  2020-06-14T18:00:00+02:00 # inform proposers of status
 
-cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_link: "https://sessionize.com/devopsdays-cape-town-2020" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet
 registration_date_end: # close registration. Leave blank if registration is not open yet.
@@ -35,9 +35,9 @@ nav_elements: # List of pages you want to show up in the navigation of your page
 #  - name: program
   - name: location
 #  - name: registration
-#  - name: sponsor
+  - name: sponsor
 #  - name: speakers
-#  - name: propose
+  - name: propose
   - name: contact
   - name: conduct
 #   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/


### PR DESCRIPTION
NB: Please only merge once https://github.com/devopsdays/devopsdays-assets/pull/78 has been merged - it is the binary of the sponsorship prospectus.

* Enable the propose page with a link to our Sessionize CFP
* Enable and populated the sponsor page with packages.