### PR TITLE
[CHI-2020] Update Chicago 2020 code of conduct for virtual

### DIFF
--- a/content/events/2020-chicago/conduct.md
+++ b/content/events/2020-chicago/conduct.md
@@ -13,16 +13,15 @@ Our conference is dedicated to providing a harassment-free conference experience
 
 ### The Less Quick Version
 
-Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+Harassment includes offensive verbal or written comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
 
-Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
-
+Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Sponsor event staff (including volunteers) should not use sexualized imagery, clothing/uniforms/costumes, or otherwise create a sexualized environment.
 If a participant engages in harassing behavior, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately.
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the conference staff (organizer or moderator) immediately.
 
-Conference staff can be identified by distinct staff badges. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+Conference staff are identified with a separate role in the online forum (organizer or moderator).. Conference staff will be happy to help participants contact  local law enforcement or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
 
-We expect participants to follow these rules at conference and workshop venues and conference-related social events.
+We expect participants to follow these rules during the conference in all conference-related media, including Discord, YouTube, Twitter, or any other online presence. 
 
 _The devopsdays Chicago 2020 Code of Conduct is based on [confcodeofconduct.com](https://confcodeofconduct.com)._ 


### PR DESCRIPTION
Small changes to the code of conduct to remove physical venue references and add some details related to the event being virtual