### PR TITLE
[DC-2020] Planning for the 2020 DC event is paused

### DIFF
--- a/content/events/2020-washington-dc/welcome.md
+++ b/content/events/2020-washington-dc/welcome.md
@@ -5,6 +5,28 @@ aliases = ["/events/2020-washington-dc/"]
 Description = "devopsdays Washington, D.C. 2020"
 +++
 
+<div class="row">
+  <div class="col-md-12">
+    <div class="alert alert-danger" role="alert">
+      <h3>DevOpsDays Washington, D.C. Coronavirus Pandemic Update: PAUSED</h3>
+      <p>
+        Last updated: March 20, 2020
+      </p>
+      <p>
+        The organizing team for DevOpsDays DC, like you, is sitting isolated at home watching the Coronavirus pandemic impact everyone.  We have paused our planning for the 2020 edition of DevOpsDays DC.
+      </p>
+      <p>
+        Our best estimation is that DevOpsDays will not be held in 2020 though we will regroup and announce our decision no later than April 15, 2020.
+      </p>
+      <p>
+        Watch our <a href="https://twitter.com/DevOpsDaysDC">twitter handle (@DevOpsDaysDC)</a> and this page for updates.
+      <p>
+        Please stay safe and follow all necessary recommendations during this difficult time.
+      </p>
+    </div>
+  </div>
+</div>
+
 <!-- <div style="text-align:center;">
   {{< event_logo >}}
 </div> -->


### PR DESCRIPTION
We will likely not hold and event in 2020.  Planning is officially paused and we will update by 15 Apr 2020.

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>

