### PR TITLE
[Aarhus-2020] Add cancellation notice

### DIFF
--- a/content/events/2020-aarhus/welcome.md
+++ b/content/events/2020-aarhus/welcome.md
@@ -4,12 +4,12 @@ Type = "welcome"
 aliases = ["/events/2020-aarhus/"]
 Description = "devopsdays aarhus 2020"
 +++
-
+<h1>Due to the COVID-19 situation, we have decided to postpone the event to February 3-4, 2021.
+We will automatically postpone your ticket to these dates, unless you prefer a full refund of course.
+If you have any questions, you can contact us: aarhus@devopsdays.org.
+Until then be safe, and keep the DevOps practices going!</h1>
 <div style="text-align:center;">
-  DevOpsDays is about learning from each other and sharing our stories. We'd love to hear your story at DevOpsDays Aarhus 2020. <br />
-  {{< event_link page="propose" text="Send us your pitch!" >}}<br />
-
-  {{< event_logo >}}
+   {{< event_logo >}}
 </div>
 
 <div class = "row">


### PR DESCRIPTION
We will unfortuantely post pone DevOpsDays Aarhus to 2020.

We will contact attendees, sponsors and speakers today.

Cheers
