### PR TITLE
[BOISE-2021] Cancel 2020, Create 2021 event

### DIFF
--- a/content/events/2020-boise/cancellation.md
+++ b/content/events/2020-boise/cancellation.md
@@ -1,0 +1,15 @@
++++
+Title = "2020 Cancelation"
+Type = "event"
+Description = "DevOpsDays Boise 2020 Cancellation Notice"
++++
+
+Every year, we look forward to connecting with our local DevOps community at DevOpsDays Boise. Sharing and learning from experts in our community, and working with DevOps thought leaders that visit our event. But given the growing concerns around COVID-19, we've made the difficult decision to cancel Boise DevOpsDays for 2020 due to the uncertainties of having a large event gathering.
+
+Canceling the event was a tough decision to make. We have thoroughly enjoyed planning DevOpsDays Boise, and it’s one of our favorite ways to engage our local community. However, we need to prioritize the health and safety of our Community, Organizers, Sponsors, and everyone who helps make Boise DevOpsDays great. We have made the decision to move the event to *April 6-7, 2021*, and make it a two day more robust event. We made this decisions based on the unknowns of the current situation.  
+
+Those of you who have registered for DevOpsDays Boise, can either have a full refund, or hold your ticket for the two-day event next year.  
+ 
+We would also like to thank our Sponsors, Cradlepoint, In Time Tec, Balsam Brands, Simplot, Chef, and Intuit for being fantastic community supporters. We look forward to an exciting event in 2021.
+On behalf of the DevOpsDays Boise organizing committee: thank you for being a part of the local DevOps community!
+

--- a/content/events/2020-boise/welcome.md
+++ b/content/events/2020-boise/welcome.md
@@ -5,11 +5,24 @@ aliases = ["/events/2020-boise/"]
 Description = "devopsdays Boise 2020"
 +++
 
-<!-- <div style="text-align:center;">
+
+<div class="alert alert-danger" role="alert">
+  Due to the global situation around COVID-19, devopsdays Boise has been canceled for 2020. We have made the decision to move the event to April 6-7, 2021, and make it a two day more robust event. <a href="/events/2020-boise/cancellation" class="alert-link">Click here for more information</a>.
+</div>
+
+<div class="d-flex p-2">
+          <a class="btn btn-secondary btn-block" style= "color: #ffffff; background-color: #CC112F; border-color: #CC112F;" href="/events/2020-boise/cancellation"> <i class="fa fa-bullhorn fa-lg"></i>&nbsp;&nbsp;&nbsp;Statement on Cancellation</a>
+</div>
+
+<div class="d-flex p-2">
+          <a class="btn btn-secondary btn-block" style= "background-color: #96bfe6; border-color: #96bfe6;" href="/events/2020-boise/contact"> <i class="fa fa-envelope-o fa-lg"></i>&nbsp;&nbsp;&nbsp;Contact the Organizers</a>
+</div>
+
+<!--<div style="text-align:center;">
   {{< event_logo >}}
 </div> -->
 
-<div class = "row">
+<!--<div class = "row">
   <div class = "col-md-2">
     <strong>Date</strong>
   </div>
@@ -43,7 +56,7 @@ Description = "devopsdays Boise 2020"
   <div class = "col-md-8">
     {{< event_link url-key="cfp_link" text="Propose a talk" >}}
   </div>
-</div>
+</div> -->
 
 <!-- <div class = "row">
   <div class = "col-md-2">
@@ -63,13 +76,13 @@ Description = "devopsdays Boise 2020"
   </div>
 </div> -->
 
-<div class = "row">
+<!-- <div class = "row">
   <div class = "col-md-2">
     <strong>Sponsors</strong>
   </div>
   <div class = "col-md-8">
     {{< event_link page="sponsor" text="Sponsor the conference!" >}}
-  </div>
+  </div> 
 </div>
 
 <div class = "row">
@@ -79,7 +92,7 @@ Description = "devopsdays Boise 2020"
   <div class = "col-md-8">
     {{< event_link page="contact" text="Get in touch with the organizers" >}}
   </div>
-</div>
+</div> -->
 
 <!-- Uncomment if you added your city twitter name -->
 <!--

--- a/content/events/2021-boise/conduct-fr.md
+++ b/content/events/2021-boise/conduct-fr.md
@@ -1,0 +1,37 @@
++++
+Title = "Conduct"
+Type = "event"
+Description = "Code de conduite devopsdays Boise 2021"
++++
+
+Tous les participants, conférenciers, sponsors et volontaires à devopsdays Boise 2021 doivent accepter le code d'éthique et de déontologie, ou « code de conduite » suivant. Les organisateurs s’attacheront à faire respecter ce code durant l’événement. Nous attendons la coopération de chacun‧e pour assurer un environnement sain pour tous.
+
+
+### La Version Rapide
+
+Notre conférence tient à être une expérience sans harcèlement pour tous, quel que soit votre sexe, votre identité sexuelle, votre âge, votre orientation sexuelle, votre handicap, votre apparence physique, votre poids, votre race, votre ethnie, votre religion (ou absence de religion), ou vos choix technologiques.
+
+Nous ne tolérons aucun harcèlement des participant‧e‧s à la conférence, sous quelque forme que ce soit, quelles qu’en soient les circonstances. Les expressions et les images à connotation sexuelle ne sont pas appropriées lors de l'événement. Ceci inclut les conférences, les ateliers, les soirées, Twitter et les autres médias en ligne.
+
+L'organisation s'engage à prendre des sanctions appropriées pour les personnes qui violent ces règles, jusqu'à l'exclusion sans remboursement et le recours légal.
+
+
+### La Version Moins Rapide
+
+Le harcèlement comprend les commentaires à l'oral ou à l'écrit ainsi que les  gestes offensants sur le sexe, l'identité sexuelle, l'âge, l'orientation sexuelle, le handicap, l'apparence physique, le poids, la race, l'ethnie, la religion, les choix technologiques, les images à connotation sexuelle dans des lieux publics, les intimidations délibérées, la traque, la poursuite, un harcèlement photographique ou vidéo, une suite d'interruptions des conférences et des autres sessions, un contact physique inapproprié et des avances sexuelles non désirées. sans son consentement ou à son insu.
+
+Les participant‧e‧s à qui il sera demandé d'arrêter tout comportement de harcèlement doivent arrêter immédiatement.
+
+Les sponsors sont aussi sujet à la politique anti-harcèlement. En particulier, les sponsors ne doivent pas utiliser d'images ou de supports à connotation sexuelle. Ils ne doivent pas non plus se livrer à des activités à connotation sexuelle. L'équipe du stand (y compris les bénévoles) ne doit pas utiliser de vêtements, uniformes ou costumes à connotation sexuelle. Ils ne doivent pas non plus créer un environnement sexualisé.
+
+Face à un comportement de harcèlement, l'équipe d'organisation de la conférence peut prendre toute action qui lui semble adéquate. Cela va d'un simple avertissement à l'exclusion sans remboursement de la conférence.
+
+Si vous vous sentez harcelé‧e, si vous pensez que quelqu'un se fait harceler, et plus généralement en cas de problème, merci de contacter immédiatement l’équipe d’organisation de l'événement.
+
+Les membres de l'organisation sont facilement identifiables grâce à un badge "STAFF". Les membres de l'organisation seront ravi‧e‧s d'aider les participants à contacter la sécurité de l'événement, ou les forces de l'ordre ; à fournir une escorte ainsi qu'à aider de toute autre façon les personnes victimes de harcèlement, pour garantir leur sécurité pendant la durée de l'événement. Nous apprécions votre participation à l'événement.
+
+Nous attendons de chacun‧e le respect de ces règles dans le bâtiment des conférences et des ateliers, ainsi que pendant les événements sociaux relatifs à la conférence.
+
+
+
+Le code de conduite devopsdays Boise 2021 est basé sur [fr.confcodeofconduct.com](https://fr.confcodeofconduct.com)._ 

--- a/content/events/2021-boise/conduct-pt-br.md
+++ b/content/events/2021-boise/conduct-pt-br.md
@@ -1,0 +1,28 @@
++++
+Title = "Conduta"
+Type = "event"
+Description = "Código de conduta do devopsdays Boise 2021"
++++
+
+
+Participantes, palestrantes, representantes de empresas e pessoas voluntárias no devopsdays Boise 2021 são requeridos a concordar com o seguinte código de conduta. A organização irá aplicar este código pelo evento. Nós esperamos cooperação de todas as pessoas participando para garantir um ambiente seguro para todas as pessoas.
+
+### A versão rápida
+
+Nossa conferência é dedicada a prover um uma experiência de conferência sem assédio para todos, independente de gênero, identidade de gênero e expressão, idade, orientação sexual, deficiência, aparência física, tamanho corporal, raça, etinia, religião (ou a falta dela) ou escolhas de tecnologias. Nós não toleramos assédio de participantes da conferência de qualquer forma. Linguagem e imagens sexuais não são apropriadas em nenhum local, incluindo palestras, workshops, festas, Twitter e outras mídias online. Violações destas regras poderão causar expulsão da conferência, sem reembolso a critério da equipe organizadora.
+
+### A versão não tão rápida
+
+Assédio inclui comentários verbais ofensivos relacionados a gênero, identidade de gênero e expressão, idade, orientação sexual, deficiência, aparência física, tamanho corporal, raça, etinia, religião (ou a falta dela) ou escolhas de tecnologias, imagens sexuais em espaços públicos, intimidação deliberada, stalking, perseguição, fotografias ou filmagens constrangedoras, interrupção contínua das apresentações ou outros eventos, contato físico inapropriado e atenção sexual indesejada. Participantes que receberem uma solicitação para interromper qualquer comportamento de assédio devem fazer isso imediatamente.
+
+As políticas antiassédio também se aplicam a representantes de empresas patrocinadoras. Em particular, não devem usar imagens, atividades ou outro material de cunho sexual. As equipes de estandes e tendas (incluindo pessoas voluntárias) não devem utilizar roupas, uniformes ou trajes sexualizados ou criar um ambiente sexualizado de quaisquer formas.
+
+Se alguém se envolver em comportamento de assédio, a equipe organizadora pode tomar qualquer ação que considerar apropriada, incluindo avisar a pessoa ofensora ou expulsá-la da conferência sem reembolso.
+
+Se você estiver sofrendo assédio, notar que alguém está sofrendo assédio, ou tenha alguma dúvida, por favor contate alguém da organização imediatamente.
+
+As pessoas da equipe da conferência podem ser identificadas por crachás distintos da organização. A organização estará disposta a contatar a segurança do hotel/local ou a polícia local, fornecer escolta ou ajudar pessoas que sofrerem assédio para que se sintam seguras durante a conferência. Nós valorizamos a sua participação.
+
+Esperamos que todas as pessoas participantes sigam estas regras em salas de apresentação e workshops da conferência, além de eventos sociais relacionados.
+
+_O código de conduta do devopsdays Boise 2021 é baseado em [confcodeofconduct.com](https://confcodeofconduct.com/index-pt-br.html)._

--- a/content/events/2021-boise/conduct.md
+++ b/content/events/2021-boise/conduct.md
@@ -1,0 +1,28 @@
++++
+Title = "Conduct"
+Type = "event"
+Description = "Code of conduct for devopsdays Boise 2021"
++++
+
+
+All attendees, speakers, sponsors, and volunteers at devopsdays Boise 2021 are required to agree with the following code of conduct. Organizers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensure a safe environment for everybody.
+
+### The Quick Version
+
+Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter, and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers.
+
+### The Less Quick Version
+
+Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+
+If a participant engages in harassing behavior, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately.
+
+Conference staff can be identified by distinct staff badges. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+We expect participants to follow these rules at conference and workshop venues and conference-related social events.
+
+_The devopsdays Boise 2021 Code of Conduct is based on [confcodeofconduct.com](https://confcodeofconduct.com)._ 

--- a/content/events/2021-boise/contact.md
+++ b/content/events/2021-boise/contact.md
@@ -1,0 +1,14 @@
++++
+Title = "Contact"
+Type = "event"
+Description = "Contact information for devopsdays Boise 2021"
++++
+
+If you'd like to contact us by email: {{< email_organizers >}}
+
+**Our local team**
+
+{{< list_organizers >}}
+
+
+{{< list_core >}}

--- a/content/events/2021-boise/location.md
+++ b/content/events/2021-boise/location.md
@@ -1,0 +1,17 @@
++++
+Title = "Location"
+Type = "event"
+Description = "Location for devopsdays Boise 2021"
++++
+
+Watch this space for information about the venue including address, map/direction, parking/transit, and any hotel details.
+
+<!-- Uncomment this only if you have set the coordinates for your location in the config yaml. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html -->
+<!-- {{< event_map >}} -->
+
+<!-- Edit and uncomment to let people know what accessibility features you have available -->
+<!-- 
+    Example from Minneapolis 2020
+
+    We offer wheelchair-designated spaces, chairs, and standing options (with tall tables) in the mainstage session room; a quiet room; bathrooms labeled according to the facilities they contain; professional live captioning of mainstage sessions; ingredient labeling (based on data provided when registering); and private space (upon request) for those nursing. We'd also be happy to accommodate any other accessibility needs upon request: {{< email_organizers >}}    
+-->

--- a/content/events/2021-boise/propose.md
+++ b/content/events/2021-boise/propose.md
@@ -1,0 +1,35 @@
++++
+Title = "Propose"
+Type = "event"
+Description = "Propose a talk for devopsdays Boise 2021"
++++
+  {{< cfp_dates >}}
+
+<hr>
+
+There are three ways to propose a topic at devopsdays:
+<ol>
+  <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
+  <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
+  <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
+</ol>
+
+<hr>
+
+Choosing talks is part art, part science; here are some factors we consider when trying to assemble the best possible program for our local audience:
+
+- _broad appeal_: How will your talk play out in a room of people with a variety of backgrounds? Technical deep dives need more levels to provide value for the whole room, some of whom might not use your specific tool.
+- _new local presenters_: You are the only one who can tell your story. We are very interested in the challenges and successes being experienced in our local area. We are happy to provide guidance/coaching for new speakers upon request.
+- _under-represented voices_: We want to hear all voices, including those that may speak less frequently at similar events. Whether you're in a field not typically thought of as a technology field, you're in a large, traditional organization, or you're the only person at your organization with your background, we are interested in your unique experience.
+- _original content_: We will consider talks that have already been presented elsewhere, but we prefer talks that the local area isn't likely to have already seen.
+- _no third-party submissions_: This is a small community-driven event, and speakers need to be directly engaged with the organizers and attendees. If a PR firm or your marketing department is proposing the talk, you've already shown that as a speaker you're distant from the process.
+- _no vendor pitches_: As much as we value vendors and sponsors, we are not going to accept a talk that appears to be a pitch for your product.
+
+<hr>
+
+<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
+<ol>
+	<li>Type (presentation, panel discussion, ignite)</li>
+	<li>Proposal Title (can be changed later)</li>
+	<li>Description (several sentences explaining what attendees will learn)</li>
+</ol>

--- a/content/events/2021-boise/registration.md
+++ b/content/events/2021-boise/registration.md
@@ -1,0 +1,11 @@
++++
+Title = "Registration"
+Type = "event"
+Description = "Registration for devopsdays Boise 2021"
++++
+
+<div style="width:100%; text-align:left;">
+
+Embed registration iframe/link/etc.
+</div></div>
+</div>

--- a/content/events/2021-boise/sponsor.md
+++ b/content/events/2021-boise/sponsor.md
@@ -1,0 +1,66 @@
++++
+Title = "Sponsor"
+Type = "event"
+Description = "Sponsor devopsdays Boise 2021"
++++
+
+We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
+
+<hr>
+
+devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
+<p>
+Gold sponsors get a full table and Silver sponsors a shared table where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.
+<p>
+The best thing to do is send engineers to interact with the experts at devopsdays on their own terms.
+<p>
+
+<!--
+<hr/>
+
+<div style="width:590px">
+<table border=1 cellspacing=1>
+  <tr>
+    <th><i>packages</i></th>
+    <th><center><b><u>Bronze<br />1000 usd</u></center></b></th>
+    <th><center><b><u>Silver<br />3000 usd</u></center></b></th>
+    <th><center><b><u>Gold<br />5000 usd</u></center></b></th>
+    <th></th>
+  </tr>
+<tr><td>2 included tickets</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
+<tr><td>logo on event website</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
+<tr><td>logo on shared slide, rotating during breaks</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
+<tr><td>logo on all email communication</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
+<tr><td>logo on its own slide, rotating during breaks</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
+<tr><td>1 minute pitch to full audience (including streaming audience)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr></tr>
+<tr><td>2 additional tickets (4 in total)</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td>4 additional tickets (6 in total)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
+<tr><td>shared table for swag</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td>booth/table space</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
+</table>
+<hr/>
+There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
+<br/>
+<br/>
+
+<br>
+<br>
+<table border=1 cellspacing=1>
+  <tr>
+    <th><i>Sponsor FAQ</i></th>
+    <th><center><b>Answers to questions frequently asked by sponsors&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</center></b></th>
+    <th></th>
+  </tr>
+<tr><td>What dates/times can we set up and tear down?</td><td></td></tr>
+<tr><td>How do we ship to the venue?</td><td></td></tr>
+<tr><td>How do we ship from the venue?</td><td></td></tr>
+<tr><td>Whom should we send?</td><td></td></tr>
+<tr><td>What should we expect regarding electricity? (how much, any fees, etc)</td><td></td></tr>
+<tr><td>What should we expect regarding WiFi? (how much, any fees, etc)</td><td></td></tr>
+<tr><td>How do we order additional A/V equipment?</td><td></td></tr>
+<tr><td>Additional important details</td><td></td></tr>
+</table>
+</div>
+
+-->
+<hr/>

--- a/content/events/2021-boise/welcome.md
+++ b/content/events/2021-boise/welcome.md
@@ -82,6 +82,5 @@ Description = "devopsdays Boise 2021"
 </div>
 
 <!-- Uncomment if you added your city twitter name -->
-<!--
 {{< event_twitter >}}
--->
+

--- a/content/events/2021-boise/welcome.md
+++ b/content/events/2021-boise/welcome.md
@@ -1,0 +1,87 @@
++++
+Title = "devopsdays Boise 2021"
+Type = "welcome"
+aliases = ["/events/2021-boise/"]
+Description = "devopsdays Boise 2021"
++++
+
+<!-- <div style="text-align:center;">
+  {{< event_logo >}}
+</div> -->
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Dates</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_start >}} - {{< event_end >}}
+  </div>
+</div>
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Location</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_location >}}
+  </div>
+</div> -->
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Register</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="registration" text="Register to attend the conference!" >}}
+  </div>
+</div> -->
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Propose</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="propose" text="Propose a talk!" >}}
+  </div>
+</div> -->
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Program</strong>
+  </div>
+  <div class = "col-md-8">
+    View the {{< event_link page="program" text="program." >}}
+  </div>
+</div> -->
+
+<!-- <div class = "row">
+  <div class = "col-md-2">
+    <strong>Speakers</strong>
+  </div>
+  <div class = "col-md-8">
+    Check out the {{< event_link page="speakers" text="speakers!" >}}
+  </div>
+</div> -->
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Sponsors</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="sponsor" text="Sponsor the conference!" >}}
+  </div>
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Contact</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="contact" text="Get in touch with the organizers" >}}
+  </div>
+</div>
+
+<!-- Uncomment if you added your city twitter name -->
+<!--
+{{< event_twitter >}}
+-->

--- a/data/events/2020-boise.yml
+++ b/data/events/2020-boise.yml
@@ -2,7 +2,7 @@ name: "2020-boise" # The name of the event. Four digit year with the city name i
 year: "2020" # The year of the event. Make sure it is in quotes.
 city: "Boise" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysboise" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
-description: "Devopsdays is coming to Boise!" # Edit this to suit your preferences
+description: "Devopsdays Boise 2020 is canceled." # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
@@ -10,38 +10,38 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 #   variable: 2019-01-05T23:59:59+02:00
 # Note: we allow 2020-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-startdate: 2020-05-15T08:00:00-06:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: 2020-05-15T19:00:00-06:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2019-11-01 # start accepting talk proposals.
-cfp_date_end: 2020-02-14T00:00:00-06:00 # close your call for proposals.
+cfp_date_start: # start accepting talk proposals.
+cfp_date_end: # close your call for proposals.
 cfp_date_announce: # inform proposers of status
 
-cfp_link: "https://www.papercall.io/devopsdaysboise"
+# cfp_link: "https://www.papercall.io/devopsdaysboise"
 
-registration_date_start: 2019-12-01 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2020-05-15 # close registration. Leave blank if registration is not open yet.
+registration_date_start: # start accepting registration. Leave blank if registration is not open yet
+registration_date_end: # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 sharing_image: "sharing.jpg"
 # Location
 #
-coordinates: "43.614893,-116.205161" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
-location: "Boise Center" # Defaults to city, but you can make it the venue name.
+coordinates: "" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+location: "" # Defaults to city, but you can make it the venue name.
 #
-location_address: "850 W Front St, Boise, ID 83702" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+location_address: "" #Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: propose
-  - name: location
-  - name: registration
- # - name: program
- # - name: speakers
-  - name: sponsor
+#- name: propose
+#  - name: location
+# - name: registration
+# - name: program
+# - name: speakers
+#  - name: sponsor
   - name: contact
-  - name: conduct
+#  - name: conduct
 # - name: example
 #   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/
 #   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
@@ -81,35 +81,35 @@ organizer_email: "boise@devopsdays.org" # Put your organizer email address here
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
-  - id: arresteddevops
-    level: community
-  - id: simplot
-    level: silver
-  - id: cradlepoint
-    level: platinum
-  - id: chef
-    level: silver
-  - id: balsam-brands
-    level: gold
-  - id: 2016-intimetec
-    level: platinum
-  - id: intuit
-    level: bronze
+  #  - id: arresteddevops
+  #  level: community
+  #- id: simplot
+  #  level: silver
+  #- id: cradlepoint
+  #  level: platinum
+  #- id: chef
+  #  level: silver
+  #- id: balsam-brands
+  #  level: gold
+  #- id: 2016-intimetec
+  #  level: platinum
+  #- id: intuit
+  #  level: bronze
 
-sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
+sponsors_accepted : "no" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.
 # You may optionally include a "max" attribute to limit the number of sponsors per level. For
 # unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
 # sponsorship for a specific level, it is best to remove the level.
 sponsor_levels:
-  - id: platinum
-    label: Platinum
-  - id: gold
-    label: Gold
-  - id: silver
-    label: Silver
-  - id: bronze
-    label: Bronze
-  - id: community
-    label: Community
+  #- id: platinum
+  #  label: Platinum
+  #- id: gold
+  #  label: Gold
+  #- id: silver
+  #  label: Silver
+  #- id: bronze
+  #  label: Bronze
+  #- id: community
+  #  label: Community

--- a/data/events/2021-boise.yml
+++ b/data/events/2021-boise.yml
@@ -1,0 +1,106 @@
+name: "2021-boise" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
+year: "2021" # The year of the event. Make sure it is in quotes.
+city: "Boise" # The displayed city name of the event. Capitalize it.
+event_twitter: "devopsdaysboise" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
+description: "Devopsdays is coming to Boise!" # Edit this to suit your preferences
+ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+
+# All dates are in unquoted 2021-MM-DDTHH:MM:SS+TZ:TZ, like this:
+#   variable: 2019-01-04T00:00:00+02:00
+#   variable: 2019-01-05T23:59:59+02:00
+# Note: we allow 2021-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
+
+startdate: 2021-04-06T08:00:00-06:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: 2021-04-07T19:00:00-06:00  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+
+# Leave CFP dates blank if you don't know yet, or set all three at once.
+cfp_date_start:  # start accepting talk proposals.
+cfp_date_end:  # close your call for proposals.
+cfp_date_announce:  # inform proposers of status
+
+cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+
+registration_date_start: # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
+registration_date_end: # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
+
+registration_closed: "" #set this to true if you need to manually close registration before your registration end date
+registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
+
+# Location
+#
+coordinates: "43.614893,-116.205161" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+location: "Boise" # Defaults to city, but you can make it the venue name.
+#
+location_address: "850 W Front St, Boise, ID 83702" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+
+nav_elements: # List of pages you want to show up in the navigation of your page.
+ # - name: propose
+ # - name: location
+ # - name: registration
+ # - name: program
+ # - name: speakers
+  - name: sponsor
+  - name: contact
+  - name: conduct
+# - name: example
+#   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/
+#   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
+
+
+# These are the same people you have on the mailing list and Slack channel.
+team_members: # Name is the only required field for team members.
+  - name: "Julie Gunderson"
+    employer: "Pager Duty"
+    twitter: "Julie_Gund"
+    linkedin: "https://www.linkedin.com/in/juliegunderson/"
+#  - name: "Stephen Spector"
+#    twitter: "SpectorID"
+#    employer: "RackN"
+  - name: "Brian Hartvigsen"
+    employer: "Cisco"
+    twitter: "tresni"
+    linkedin: "https://linkedin.com/in/tresni"
+    github: "tresni"
+  - name: "Robert Meyer"
+    employer: "Taos"
+    twitter: "BDArcholite"
+    github: "Robert-R-Meyer"
+    linkedin: "https://www.linkedin.com/in/robertrmeyer/"
+  - name: "Paul Remeis"
+    employer: "In Time Tec"
+    twitter: "PaulRemeis"
+    linkedin: "https://www.linkedin.com/in/paulremeis/"
+  - name: "Jane Miceli"
+    employer: "Taos"
+    linkedin: "https://www.linkedin.com/in/janemiceli/"
+    twitter: "janemiceli"
+    github: "janemiceli"
+
+organizer_email: "boise@devopsdays.org" # Put your organizer email address here
+
+# List all of your sponsors here along with what level of sponsorship they have.
+# Check data/sponsors/ to use sponsors already added by others.
+sponsors:
+  - id: samplesponsorname
+    level: gold
+ #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
+  - id: arresteddevops
+    level: community
+
+sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
+
+# In this section, list the level of sponsorships and the label to use.
+# You may optionally include a "max" attribute to limit the number of sponsors per level. For
+# unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
+# sponsorship for a specific level, it is best to remove the level.
+sponsor_levels:
+  - id: platinum
+    label: Platinum
+  - id: gold
+    label: Gold
+  - id: silver
+    label: Silver
+  - id: bronze
+    label: Bronze
+  - id: community
+    label: Community

--- a/static/_redirects
+++ b/static/_redirects
@@ -12,7 +12,7 @@
 /berlin/*		/events/2020-berlin/:splat		302
 /birmingham/*		/events/2021-birmingham/:splat		302
 /bogota/*		/events/2020-bogota/:splat		302
-/boise/*		/events/2020-boise/:splat		302
+/boise/*		/events/2021-boise/:splat		302
 /boston/*		/events/2020-boston/:splat		302
 /brasilia/*		/events/2017-brasilia/:splat		302
 /buenos-aires/*		/events/2020-buenos-aires/:splat	302


### PR DESCRIPTION
Adding cancelation messaging for Boise 2020 and creating the new 2021 page with confirmed dates.

I marked this as a WIP as I am not actually a Boise organizer and would like to get approval from them before this gets merged.