### PR TITLE
[NYC-2020] Update VMware logo for 2020 Events

### DIFF
--- a/data/events/2020-atlanta.yml
+++ b/data/events/2020-atlanta.yml
@@ -113,7 +113,7 @@ sponsors:
     level: gold
   - id: chef
     level: gold
-  - id: vmware
+  - id: vmware-tanzu
     level: gold
   - id: gitlab
     level: silver

--- a/data/events/2020-new-york-city.yml
+++ b/data/events/2020-new-york-city.yml
@@ -167,7 +167,7 @@ sponsors:
     level: silver
   - id: logz
     level: silver
-  - id: vmware
+  - id: vmware-tanzu
     level: gold
   - id: googlecloud
     level: silver

--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -138,7 +138,7 @@ sponsors:
     level: gold
   - id: chef
     level: gold
-  - id: vmware
+  - id: vmware-tanzu
     level: gold
   - id: appdynamics
     level: gold


### PR DESCRIPTION
VMware requested we use the 'vmware-tanzu' logo for their events in 2020. I updated NYC, Atlanta, and Seattle since they were already configured with the regular logo.