### PR TITLE
[AMS-2020] Remove incorrect sharing image data

### DIFF
--- a/data/events/2020-amsterdam.yml
+++ b/data/events/2020-amsterdam.yml
@@ -5,7 +5,6 @@ event_twitter: "devopsams" # Change this to the twitter handle for your event su
 description: "devopsdays Amsterdam is back for the 8th time. Going online this time!" # Edit this to suit your preferences
 ga_tracking_id: "UA-38891729-3" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 masthead_background: "skyline-ams.jpg"
-sharing_image: "logo-rectangle.png"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00


### PR DESCRIPTION
A sharing image was specified in the datafile for 2020 Amsterdam, but that image does not exist. This removes the reference. If AMS 2020 would like to use this sharing image, a new PR will need to be submitted to add the image to the `/static/events/2020-amsterdam/sharing` directory.
