### PR TITLE
[BUF-2020] - Virtual Conference Reschedule

### DIFF
--- a/content/events/2020-buffalo/welcome.md
+++ b/content/events/2020-buffalo/welcome.md
@@ -18,7 +18,7 @@ Description = "devopsdays Buffalo 2020"
   <li><a href = 'https://www.cdc.gov/coronavirus/2019-ncov/index.html' target = _new>Center for Disease Control</a></li>
   <li><a href = 'http://www2.erie.gov/health/index.php?q=coronavirus' target = _new>Erie County Department of Health</a></li>
 </ul>
-<p>Stay safe, and safeguard your toilet paper! We’ll see you in September!</p>
+<p>Stay safe, and safeguard your toilet paper! We’ll see you in October!</p>
 </div>
 
 <div class = "row">

--- a/data/events/2020-buffalo.yml
+++ b/data/events/2020-buffalo.yml
@@ -10,7 +10,7 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 #   variable: 2019-01-05T23:59:59+02:00
 # Note: we allow 2020-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-startdate: 2020-09-30T00:08:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2020-10-01T00:08:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2020-10-01T00:17:00-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
@@ -21,7 +21,7 @@ cfp_date_announce:  2020-07-01T23:59:59-05:00 # inform proposers of status
 cfp_link: "https://www.papercall.io/dodbuf2020" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2020-02-25T12:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2020-09-30T08:59:59-05:00 # close registration. Leave blank if registration is not open yet.
+registration_date_end: 2020-10-01T11:59:59-05:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://ti.to/devops-days-buffalo/2020" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.


### PR DESCRIPTION
DevOpsDays Buffalo 2020 has decided, with the virtualization move, to
reduce schedule to one day, from two.

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
