### PR TITLE
Standardize on Hugo usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   production:
     docker:
-      - image: cibuilds/hugo:0.65.2
+      - image: cibuilds/hugo:0.67.1
     steps:
       - checkout
       - run:
@@ -11,7 +11,7 @@ jobs:
 
   build:
     docker:
-      - image: cibuilds/hugo:0.65.2
+      - image: cibuilds/hugo:0.67.1
     working_directory: ~/devopsdays
     steps:
       - checkout

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 install:
 #  Install Hugo from chocolatey and display the version number
 - cmd: >-
-    choco install hugo --version=0.67.0
+    choco install hugo --version=0.67.1
 
     hugo version
 

--- a/hugoserver.ps1
+++ b/hugoserver.ps1
@@ -1,8 +1,8 @@
 # You will need to make sure you have your C drive (or whatever drive you have the devopsdays code on) shared in Docker
-# NOTE: The docker image provided by jojomi is not managed or audited by devopsdays
+# NOTE: The docker image provided by cibuilds is not managed or audited by devopsdays
 
 $MyPath = $PSScriptRoot
 
 docker stop hugo-server
 docker rm hugo-server
-docker run -tip 1313:1313 -v ${MyPath}:/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.67.0
+docker run -tip 1313:1313 -v $(pwd):/home/circleci/project:cached -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.67.0 hugo server --watch --bind ""

--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -11,4 +11,4 @@
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tip 1313:1313 -v $(pwd):/src:cached -e HUGO_THEME=devopsdays-theme -e HUGO_WATCH=1 -e HUGO_BASEURL="http://localhost:1313" --name hugo-server jojomi/hugo:0.67.0
+docker run -tip 1313:1313 -v $(pwd):/home/circleci/project:cached -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.67.0 hugo server --watch --bind ""

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
 	"theme_version": "1.17.0",
-	"hugo_version": "0.67.0",
+	"hugo_version": "0.67.1",
 	"devopsdays_cli_version": "0.22.1"
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,10 +15,10 @@
   skip_processing = true
 
 [context.production.environment]
-   HUGO_VERSION = "0.67.0"
+   HUGO_VERSION = "0.67.1"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.67.0"
+  HUGO_VERSION = "0.67.1"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.67.0"
+  HUGO_VERSION = "0.67.1"


### PR DESCRIPTION
This standardized on using cibuilds/hugo instead of the normal
jojomi/hugo docker image as well as using 0.67.1 everywhere.

See https://github.com/devopsdays/devopsdays-web/pull/9638 for more history.