### PR TITLE
[Aar-2020] Aarhus prospectus

### DIFF
--- a/content/events/2020-aarhus/sponsor.md
+++ b/content/events/2020-aarhus/sponsor.md
@@ -7,7 +7,8 @@ description = "Interested in sponsoring DevOpsDays Aarhus 2020? We greatly value
 +++
 <div class = "row">
 <div class = "col-md-8 col-sm-12">
-We greatly value sponsors for this community event. If you are interested in sponsoring, please <a href="mailto:aarhus@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Aarhus%202020">send us an email</a>.
+We greatly value sponsors for this community event. If you are interested in sponsoring, please
+please check out our <a href="https://assets.devopsdays.org/events/events/2020/aarhus/DEVOPSDAYS_TECHSPONSOR_v6.pdf" target="_blank">prospectus</a> or <a href="mailto:aarhus@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Aarhus%202020">send us an email</a>.
 
 <hr>
 
@@ -72,8 +73,8 @@ All sponsors will have their logo displayed on the DevOpsDays Aarhus website, a 
     </tr>
     <tr>
       <td>Booth space in sponsor area (with chair, table & power)</td>
-      <td><img src = "/events/2020-aarhus/logo-square-tiny.jpg"><br />4 meters wide</td>
-      <td><img src = "/events/2020-aarhus/logo-square-tiny.jpg"><br />2 meters wide</td>
+      <td><img src = "/events/2020-aarhus/logo-square-tiny.jpg"><br />3 meters wide</td>
+      <td><img src = "/events/2020-aarhus/logo-square-tiny.jpg"><br />1.5 meters wide</td>
       <td></td>
     </tr>
     <tr>

--- a/data/events/2020-aarhus.yml
+++ b/data/events/2020-aarhus.yml
@@ -16,8 +16,8 @@ enddate:  2020-06-11T23:59:59+01:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2020-01-24T00:12:00+01:00
-cfp_date_end: 2020-02-29T23:59:00+01:00
-cfp_date_announce: 2020-03-15T12:00:00+01:00
+cfp_date_end: 2020-03-07T23:59:00+01:00
+cfp_date_announce: 2020-03-22T12:00:00+01:00
 
 cfp_open: "true"
 cfp_link: "https://www.papercall.io/devopsdaysaarhus-2020" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.


### PR DESCRIPTION
In this pull request we update our CFP date, and add our sponsor prospectus.

I have noticed chicago links directly to assets.devopsdays.org for the link to the PDF, but could not find any documentation on this ( or how to test this locally :) ) so here goes my attempt at solving it.

Cheers!