### PR TITLE
[VAN-2020] Remove Sponsor until contract signing

### DIFF
--- a/data/events/2020-vancouver.yml
+++ b/data/events/2020-vancouver.yml
@@ -100,8 +100,6 @@ organizer_email: "vancouver@devopsdays.org" # Put your organizer email address h
 sponsors:
   - id: xmatters
     level: gold
-  - id: microsoft
-    level: gold
   - id: influxdata
     level: gold
   - id: site24x7


### PR DESCRIPTION
We added confirmed sponsors in good faith - but we've just learned that some sponsors require a signed contract before usage of their logo. This PR removes affected sponsors.