### PR TITLE
[PHILLY2020] Cancel event on web for 2020.

### DIFF
--- a/content/events/2020-philadelphia/welcome.md
+++ b/content/events/2020-philadelphia/welcome.md
@@ -10,7 +10,7 @@ Description = "devopsdays philadelphia 2020"
 </div>
 
 <div class = "row" style="background: #ed0b07; color: #ffffff; padding: 20px; margin: 20px; font-size: 20px">
-<p>UPDATE: Due to COVID-19 we have decided to cancel DevOpDays Philadelphia for 2020. We will be returning in 2021, please stay tuned. For any questions or concerns, please reach out at philadelphia@devopsdays.org</p>
+<p>UPDATE: Due to COVID-19 we have decided to cancel DevOpsDays Philadelphia for 2020. We will be returning in 2021, please stay tuned. For any questions or concerns, please reach out at philadelphia@devopsdays.org</p>
 </div>
 
 <div class = "row">

--- a/content/events/2020-philadelphia/welcome.md
+++ b/content/events/2020-philadelphia/welcome.md
@@ -9,6 +9,10 @@ Description = "devopsdays philadelphia 2020"
   {{< event_logo >}}
 </div>
 
+<div class = "row" style="background: #ed0b07; color: #ffffff; padding: 20px; margin: 20px; font-size: 20px">
+<p>UPDATE: Due to COVID-19 we have decided to cancel DevOpDays Philadelphia for 2020. We will be returning in 2021, please stay tuned. For any questions or concerns, please reach out at philadelphia@devopsdays.org</p>
+</div>
+
 <div class = "row">
   <div class = "col-md-2">
     <strong>Dates</strong>

--- a/data/events/2020-philadelphia.yml
+++ b/data/events/2020-philadelphia.yml
@@ -5,6 +5,8 @@ event_twitter: "DevOpsDaysPHL"
 description: "Devopsdays Philadelphia is celebrating its 5th year!"
 ga_tracking_id: "UA-61551732-3"
 
+cancel: "true"
+
 startdate: 2020-10-20T00:00:00-04:00
 enddate: 2020-10-21T23:59:59-04:00
 
@@ -27,12 +29,12 @@ location: "Science History Institute"
 location_address: "315 Chestnut St, Philadelphia, PA 19106"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: propose
+ # - name: propose
   - name: location
-  - name: registration
+ # - name: registration
  # - name: program
-  - name: speakers
-  - name: sponsor
+ # - name: speakers
+ # - name: sponsor
   - name: contact
   - name: conduct
 # - name: example

--- a/data/events/2020-philadelphia.yml
+++ b/data/events/2020-philadelphia.yml
@@ -24,13 +24,13 @@ registration_closed: "" #set this to true if you need to manually close registra
 registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 
 # Location
-coordinates: "39.9500, -75.1667"
-location: "Science History Institute"
-location_address: "315 Chestnut St, Philadelphia, PA 19106"
+# coordinates: "39.9500, -75.1667"
+# location: "Science History Institute"
+# location_address: "315 Chestnut St, Philadelphia, PA 19106"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
  # - name: propose
-  - name: location
+ # - name: location
  # - name: registration
  # - name: program
  # - name: speakers


### PR DESCRIPTION
Due to covid-19 we cancelled dod philly 2020. This removed it from the site and places a message.