### PR TITLE
Set cancel flags

### DIFF
--- a/content/events/2020-seattle/welcome.md
+++ b/content/events/2020-seattle/welcome.md
@@ -9,7 +9,7 @@ Description = "We're very sorry to announce that DevOpsDays Seattle 2020 will no
 
 Due to the outbreak of COVID-19 and growing concern over the spread of the disease, we have decided not to hold DevOpsDays Seattle on April 14th and 15th. While we are disappointed not to host the event in April, the health and well-being of the community is our top priority.
 
-At this moment, we do not know whether the event is postponed to the fall or canceled, but we wanted to let you know as soon as possible that the event will not take place as planned. We are researching the feasibility of holding an event in the fall. We will provide updates via email and social channels by March 20th. 
+Thank you for your patience as we researched whether we could hold DevOpsDays Seattle later this year. Given the uncertainty of the situation, we have decided not to reschedule. We will be back, better than ever in 2021.
 
 #### Attendees
 Starting this evening, March 4th, we will begin canceling ticket registrations and refunding your money for the event. 

--- a/data/events/2020-baltimore.yml
+++ b/data/events/2020-baltimore.yml
@@ -13,6 +13,7 @@ masthead_background: "bmore_skyline_inner_harbor.jpg"
 
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+cancel: "true"
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2019-12-01T09:00:00-04:00  # start accepting talk proposals.

--- a/data/events/2020-boise.yml
+++ b/data/events/2020-boise.yml
@@ -12,6 +12,7 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 
 startdate: # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: # The end date of your event. Leave blank if you don't have a venue reserved yet.
+cancel: "true"
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: # start accepting talk proposals.

--- a/data/events/2020-des-moines.yml
+++ b/data/events/2020-des-moines.yml
@@ -12,6 +12,7 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 
 startdate:  # 2020-05-14T00:01:00-05:00
 enddate:  # 2020-05-15T00:01:00-05:00
+cancel: "true"
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2019-12-10T00:00:00-06:00

--- a/data/events/2020-portland-me.yml
+++ b/data/events/2020-portland-me.yml
@@ -13,6 +13,7 @@ masthead_background: pwm_sunset.jpg
 
 startdate: # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: # The end date of your event. Leave blank if you don't have a venue reserved yet.
+cancel: "true"
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2020-portland-or.yml
+++ b/data/events/2020-portland-or.yml
@@ -12,6 +12,7 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 
 startdate: #2020-09-08T09:00:00-07:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: #2020-09-10T23:59:59-07:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+cancel: "true"
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: #2020-01-28T09:00:00-07:00 # start accepting talk proposals.

--- a/data/events/2020-seattle.yml
+++ b/data/events/2020-seattle.yml
@@ -14,6 +14,8 @@ masthead_background: "seattle-skyline.jpg"
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
+cancel: "true"
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.

--- a/data/events/2020-tokyo.yml
+++ b/data/events/2020-tokyo.yml
@@ -10,6 +10,7 @@ description: "The event has been cancelled due to COVID-9; please see https://ww
 
 #startdate: 2020-04-09T00:00:00+09:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 #enddate: 2020-04-10T23:59:59+09:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+cancel: "true"
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2019-08-20T00:00:00+09:00 # start accepting talk proposals.
 cfp_date_end: 2019-12-31T15:00:00+09:00  # close your call for proposals.

--- a/data/events/2020-vancouver.yml
+++ b/data/events/2020-vancouver.yml
@@ -10,6 +10,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 #   variable: 2019-01-05T23:59:59+02:00
 # Note: we allow 2020-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
+cancel: "true"
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2019-12-11T00:00:00-07:00  # start accepting talk proposals.
 cfp_date_end: 2020-02-15T10:47:00-07:00  # close your call for proposals.

--- a/data/events/2020-washington-dc.yml
+++ b/data/events/2020-washington-dc.yml
@@ -13,6 +13,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 startdate:  # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate:  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
+cancel: "true"
+
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.
 cfp_date_end:  # close your call for proposals.


### PR DESCRIPTION
Setting flags for cancellation for previously-scheduled 2020 events that state they now won't run in 2020 (to remove these events from the TBD sidebar). Updating language on Seattle site based on the later Twitter update (/cc @kmugrage).