### PR TITLE
[Vancouver 20202] Correcting CFP close date

### DIFF
--- a/data/events/2020-vancouver.yml
+++ b/data/events/2020-vancouver.yml
@@ -15,7 +15,7 @@ enddate: 2020-03-31T00:00:00-07:00 # The end date of your event. Leave blank if 
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2019-12-11T00:00:00-07:00  # start accepting talk proposals.
-cfp_date_end: 2020-03-16T00:00:00-07:00  # close your call for proposals.
+cfp_date_end: 2020-02-15T10:47:00-07:00  # close your call for proposals.
 # cfp_date_announce: 2019-12-12T00:00:00-07:00  # inform proposers of status
 
 cfp_link: "https://www.papercall.io/devopsdays-vancouver-2020" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.


### PR DESCRIPTION
Hi, @Velutas - I see that we merged https://github.com/devopsdays/devopsdays-web/pull/8873 without noticing that you're listing the CFP end date incorrectly - according to your papercall it's a month earlier. We don't want incorrect info on https://devopsdays.org/speaking so I'm fixing it here.