### PR TITLE
Update Docker to use hugo 0.62.1

### DIFF
--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -11,4 +11,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tip 1313:1313 -v $(pwd):/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.62.0
+docker run -tip 1313:1313 -v $(pwd):/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.62.1


### PR DESCRIPTION
In order to match the other deployments

https://github.com/devopsdays/devopsdays-web/commit/325acc5b43bb244a0eb1215a1307336bcdb4c817