### PR TITLE
Update to Hugo v0.62.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   production:
     docker:
-      - image: cibuilds/hugo:0.57.1
+      - image: cibuilds/hugo:0.62.1
     steps:
       - checkout
       - run:
@@ -11,7 +11,7 @@ jobs:
 
   build:
     docker:
-      - image: cibuilds/hugo:0.57.1
+      - image: cibuilds/hugo:0.62.1
     working_directory: ~/devopsdays
     steps:
       - checkout

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,12 @@ PaginatePath = "blog"
 buildDrafts = false
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+    unsafe = true
+
+
 [[menu.main]]
   name = "events"
   url = "/events"

--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -9,4 +9,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tip 1313:1313 -v $(pwd):/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.57.1
+docker run -tip 1313:1313 -v $(pwd):/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.62.0

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,10 +17,10 @@
   
 
 [context.production.environment]
-   HUGO_VERSION = "0.57.1"
+   HUGO_VERSION = "0.62.1"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.57.1"
+  HUGO_VERSION = "0.62.1"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.57.1"
+  HUGO_VERSION = "0.62.1"


### PR DESCRIPTION
This updates the hugo version, and adds a configuration option to make html/markdown work properly with that version.

Please do not merge this - let Matt do it. but please *do* look through the deploy preview and test various pages, events, etc.

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>


