### PR TITLE
[Aar-2020] Update link to prospectus

### DIFF
--- a/content/events/2020-aarhus/sponsor.md
+++ b/content/events/2020-aarhus/sponsor.md
@@ -8,7 +8,7 @@ description = "Interested in sponsoring DevOpsDays Aarhus 2020? We greatly value
 <div class = "row">
 <div class = "col-md-8 col-sm-12">
 We greatly value sponsors for this community event. If you are interested in sponsoring, please
-please check out our <a href="https://assets.devopsdays.org/events/events/2020/aarhus/DEVOPSDAYS_TECHSPONSOR_v6.pdf" target="_blank">prospectus</a> or <a href="mailto:aarhus@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Aarhus%202020">send us an email</a>.
+please check out our <a href="https://assets.devopsdays.org/events/2020/aarhus/DEVOPSDAYS_TECHSPONSOR_v6.pdf" target="_blank">prospectus</a> or <a href="mailto:aarhus@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Aarhus%202020">send us an email</a>.
 
 <hr>
 


### PR DESCRIPTION
Sorry for the inconvenience - my lack of string comparison super eyes let to an extra `/events` in the URL to the sponsor prospect. 
This commit fixes it.