### PR TITLE
Let SELinux-protected hosts mount in site data.

### DIFF
--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -8,7 +8,12 @@
 #
 # NOTE: The docker image provided by jojomi is not managed or audited by devopsdays
 
+if [ "$(uname)" == "Linux" ]; then
+  MOUNT_OPTION="Z"
+else
+  MOUNT_OPTION="cached"
+fi
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tip 1313:1313 -v $(pwd):/home/circleci/project:cached -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.67.0 hugo server --watch --bind ""
+docker run -tip 1313:1313 -v $(pwd):/home/circleci/project:$MOUNT_OPTION -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.67.0 hugo server --watch --bind ""


### PR DESCRIPTION
This is a change I've been carrying forward for some time now in my local clone.

The `cached` option is specific to Docker for Mac, and has no bearing on a Linux host. Linux hosts with SELinux enabled will end up with a container that can't read the local copy of the site data, unless Docker is told to change labels on the files beforehand.

**I did not test this on a Mac.** That is why I have the global `else` that makes any non-Linux host behave the old way.
