### PR TITLE
Revert "Update Docker to use hugo 0.62.1"

### DIFF
--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -11,4 +11,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tip 1313:1313 -v $(pwd):/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.62.1
+docker run -tip 1313:1313 -v $(pwd):/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.62.0


### PR DESCRIPTION
This reverts commit 8b6336ea40380c0b95b092a6aeedec645ae819ce.

This docker tag doesn't exist, lets revert to 0.62.0 for now.
