### PR TITLE
Salt lake is Canceling

### DIFF
--- a/content/events/2020-salt-lake-city/welcome.md
+++ b/content/events/2020-salt-lake-city/welcome.md
@@ -9,64 +9,14 @@ Description = "devopsdays Salt Lake City 2020"
   {{< event_logo >}}
 </div> -->
 
-<h2>DevOpsDays is returning to Salt Lake City in June!</h2>
-<h3>More information to come as we get everything planned out - stay tuned!</h3>
-<br><br>
-<h4>Our CFP is now open! Check it out here: https://www.papercall.io/slcdod2020</h4>
-<br><hr><br>
-<div class="row">
-    <div class="col-md-6">
-        <div class="row">
-            <div class="col-md-2"><strong>Dates</strong></div>
-            <div class="col-md-8">{{< event_start >}} - {{< event_end >}}</div>
-        </div>
-        <!-- <div class="row">
-            <div class="col-md-2"><strong>Schedule</strong></div>
-            <div class="col-md-8">{{< event_link page="schedule" text="View the schedule!" >}}</div>
-        </div> -->
-        <div class="row">
-            <div class="col-md-2"><strong>Location</strong></div>
-            <div class="col-md-8">{{< event_location >}}</div>
-        </div>
-        <div class="row">
-          <div class="col-md-2"><strong>Propose</strong></div>
-          <div class="col-md-8">{{< event_link page="propose" text="Propose a talk!" >}}</div>
-        </div>
-        <!--<div class="row">
-          <div class="col-md-2"><strong>Register</strong></div>
-          <div class="col-md-8">{{< event_link page="registration" text="Register to attend the conference!" >}}</div>
-        </div>-->
-        <!--<div class = "row">
-          <div class = "col-md-2"><strong>Program</strong></div>
-          <div class = "col-md-8">View the {{< event_link page="program" text="program." >}}</div>
-        </div>-->
-        <!-- <div class = "row">
-          <div class = "col-md-2"><strong>Speakers</strong></div>
-          <div class = "col-md-8">Check out the {{< event_link page="speakers" text="speakers!" >}}</div>
-        </div> -->
-        <!--<div class="row">
-          <div class="col-md-2"><strong>Sponsors</strong></div>
-          <div class="col-md-8">{{< event_link page="sponsor" text="Sponsor the summit!" >}}</div>
-        </div>-->
-        <div class="row">
-          <div class="col-md-2"><strong>Contact</strong></div>
-          <div class="col-md-8">{{< event_link page="contact" text="Get in touch with the organizers" >}}</div>
-        </div>
-        <div class="row">
-          <div class="col-md-2"></div>
-          <div class="col-md-8">{{< event_twitter >}}</div>
-        </div>
-    </div>
-    <div class="col-md-6">
-        <div style="text-align:center;">
-          <a href="http://slcdevopsdays.org">{{< event_logo >}}</a>
-        </div>
-    </div>
-</div>
-<br><br>
-<h3>Join us for our 5th year in the Silicon Slopes!</h3>
-<h4>The conference for organizational excellence</h4>
-<a href="../registration" class="btn btn-info">Register!</a> <a href="../sponsor" class="btn btn-info">Sponsor DevOpsDays SLC!</a><br>
-Come join us on June 1 - 2, 2020 and find out how to level your expertise with those of us who strive for operational nirvana.
-<br>
-<br>
+<h2>Salt Lake City DevOpsDays 2020 - Canceled</h2>
+<h3>Every year, we look forward to connecting with our local DevOps community at SLC DevOps Days; Sharing and learning from experts in our community, and working with DevOps thought leaders that visit our event. But given the growing concerns around COVID-19, we've made the difficult decision to cancel Salt Lake City DevOps Days for 2020 due to the uncertainties of having a large event gathering.
+
+Canceling the event was a tough decision to make. We have thoroughly enjoyed planning SLC DevOps Days, and it's one of our favorite ways to engage our local community. However, we need to prioritize the health and safety of our Community, Organizers, Sponsors, and everyone who helps make SLC DevOps days great. We are exploring the possibility of hosting the event later in the year. Based on current government guidelines and the general uncertainty around how this virus behaves, we are unable to confirm if this will be the case at this point.
+
+Those of you who have registered for the event, SLC DevOps Days, will be provided a full refund within the next week.
+
+We would also like to thank our Sponsors, Launch Darkly, Splunk, and GitLab, for being fantastic community supporters. We look forward to working with you in the future.
+
+On behalf of the SLC DevOps Days staff, Board of Directors, and conference volunteers, thank you for being a part of the local DevOps community.
+</h3>

--- a/data/events/2020-salt-lake-city.yml
+++ b/data/events/2020-salt-lake-city.yml
@@ -3,7 +3,7 @@ year: "2020" # The year of the event. Make sure it is in quotes.
 city: "Salt Lake City" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysslc" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 event_logo: "logo-square.jpg"
-description: "Devopsdays is returning to Salt Lake City!" # Edit this to suit your preferences
+description: "Salt Lake City DevOpsDays" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
@@ -11,22 +11,22 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 #   variable: 2020-01-05T23:59:59+02:00
 # Note: we allow YYYY-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-startdate: 2020-06-01T08:00:00-06:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2020-06-02T18:00:00-06:00   # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:   # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2019-08-30T07:01:00-06:00  # start accepting talk proposals.
 cfp_date_end: 2020-01-07T07:01:00-06:00 # close your call for proposals.
 cfp_date_announce:  2020-03-04T07:01:00-06:00 # inform proposers of status
 
-cfp_open: "true"
-cfp_link: "https://www.papercall.io/slcdod2020" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_open: "false"
+cfp_link:  #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2020-01-28T07:01:00-06:00   # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2020-06-01T01:59:59-06:00     # close registration. Leave blank if registration is not open yet.
+registration_date_start:    # start accepting registration. Leave blank if registration is not open yet
+registration_date_end:     # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
-registration_link: "https://www.slcdevopsdays.org/purchase-tickets/" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
+registration_link:  # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 
 # Location
 #


### PR DESCRIPTION
It was a very tough decision, but our biggest reason is that many of our repeat sponsors have chosen to abstain this year due to concerns surrounding covid-19. We are working on messaging and will submit a PR shortly to get us off the global DOD site. We are planning to review the status in May and possible look to host the event in October

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organizers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
