### PR TITLE
[Montreal 2020] Correcting time zone

### DIFF
--- a/data/events/2020-montreal.yml
+++ b/data/events/2020-montreal.yml
@@ -10,8 +10,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 #   variable: 2019-01-05T23:59:59+02:00
 # Note: we allow 2020-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-startdate: 2020-11-10T00:00:00+02:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2020-11-11T23:59:59+02:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2020-11-10T00:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2020-11-11T23:59:59-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.


### PR DESCRIPTION
Hi, @idcrosby! You probably want the right TZ; correction for https://github.com/devopsdays/devopsdays-web/pull/9501. (This fix will prevent your event from being removed from the front page mid-event, if a site build happens during your second day.)