### PR TITLE
[Boston 2020] redirect date update

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -13,7 +13,7 @@
 /birmingham/*		/events/2021-birmingham/:splat		302
 /bogota/*		/events/2020-bogota/:splat		302
 /boise/*		/events/2020-boise/:splat		302
-/boston/*		/events/2019-boston/:splat		302
+/boston/*		/events/2020-boston/:splat		302
 /brasilia/*		/events/2017-brasilia/:splat		302
 /buenos-aires/*		/events/2020-buenos-aires/:splat	302
 /buffalo/*		/events/2020-buffalo/:splat		302


### PR DESCRIPTION
Hi @don-code - in https://github.com/devopsdays/devopsdays-web/pull/9201 since you set it up manually instead of using https://github.com/devopsdays/devopsdays-web/blob/master/utilities/add_new_event.sh you did not update the redirect for the https://devopsdays.org/boston link. I'm updating it here. 