### PR TITLE
[BUF-2020] Adding a COVID-19 statement

### DIFF
--- a/content/events/2020-buffalo/welcome.md
+++ b/content/events/2020-buffalo/welcome.md
@@ -9,6 +9,20 @@ Description = "devopsdays Buffalo 2020"
   {{< event_logo >}}
 </div> -->
 
+<div style="text-align:left;">
+<h2>COVID-19 Statement from the Organizers of DevOps Days Buffalo</h2>
+<p>The organizers of DevOpsDays Buffalo are monitoring developments related to the coronavirus disease (COVID-19) outbreak and potential impact on local, national, and international travel in regard to our 2020 event.</p>
+
+<p>At this point, we are anticipating things will be resolved by the time the event arrives and we’re therefore planning to move forward with the event. We will continue to monitor events as they unfold and will update this page with additional information if it looks like there might be an impact to your favorite DevOps event.</p>
+
+<p>For the most up-to-date information regarding the virus, please refer to the following Health Agencies:</p>
+<ul>
+  <li><a href = 'https://www.cdc.gov/coronavirus/2019-ncov/index.html' target = _new>Center for Disease Control</a></li>
+  <li><a href = 'http://www2.erie.gov/health/index.php?q=coronavirus' target = _new>Erie County Department of Health</a></li>
+</ul>
+<p>Stay safe, and safeguard your toilet paper! Hopefully, we’ll see you in September!</p>
+</div>
+
 <div class = "row">
   <div class = "col-md-2">
     <strong>Dates</strong>


### PR DESCRIPTION
Adding a COVID-19 Statement. We aren't cancelling as of yet, but we want people to be clear on our current status and intentions.
