### PR TITLE
Improve blog display

### DIFF
--- a/themes/devopsdays-theme/layouts/blog/single.html
+++ b/themes/devopsdays-theme/layouts/blog/single.html
@@ -6,7 +6,7 @@
 {{- else -}}
   <small>{{ dateFormat "02 January, 2006" .Date }}</small>
 {{- end -}}
-
+<br><br>
 {{ .Content }}
 <div id="share"></div>
 <div class="row">

--- a/themes/devopsdays-theme/layouts/blog/summary.html
+++ b/themes/devopsdays-theme/layouts/blog/summary.html
@@ -1,5 +1,11 @@
 <header>
   <h2><a href='{{ .Permalink }}'> {{ .Title }}</a> </h2>
+       {{- if isset .Params "author" -}}
+         <h2 class="footer-heading">by {{ .Params.author }} - {{ dateFormat "02 January, 2006" .Date }}</h2>
+       {{- else -}}
+         <h2 class="footer-heading">{{ dateFormat "02 January, 2006" .Date }}</h2>
+       {{- end -}}
+
 </header>
 {{ if isset .Params "description" }}
   {{ if ne .Params.descripton "" }}
@@ -11,3 +17,4 @@
 <footer>
   <a href='{{ .Permalink }}'><nobr>Read more →</nobr></a>
 </footer>
+<br>

--- a/themes/devopsdays-theme/layouts/partials/footer.html
+++ b/themes/devopsdays-theme/layouts/partials/footer.html
@@ -24,24 +24,16 @@
   </div>
   <div class="col-md-6 col-lg-3 footer-nav-col footer-content">
     <h3 class="footer-nav">BLOG</h3>
-    {{- range first 2 (where .Site.Pages "Type" "blog") -}}
+    {{- range first 4 (where .Site.Pages "Type" "blog") -}}
       <a href = "{{ .Permalink }}"><h1 class = "footer-heading">{{ .Title }}</h1></a>
       {{- if isset .Params "author" -}}
         <h2 class="footer-heading">by {{ .Params.author }} - {{ dateFormat "02 January, 2006" .Date }}</h2>
       {{- else -}}
         <h2 class="footer-heading">{{ dateFormat "02 January, 2006" .Date }}</h2>
       {{- end -}}
-      <p class="footer-content">
-        {{- if isset .Params "description" -}}
-          {{- if ne .Params.description "" -}}
-            {{ .Params.description | markdownify }}
-          {{- end -}}
-        {{- else -}}
-          {{ .Summary }}
-        {{- end -}}
-      </p>
+<br>
     {{- end -}}
-    <a href="https://www.devopsdays.org/blog/index.xml">Feed</a>
+    <a href="https://www.devopsdays.org/blog/index.xml">Blog Feed</a>
   </div>
   <div class="col-md-6 col-lg-3 footer-nav-col">
       <h3 class="footer-nav">CFP OPEN</h3>


### PR DESCRIPTION
Cosmetic improvements around blog display. I highlight a few examples here.

Before: 
<img width="1190" alt="Screen Shot 2020-01-27 at 7 48 52 PM" src="https://user-images.githubusercontent.com/2104453/73229069-1c7db680-413e-11ea-9ff9-27900aa58ca8.png">

After:

<img width="1191" alt="Screen Shot 2020-01-27 at 7 49 09 PM" src="https://user-images.githubusercontent.com/2104453/73229075-230c2e00-413e-11ea-800d-50208b11d354.png">

Before:

<img width="224" alt="Screen Shot 2020-01-27 at 7 50 11 PM" src="https://user-images.githubusercontent.com/2104453/73229134-50f17280-413e-11ea-9cc0-cb5f5b67d548.png">

After:

<img width="458" alt="Screen Shot 2020-01-27 at 7 50 30 PM" src="https://user-images.githubusercontent.com/2104453/73229139-56e75380-413e-11ea-971b-d4d011fda6af.png">
