### PR TITLE
[SEA-2020] Add sponsor info page (WIP)

### DIFF
--- a/content/events/2020-seattle/sponsor-info.md
+++ b/content/events/2020-seattle/sponsor-info.md
@@ -1,0 +1,129 @@
++++
+date = "2016-09-20T21:46:51+01:00"
+title = "Sponsor Information"
+type = "event"
+
++++
+
+<br><br>
+## Thank you for sponsoring DevOpsDays Seattle!
+
+As you probably know, DevOpsDays is a volunteer run not-for-profit event. Our goal is to help people learn about DevOps, and we couldn’t do it without your support. Thank You!!
+
+### Book your hotel rooms!
+
+A lot of hotels in Seattle sell out in the spring. It’s a good idea to book any rooms you’ll need as soon as possible. We don't have an official hotel, but there are many in the area.
+
+### Register your attendees.
+You’ll receive a registration code to be given to people who will be attending on behalf of your company. Please don’t wait to have them register once you receive your code! We’d like to have an accurate count as soon as possible. 
+
+### Venue Location
+<a href="https://www.wscc.com/venues/conference-center">The Conference Center at WSCC</a><br>
+705 Pike Street<br>
+Seattle, WA 98101<br>
+<a href="https://www.wscc.com/directions">Directions and Parking</a>
+
+### Dates and Times
+This year’s event is on April 14th and 15th, 2020. A detailed program can be found at http://www.devopsdays.org/events/2020-seattle/program/. Please note the speaker schedule is subjeect to change.
+
+* Booth set up - 7:00AM April 14th
+* Registration opens - 8:00AM April 14th (you'll want to be ready to talk to people
+by this time)
+* Tear down - approximately 4:00PM on April 15th.
+
+### Sponsor Pitch Schedule
+Gold sponsors have 1 minute for a pitch to the full audience. This time will be strictly enforced to make
+sure we stay on schedule! 
+
+<iframe width=700 height=450 src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQMBAS2c45N6OTxA1JkSpAm7bmBZu28fG_Ntv8-aE5FxdNAOmiPaek6MCvzbCUt0X2B8amuV3GRhNpE/pubhtml?gid=0&single=true&widget=true&headers=false"></iframe>
+
+### Who to Send
+Of course this is up to you, but most attendees will be practitioners. It’s
+important to your success that you send people able to have practitioner level
+conversations. If you’re showing off your latest product, be ready to answer
+some technical questions. If you’re looking to hire people, have someone there
+who works in the type of role you’re hiring for.
+
+### Conference Format
+
+DevOpsDays is a unique blend of presentation style talks and interactive open
+discussions. The presentations are being chosen from over 200 submissions. We’re
+really excited about the talks we’ll see.
+
+The afternoons are run as open spaces. You can learn more about this format
+at https://www.devopsdays.org/open-space-format/. To make the most of your
+participation it’s highly recommended that your staff participate in the open
+space discussions. This is your best chance to show off how valuable you can
+be to the attendees.
+
+### Shipping
+
+There is no shipping directly to the venue, so we have contracted a drayage company to all you to ship items for the event.
+
+**Sponsors are responsible for any charges from using this third party vendor. Please read their instructions carefully to make sure there are no issues.**
+
+<a href="https://assets.devopsdays.org/events/2020/seattle/DevOpsDays-Seattle-exhibitor-freight-kit.pdf">Click here to download the exhibitor freight kit</a>
+
+For outbound shipping only, there is a FedEx Office location across the street from the venue. Unlike some FedEx locations, this location does **not** offer a hold for pickup service so you should not send any incoming shipments there.
+
+### Loading / Unloading at venue
+
+Sponsors are welcome to come up to the WSCC Loading Dock for loading/unloading purposes.  
+The WSCC Loading Dock will be open from 6am-10pm on 4/24 and 4/25. Long term parking is 
+not allowed in either the alley or at the Loading Dock.
+
+<a href="https://assets.devopsdays.org/events/2018/seattle/WSCC-Loading-Dock-Map.pdf">Map to loading dock</a>
+
+### Sponsor Tables
+
+Gold sponsors will be able to choose the location in the venue of your sponsor table. Once we have finalized the layout (probably in early March) we will send out emails to sponsors in batches of 5 per day in the order the sponsorship was paid for. The email will contain a link to a page where you can choose your sponsor table. It's very important that you choose your table as soon as you receive this email for the best choice. 
+
+With that said, we've been told that we have one of the most welcoming sponsor areas of any DevOpsDays event and will do everything in our power to make sure there's no such thing as a "bad table spot".
+
+Floor Plan<br>
+<a href="/events/2020-seattle/2020-floor-plan.png"><img style="max-width: 500px; padding: 0px 20px 20px 0px" src="/events/2020-seattle/2020-floor-plan.png"></a>
+
+#### Gold Sponsors
+* 6 foot table with two chairs
+* Power available at table
+* WiFi is shared with the conference attendees, bandwidth heavy demos are not
+recommended
+
+#### Silver Sponsors
+* Share a 6 foot table with another sponsor
+* Power available at table
+* WiFi is shared with the conference attendees, bandwidth heavy demos are not
+recommended
+
+The sponsor area will be set up to encourage people to hang out and enjoy coffee breaks and meals. It isn’t designed like a big trade show with aisles of booths. You should bring retractable banners instead of traditional trade show booths.
+
+<img style="max-width: 500px; padding: 0px 20px 20px 0px" src="/events/2017-seattle/banner_styles.png">
+
+### A/V Rental<a id="av_rental">
+
+A/V rental is available directly from the venue. All tables will have power and access to the shared wireless service. Anything else you require can be ordered with <a href="https://assets.devopsdays.org/events/2020/seattle/devopsdays-2020-exhibitor-kit-form.pdf">this form</a>. 
+
+### Lead Collection
+We don’t share attendee information with sponsors.
+
+You’re welcome to ask people to share their contact information voluntarily.
+It’s very common for sponsors to hold drawings for this purpose and we will have
+a time at the end of day 2 to announce winners.
+
+Most attendees will not have business cards, so you’ll want to have a way to
+capture this information. Some sponsors will bring slips of paper and a
+punchbowl, others will use something like Google Forms on a laptop or tablet.
+
+<a href="/events/2020-seattle/sponsor-content/drawings">Information for holding a drawing</a>
+
+### Code of Conduct
+
+DevOpsDays is dedicated to providing a harassment-free conference experience
+for everyone. The Code of Conduct will be strictly enforced, please be sure to
+read it at http://www.devopsdays.org/events/2020-seattle/conduct/. In particular,
+exhibitors should not use sexualized images, activities, or other material.
+Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes,
+or otherwise create a sexualized environment.
+
+### Social Networks
+We have the twitter handle @DevOpsDaysSEA, but people will most likely use the #DevOpsDays hashtag.


### PR DESCRIPTION
Adds a sponsor info page for Seattle 2020.

WIP todo items
1. [ ] Upload shipping info pdf for 2020
1. [ ] Upload floor plan
1. [ ] Update all dates
1. [ ] Review/finalize sponsor pitch schedule