### PR TITLE
[LDN-2020] Update Evening Event sponsor benefits

### DIFF
--- a/content/events/2020-london/sponsor.md
+++ b/content/events/2020-london/sponsor.md
@@ -74,7 +74,7 @@ Description = "Sponsor devopsdays London 2020"
          <center>5</center>
        </td>
        <td>
-         <center>2</center>
+         <center>5</center>
        </td>
      </tr>
      <tr>
@@ -99,12 +99,12 @@ Description = "Sponsor devopsdays London 2020"
        </td>
        <td class="table-warning">
          <center>&nbsp;</center>
-  </td>
+       </td>
        <td>
          <center>1 Minute</center>
        </td>
-       <td class="table-warning">
-         <center>&nbsp;</center>
+       <td>
+         <center>1 Minute</center>
        </td>
      </tr>
    </tbody>


### PR DESCRIPTION
Evening event sponsors now get stuff like 5 tickets and a 1 minute address to delegates. 

I've not been around for a while so if anything's changed that I didn't see in the contributing guidelines when I had a quick skim through agian let me know.
