### PR TITLE
[MSP 2021] Moving sponsor to 2021

### DIFF
--- a/data/events/2020-minneapolis.yml
+++ b/data/events/2020-minneapolis.yml
@@ -112,8 +112,6 @@ organizer_email: "minneapolis@devopsdays.org" # Put your organizer email address
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
  #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
-  - id: redhat
-    level: silver
   - id: xmatters
     level: gold
   - id: hashicorp
@@ -130,6 +128,3 @@ sponsor_levels:
   - id: gold
     label: Gold
     max: 15
-  - id: silver
-    label: Silver
-    max: 13

--- a/data/events/2021-minneapolis.yml
+++ b/data/events/2021-minneapolis.yml
@@ -121,7 +121,8 @@ sponsors:
     level: community
   - id: appdynamics
     level: gold
-
+  - id: redhat
+    level: silver
 
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link


### PR DESCRIPTION
Red Hat would like to carry their sponsorship forward to 2021.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
