### PR TITLE
[CLT-2020] Update Jason Yee Bio

### DIFF
--- a/content/events/2020-charlotte/speakers/jason-yee.md
+++ b/content/events/2020-charlotte/speakers/jason-yee.md
@@ -7,4 +7,4 @@ linktitle = "jason-yee"
 
 +++
 
-Jason is a technical writer and evangelist at Datadog, where he works to inspire developers and ops engineers with the power of metrics and monitoring. Previously, he was the community manager for DevOps & Performance at O'Reilly Media and a software engineer at MongoDB. When he's not speaking at conferences or helping organize them, he likes to spend time on planes ‚"travel hacking", hunting for interesting, regional whiskey; and catching pokemon.
+Jason Yee is Director of Advocacy at Gremlin where he helps people build more resilient systems by learning from how they fail. Previously, he was Senior Technical Evangelist at Datadog, a Community Manager for DevOps & Performance at O’Reilly Media, and a Software Engineer at MongoDB. Outside of work, he likes to spend his time collecting interesting regional whiskey and pokemon.


### PR DESCRIPTION
I'm no longer at Datadog. This updates my bio to reflect my new role at Gremlin.