### PR TITLE
updated to use the same docker image as *nix

### DIFF
--- a/hugoserver.ps1
+++ b/hugoserver.ps1
@@ -1,4 +1,5 @@
 # You will need to make sure you have your C drive (or whatever drive you have the devopsdays code on) shared in Docker
+# NOTE: The docker image provided by jojomi is not managed or audited by devopsdays
 
 $MyPath = $PSScriptRoot
 

--- a/hugoserver.ps1
+++ b/hugoserver.ps1
@@ -4,4 +4,4 @@ $MyPath = $PSScriptRoot
 
 docker stop hugo-server
 docker rm hugo-server 
-docker run -p 1313:1313 -v ${MyPath}:/site --name hugo-server devopsdays/docker-hugo-server:v0.30.2
+docker run -tip 1313:1313 -v ${MyPath}:/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.62.0


### PR DESCRIPTION
As the title says, updating this to use the same docker image as the .sh version.

Testing on Windows 10 Pro v1903 build 18362.535
                                                                                                                                                             Client: Docker Engine - Community
 Version:           19.03.5
 API version:       1.40
 Go version:        go1.12.12
 Git commit:        633a0ea
 Built:             Wed Nov 13 07:22:37 2019
 OS/Arch:           windows/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.5
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.12
  Git commit:       633a0ea
  Built:            Wed Nov 13 07:29:19 2019
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.2.10
  GitCommit:        b34a5c8af56e510852c35414db4c1f4fa6172339
 runc:
  Version:          1.0.0-rc8+dev
  GitCommit:        3e425f80a8c931f88e6d94a8c831b9d5aa481657
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683