### PR TITLE
[PDX-2020] Remove boilerplate submission info

### DIFF
--- a/content/events/2020-portland-or/propose.md
+++ b/content/events/2020-portland-or/propose.md
@@ -27,9 +27,4 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+The CFP is not yet open. Please keep an eye on this page for updated information on how to submit a session.


### PR DESCRIPTION
Our CFP is not yet open. We need to need to remove the boilerplate info to prevent email submissions.
