### PR TITLE
[AMS-2020] Revert back to ti.to for registration page

### DIFF
--- a/content/events/2020-amsterdam/registration.md
+++ b/content/events/2020-amsterdam/registration.md
@@ -14,5 +14,7 @@ Description = "Registration for devopsdays Amsterdam 2020"
 <br>
 
 <div class = "col-md-12">
-<iframe width="100%" height="800" frameborder="0" marginheight="0" marginwidth="0" allowtransparency="true" src="https://www.crowdcast.io/e/devopdays-online?navlinks=false&embed=true" style="border: 1px solid #EEE;border-radius:3px" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"></iframe>
+<script src='https://js.tito.io/v1' async></script>
+<link rel="stylesheet" type="text/css" href='https://css.tito.io/v1.1' />	
+<tito-widget event="devopdays-amsterdam/2020"></tito-widget>
 </div>


### PR DESCRIPTION
As we have seen issues with the crowdcast registration iframe we revert back to the Tito solution for now.
