### PR TITLE
[ZRH-2020] Removed Nine as sponsor from 2020 and 2021

### DIFF
--- a/content/events/2020-zurich/sponsor.md
+++ b/content/events/2020-zurich/sponsor.md
@@ -37,7 +37,7 @@ We greatly value sponsors for this open event.  If you are interested in sponsor
     <td bgcolor="#B3DEC7"><center>3</center></td>
     <td bgcolor="#B3DEC7"><center>2</center></td>
     <td bgcolor="#B3DEC7"><center>unlimited</center></td>
-    <td bgcolor="#E2B3CE"><center><b><font color=red>SOLD OUT</font></b></center></td>
+    <td bgcolor="#E2B3CE"><center>1</center></td>
     <td bgcolor="#E2B3CE"><center><b><font color=red>SOLD OUT</font></b></center></td>
   </tr>
   <tr>

--- a/content/events/2021-zurich/sponsor.md
+++ b/content/events/2021-zurich/sponsor.md
@@ -36,7 +36,7 @@ We greatly value sponsors for this open event.  If you are interested in sponsor
     <td bgcolor="#B3DEC7"><center>3</center></td>
     <td bgcolor="#B3DEC7"><center>2</center></td>
     <td bgcolor="#B3DEC7"><center>unlimited</center></td>
-    <td bgcolor="#E2B3CE"><center><b><font color=red>SOLD OUT</font></b></center></td>
+    <td bgcolor="#E2B3CE"><center>1</center></td>
     <td bgcolor="#E2B3CE"><center><b><font color=red>SOLD OUT</font></b></center></td>
   </tr>
   <tr>

--- a/data/events/2020-zurich.yml
+++ b/data/events/2020-zurich.yml
@@ -159,8 +159,6 @@ organizer_email: "zurich@devopsdays.org" # Put your organizer email address here
 sponsors:
   - id: zhlke
     level: bronze
-  - id: nine
-    level: silver
   - id: avega
     level: silver
   - id: devops-meetup-zurich

--- a/data/events/2021-zurich.yml
+++ b/data/events/2021-zurich.yml
@@ -159,8 +159,6 @@ organizer_email: "zurich@devopsdays.org" # Put your organizer email address here
 sponsors:
   - id: zhlke
     level: bronze
-  - id: nine
-    level: silver
   - id: avega
     level: silver
   - id: devops-meetup-zurich


### PR DESCRIPTION
*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
