### PR TITLE
[TOR-2020] Remove Suzan Mahboob as an organizer

### DIFF
--- a/data/events/2020-toronto.yml
+++ b/data/events/2020-toronto.yml
@@ -54,8 +54,6 @@ team_members: # Name is the only required field for team members.
     twitter: "whatschrisdoing"
   - name: "Abeer Rahman"
     twitter: "abeer486"
-  - name: "Suzan Mahboob"
-    linkedin: https://linkedin.com/in/suzanmahboob/
   - name: "Elizabeth White"
   - name: "Amy Mansell"
     twitter: "ae_mansell"


### PR DESCRIPTION
Suzan resigned from the organizing team last week. Email sent to the core team.