### PR TITLE
[SEA 2020] Add multiple sponsors

### DIFF
--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -112,16 +112,16 @@ sponsors:
 #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
 # - id: arresteddevops
 #  level: community
-  - id: launch-darkly
-    level: gold
   - id: influxdata
+    level: gold
+  - id: launch-darkly
     level: gold
   - id: microsoft
     level: gold
-  - id: timescale
-    level: gold
   - id: salesforce
     level: gold    
+  - id: timescale
+    level: gold
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 

--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -128,6 +128,8 @@ sponsors:
     level: gold    
   - id: scalyr
     level: gold
+  - id: skykick
+    level: bronze
   - id: timescale
     level: gold
 

--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -128,8 +128,6 @@ sponsors:
     level: gold    
   - id: scalyr
     level: gold
-  - id: skykick
-    level: bronze
   - id: timescale
     level: gold
 

--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -118,6 +118,8 @@ sponsors:
     level: gold
   - id: launch-darkly
     level: gold
+  - id: mattermost
+    level: gold
   - id: microsoft
     level: gold
   - id: salesforce

--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -120,6 +120,8 @@ sponsors:
     level: gold
   - id: salesforce
     level: gold    
+  - id: scalyr
+    level: gold
   - id: timescale
     level: gold
 

--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -122,6 +122,8 @@ sponsors:
     level: gold
   - id: microsoft
     level: gold
+  - id: pulumi
+    level: silver
   - id: salesforce
     level: gold    
   - id: scalyr

--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -114,6 +114,8 @@ sponsors:
 #  level: community
   - id: influxdata
     level: gold
+  - id: instana
+    level: gold
   - id: launch-darkly
     level: gold
   - id: microsoft


### PR DESCRIPTION
Adds the following as sponsors for Seattle 2020

## Gold
Instana
Mattermost
Scalyr

## Silver
Pulumi

## Bronze
Sky Kick

**Note:** We still need to upload a logo for Sky Kick, unless it's a requirement for this PR, we can submit that separately