### PR TITLE
[CLT-2020] Add Instana as gold sponsor

### DIFF
--- a/data/events/2020-charlotte.yml
+++ b/data/events/2020-charlotte.yml
@@ -81,6 +81,8 @@ sponsors:
     level: gold
   - id: gitlab
     level: gold
+  - id: instana
+    level: gold
   - id: arresteddevops
     level: community
   - id: manning


### PR DESCRIPTION
Adding Instana as a gold sponsor for Charlotte's 2020 event.