### PR TITLE
[BER-2020] Point in-page CfP link to actual CfP tool

### DIFF
--- a/content/events/2020-berlin/welcome.md
+++ b/content/events/2020-berlin/welcome.md
@@ -49,7 +49,7 @@ Description = "devopsdays Berlin 2020"
     <strong>Propose</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_link page="propose" text="Propose a talk!" >}}
+    <a href="https://cfp.devopsdays.berlin/2020/">Propose a talk!</a>
   </div>
 </div>
 


### PR DESCRIPTION
Slight oversight, link on page text pointed to the wrong CfP page. 