### PR TITLE
[BUF-2020] Adding Gitlab as a Silver sponsor and the CFP link

### DIFF
--- a/data/events/2020-buffalo.yml
+++ b/data/events/2020-buffalo.yml
@@ -14,11 +14,11 @@ startdate: 2020-09-30T00:08:00-04:00 # The start date of your event. Leave blank
 enddate: 2020-10-01T00:17:00-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:  # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_start:  2020-01-10 # start accepting talk proposals.
+cfp_date_end:  2020-04-15# close your call for proposals.
+cfp_date_announce:  2020-05-01# inform proposers of status
 
-cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_link: "https://www.papercall.io/dodbuf2020" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet
 registration_date_end: # close registration. Leave blank if registration is not open yet.
@@ -34,7 +34,7 @@ location: "Hotel Henry" # Defaults to city, but you can make it the venue name.
 location_address: "444 Forrest Avenue, BUFFALO, NY, 14213" #Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- # - name: propose
+  - name: propose
   - name: location
  # - name: registration
  # - name: program
@@ -96,13 +96,10 @@ organizer_email: "buffalo@devopsdays.org" # Put your organizer email address her
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
-  - id: samplesponsorname
-    level: gold
- #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
-  - id: arresteddevops
-    level: community
   - id: devrelate
     level: community
+  - id: gitlab
+    level: silver
 
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link

--- a/data/events/2020-buffalo.yml
+++ b/data/events/2020-buffalo.yml
@@ -15,8 +15,8 @@ enddate: 2020-10-01T00:17:00-04:00 # The end date of your event. Leave blank if 
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2020-01-10 # start accepting talk proposals.
-cfp_date_end:  2020-04-15# close your call for proposals.
-cfp_date_announce:  2020-05-01# inform proposers of status
+cfp_date_end:  2020-04-15 # close your call for proposals.
+cfp_date_announce:  2020-05-01 # inform proposers of status
 
 cfp_link: "https://www.papercall.io/dodbuf2020" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 


### PR DESCRIPTION
More preparation for DevOps Days Buffalo 2020. Adding Gitlab as a Silver sponsor and opening the CFP.
