### PR TITLE
[MSP 2021] HashiCorp has moved to 2021

### DIFF
--- a/data/events/2020-minneapolis.yml
+++ b/data/events/2020-minneapolis.yml
@@ -114,8 +114,6 @@ sponsors:
  #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
   - id: xmatters
     level: gold
-  - id: hashicorp
-    level: gold
 
 
 sponsors_accepted : "no" # Whether you want "Become a XXX Sponsor!" link

--- a/data/events/2021-minneapolis.yml
+++ b/data/events/2021-minneapolis.yml
@@ -123,6 +123,8 @@ sponsors:
     level: gold
   - id: redhat
     level: silver
+  - id: hashicorp
+    level: gold
 
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link


### PR DESCRIPTION
Moving HashiCorp's MSP sponsorship to 2021, per @solutiongeek.
Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
