### PR TITLE
Remove apostrophe in local event logo header on organizing guide

### DIFF
--- a/content/page/organizing.md
+++ b/content/page/organizing.md
@@ -187,7 +187,7 @@ If you have some legal entity created for the event, have the details at hand (l
 
 ---
 
-## Designing a local event's devopsdays logo
+## Designing a local event devopsdays logo
 
 The devopsdays logo with the gears in the brain has become recognizable for the overall devopsdays brand. For each individual devopsdays event you can take elements from the devopsdays brand logo. This is optional, but recommended. The goal should be to design something that denotes your city specifically.
 


### PR DESCRIPTION
Having an apostrophe in the title seemed to be breaking the TOC for the section "designing an local event's logo" section, so I removed it :)