### PR TITLE
Add field to event data file to keep cancelled events from showing alongside upcoming events

### DIFF
--- a/data/events/2020-minneapolis.yml
+++ b/data/events/2020-minneapolis.yml
@@ -13,6 +13,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 startdate:
 enddate:
 
+cancel: "true"
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:
 cfp_date_end:

--- a/themes/devopsdays-theme/REFERENCE.md
+++ b/themes/devopsdays-theme/REFERENCE.md
@@ -54,6 +54,7 @@ The YYYY-CITY.yml file is the main configuration file for your event. This is wh
 | `description`    | String | No       | Overall description of your event. Quotation marks need to be escaped.                                | "It's time for more DevOpsDays at Ponyville!" |
 | `ga_tracking_id` | String | No       | If you have your own Google Analytics tracking ID, enter it here.                                     | "UA-74738648-1"                               |
 | `speakers_verbose` | String | No     | Set this to "true" if you want verbose speaker attributes (URLs visible).                             | "true"                                        |
+| `cancel`       | String     | No       | If your event must be cancelled, add this field with the value of "true" (case-sensitive). This will keep it from being listed in the "upcoming events" views.                                                                                         | "true"  |                                                                                   |
 
 ### Date-related Fields
 All dates are in unquoted YYYY-MM-DD, like this: `variable: 2016-01-05`, or like `variable: 2016-01-05T23:59:00-06:00`

--- a/themes/devopsdays-theme/layouts/index.html
+++ b/themes/devopsdays-theme/layouts/index.html
@@ -5,46 +5,48 @@
 
     <div class="row">
         {{- range sort $.Site.Data.events "startdate" -}}
-        {{- if .startdate -}}
-<!-- Subtracting a day is a patch for https://github.com/devopsdays/devopsdays-theme/issues/656 -->
-        {{- if ge (time .enddate) now -}}
-        {{- $.Scratch.Set "city" .city -}}
-        {{- $.Scratch.Set "year" .year -}}
-        {{- $.Scratch.Set "logo" "unset" -}}
-        <div class="col-md-3 homepage-grid-col">
-            {{- $.Scratch.Set "subdir" .name -}}
-            {{- $.Scratch.Set "contentdir" (printf "static/events/%s/" ($.Scratch.Get "subdir")) -}}
-            {{- if (where (readDir "static/events") "Name" ($.Scratch.Get "subdir")) -}}
-                {{- if (where (readDir ($.Scratch.Get "contentdir")) "Name" "logo-square.jpg") -}}
-                    <a href="{{ (printf "/events/%s" .name) }}"><img src="{{ (printf "/events/%s/logo-square.jpg" .name)  }}" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
-                    {{- $.Scratch.Set "logo" "set" -}}
+            {{- if .startdate -}}
+                {{- if ne .cancel "true" -}}
+            <!-- Subtracting a day is a patch for https://github.com/devopsdays/devopsdays-theme/issues/656 -->
+                    {{- if ge (time .enddate) now -}}
+                    {{- $.Scratch.Set "city" .city -}}
+                    {{- $.Scratch.Set "year" .year -}}
+                    {{- $.Scratch.Set "logo" "unset" -}}
+                    <div class="col-md-3 homepage-grid-col">
+                        {{- $.Scratch.Set "subdir" .name -}}
+                        {{- $.Scratch.Set "contentdir" (printf "static/events/%s/" ($.Scratch.Get "subdir")) -}}
+                        {{- if (where (readDir "static/events") "Name" ($.Scratch.Get "subdir")) -}}
+                            {{- if (where (readDir ($.Scratch.Get "contentdir")) "Name" "logo-square.jpg") -}}
+                                <a href="{{ (printf "/events/%s" .name) }}"><img src="{{ (printf "/events/%s/logo-square.jpg" .name)  }}" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
+                                {{- $.Scratch.Set "logo" "set" -}}
+                            {{- end -}}
+                        {{- end -}}
+                        {{- if ne ($.Scratch.Get "logo") "set" -}}
+                            <a href="{{ (printf "/events/%s" .name) }}"><img src="{{"/img/event-logo-square.jpg"  }}" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
+                            {{- end -}}
+                            <br/>
+                {{- if or (ne (time .startdate).Month (time .enddate).Month) (ne (time .startdate).Day (time .enddate).Day) -}}
+                        <span class="homepage-grid-date">
+                        {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2, 2006" .enddate }}<br />
+                        </span>
+                {{- else -}}
+                        <span class="homepage-grid-date">
+                    {{ dateFormat "Jan 2, 2006" .startdate }}<br />
+                        </span>
                 {{- end -}}
-            {{- end -}}
-            {{- if ne ($.Scratch.Get "logo") "set" -}}
-                <a href="{{ (printf "/events/%s" .name) }}"><img src="{{"/img/event-logo-square.jpg"  }}" class="img-fluid" alt="devopsdays {{ .city }}"/></a>
-                {{- end -}}
-                <br/>
-      {{- if or (ne (time .startdate).Month (time .enddate).Month) (ne (time .startdate).Day (time .enddate).Day) -}}
-            <span class="homepage-grid-date">
-            {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2, 2006" .enddate }}<br />
-            </span>
-      {{- else -}}
-            <span class="homepage-grid-date">
-          {{ dateFormat "Jan 2, 2006" .startdate }}<br />
-            </span>
-      {{- end -}}
-        <span class="homepage-grid-city">
-            <a href="{{ (printf "/events/%s" .name) }}">{{ .city }}</a>
-        </span>
-            </div>
-            {{- if modBool ($.Scratch.Get "i") 4 -}}
-        </div>
-        <div class="row">
-            {{- end -}}
-            {{ $.Scratch.Add "i" 1 }}
-            {{- end -}}
-            {{- end -}}
-            {{- end -}}
+                    <span class="homepage-grid-city">
+                        <a href="{{ (printf "/events/%s" .name) }}">{{ .city }}</a>
+                    </span>
+                        </div>
+                        {{- if modBool ($.Scratch.Get "i") 4 -}}
+                    </div>
+                    <div class="row">
+                        {{- end -}}
+                        {{ $.Scratch.Add "i" 1 }}
+                        {{- end -}}
+                    {{- end -}}<!-- end cancel check-->
+                {{- end -}}<!-- end startdate check -->
+            {{- end -}} <!-- end range -->
         </div>
         <!-- <div id="share"></div> -->
 {{- end -}}

--- a/themes/devopsdays-theme/layouts/partials/footer.html
+++ b/themes/devopsdays-theme/layouts/partials/footer.html
@@ -38,11 +38,13 @@
   <div class="col-md-6 col-lg-3 footer-nav-col">
       <h3 class="footer-nav">CFP OPEN</h3>
       {{- range sort $.Site.Data.events "startdate" -}}
+      {{- if ne .cancel "true" -}}
         {{- if .cfp_date_end -}}
           {{- if and (ge now (time .cfp_date_start)) (ge (time .cfp_date_end) now) -}}
             <a href = "{{ (printf "/events/%s" .name) }}" class = "footer-content">{{ .city }}</a><br />
           {{- end -}} {{/* end: date is now or afterwards */}}
         {{- end -}} {{/* end: if .cfp_date_end */}}
+        {{- end -}}
       {{- end -}} {{/* end: range sort $.Site.Data.events "startdate" */}}
       <br /><a href="https://devopsdays.org/speaking">Propose a talk</a> at an event near you!<br />
   </div>

--- a/themes/devopsdays-theme/layouts/partials/future.html
+++ b/themes/devopsdays-theme/layouts/partials/future.html
@@ -1,5 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
+  {{- if ne .cancel "true" -}}
     {{- if ge (time .enddate) now -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
@@ -37,11 +38,14 @@
       </a><br />
       {{- end -}}
     {{- end -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 <h3 class="left-nav-year">TBD</h3>
 {{- range $.Site.Data.events -}}
   {{- if not .startdate -}}
-    <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">{{ .city }}</a><br />
+    {{- if ne .cancel "true" -}}
+      <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">{{ .city }}</a><br />
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/themes/devopsdays-theme/layouts/partials/speaking.html
+++ b/themes/devopsdays-theme/layouts/partials/speaking.html
@@ -1,6 +1,7 @@
 {{- $.Scratch.Add "events" "<table id = 'cfp-list' class = 'table table-condensed'><thead><tr><th>City</th><th>&nbsp;&nbsp;CFP Closes</th><th>&nbsp;&nbsp;&nbsp;&nbsp;Event Starts</th></tr></thead><tbody>" -}}
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if (and .cfp_date_end .startdate) -}}
+  {{- if ne .cancel "true" -}}
     {{- if and (ge now (time .cfp_date_start)) (ge (time .cfp_date_end) now) -}}
       {{- $.Scratch.Add "events" "<tr><td><a href = '/events/" -}}
       {{- $.Scratch.Add "events" .name -}}
@@ -12,6 +13,7 @@
       {{- $.Scratch.Add "events" (dateFormat "2006-01-02" .startdate) -}}
       {{- $.Scratch.Add "events" "</td></tr>" -}}
     {{- end }} {{/* end: date is now or afterwards */}}
+    {{- end -}}
   {{- end }} {{/* end: if .cfp_date_end */}}
 {{ end }} {{/* end: range sort $.Site.Data.events "startdate" */}}
 {{- $.Scratch.Add "events" "</tbody></table>" -}}

--- a/themes/devopsdays-theme/layouts/partials/welcome.html
+++ b/themes/devopsdays-theme/layouts/partials/welcome.html
@@ -90,6 +90,7 @@
           {{- $.Scratch.Set "past-counter" 0 -}}
           {{- range sort $.Site.Data.events "startdate" -}}
           {{- if .startdate -}}
+          {{- if ne .cancel "true" -}}
 
             {{- if $e.event_group -}}
               {{- if eq .event_group $e.event_group -}}
@@ -113,6 +114,7 @@
                 {{- end -}}
               {{- end -}}
               {{- end -}}
+            {{- end -}}
             {{- end -}}
           {{- end -}}
           <br /><br />

--- a/utilities/docs/cancel-event.md
+++ b/utilities/docs/cancel-event.md
@@ -38,7 +38,11 @@ cfp_date_start:
 cfp_date_end:
 cfp_date_announce:
 ```
+You also need to add a new entry like this (note it is case-sensitive):
 
+```yaml
+cancel: "true"
+```
 
 Remove any location information:
 


### PR DESCRIPTION
This adds support for the `cancel:` field in data files, which prevents events from showing up in the sidebar, on future lists, home page, etc.

Tested with 2020 MSP in this PR.

Fixes #9681