### PR TITLE
[MDE-2020] Changes to indicate the Event in Virtual Modality

### DIFF
--- a/content/events/2020-medellin/welcome.md
+++ b/content/events/2020-medellin/welcome.md
@@ -9,7 +9,7 @@ Description = "devopsdays Medellín 2020"
     <img alt="DevOpsDays Medellin 2020" src="/events/2020-medellin/logo.png" class="img-fluid">
   </div>
   <div class="col-md-7">
-    <h2>¡La conferencia inaugural de DevOpsDays llegará a Medellín, Colombia en Julio 2020!</h2>
+    <h2>¡La conferencia inaugural de DevOpsDays llegará a Medellín de manera virtual a Colombia en Julio 2020!</h2>
     <p>
       The DevOpsDays conference arrives to Medellín, and it'll be the first DevOpsDays conference that will happen in the City!, Be part of history on July 2020!
     </p>
@@ -21,12 +21,6 @@ Description = "devopsdays Medellín 2020"
         </li>
         <li style="margin-left:15px;">
           <div>{{< event_start >}} - {{< event_end >}}</div>
-        </li>
-        <li>
-          <h3>Location</h3>
-        </li>
-        <li style="margin-left:15px;">
-          {{< event_location >}}
         </li>  
       </ul>      
     </p>

--- a/data/events/2020-medellin.yml
+++ b/data/events/2020-medellin.yml
@@ -37,8 +37,8 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: Spanish
     url: "https://devopsdays.io/"
  # - name: location
-  - name: propose
-    url: "https://www.papercall.io/devopsdaysmedellin"
+ # - name: propose
+ #   url: "https://www.papercall.io/devopsdaysmedellin"
   - name: registration
     url: "https://www.ticketopolis.com/medellindevopsdays2020"
  # - name: program

--- a/data/events/2020-medellin.yml
+++ b/data/events/2020-medellin.yml
@@ -2,7 +2,7 @@ name: "2020-medellin" # The name of the event. Four digit year with the city nam
 year: "2020" # The year of the event. Make sure it is in quotes.
 city: "Medellín" # The displayed city name of the event. Capitalize it.
 event_twitter: "DevopsdaysMed" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
-description: "DevOpsDays is coming to Medellín! More updates will be available soon." # Edit this to suit your preferences
+description: "DevOpsDays is coming to Medellín! We are going virtual! More updates will be available soon." # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
@@ -29,14 +29,14 @@ registration_link: "https://www.ticketopolis.com/medellindevopsdays2020/tickets.
 # Location
 #
 coordinates: "6.2339363,-75.5887074" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
-location: "Auditorio del Premium Plaza" # Defaults to city, but you can make it the venue name.
+location: "¡Conferencia Virtual!" # Defaults to city, but you can make it the venue name.
 #
-location_address: "Carrera 43A (Av. El Poblado) con Calle 30, Medellín, Antioquia, Colombia" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+# location_address: "Carrera 43A (Av. El Poblado) con Calle 30, Medellín, Antioquia, Colombia" #Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: Spanish
     url: "https://devopsdays.io/"
-  - name: location
+ # - name: location
   - name: propose
     url: "https://www.papercall.io/devopsdaysmedellin"
   - name: registration


### PR DESCRIPTION
Changes in the Welcome Page and the Data file to hide the location section and indicate the evenit is going virtual

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
