### PR TITLE
Automate the process of changing a sponsor logo.

### DIFF
--- a/utilities/README.md
+++ b/utilities/README.md
@@ -60,42 +60,21 @@ If you want to update a sponsor's info, keep in mind that we don't want to retro
 
 Determine which sponsor is being discussed. For this example, we'll use Pivotal.
 
-First, we'll do filename updates. Existing sponsors have an image and a data file:
-
+Run the script `change_sponsor_logo.sh` in the `utilities` subdirectory, giving it the name of the sponsor (`pivotal`) and the path on disk to your new logo:
 ```
-static/img/sponsors/pivotal.png
-data/sponsors/pivotal.yml
-```
-
-- When a sponsor wants an update to the image, data file, or both, first you copy the current files to a new filename containing the current date:
-
-```
-cp static/img/sponsors/pivotal.png static/img/sponsors/pivotal-before-20190307.png
-cp data/sponsors/pivotal.yml data/sponsors/pivotal-before-20190307.yml
+[don@zeus ~/devopsdays-web/utilities:don/bos-lightstep]  ./change_sponsor_logo.sh pivotal ~/Downloads/pivotal.png
+Modifying 2018-chicago.yml
+Modifying 2019-detroit.yml
+Modifying 2018-chicago/conduct/index.html
+Modifying 2018-chicago/contact/index.html
+...
 ```
 
-Do this even if you're only changing one of them.
-
-Then, make sure all events in the past get the update. Edit the "- id: pivotal" line for any past events:
-
-```
-$ grep "id: pivotal" data/events/*
-[...]
-data/events/2015-minneapolis.yml:  - id: pivotal-before-20190307
-data/events/2016-atlanta.yml:  - id: pivotal-before-20190307
-data/events/2019-minneapolis.yml:  - id: pivotal
-```
-
-It is possible that the previous city has already been archived and static items have already been created. You will have to update the image source for these pages
-
-```
-grep -r "sponsors\/pivotal.png" static/events/*
-[...]
-static/events/2016-chicago/contact/index.html:<img src="/img/sponsors/pivotal.png" alt="Pivotal" title="Pivotal" class="img-fluid">
-```
-:warning: The above will require you to be comfortable with search & replace utilities as you'd potentially be modifying hundreds of files. Please ask for assistance if desired. 
-
-For the current year, you only want to make the edits if the event has already happened.
+Under the hood, the script is:
+1. Copying the existng sponsor files to `sponsor-before-todaysdate.{png,yml}`.
+1. Copying in the new image to `sponsor.png`.
+1. Modifying any events that did _not_ occur this year such that they are sponsored by `sponsor-before-todaysdate`, rather than `sponsor`.
+1. Modifying any archived events such that they are sponsored by `sponsor-before-todaysdate`, rather than `sponsor`.
 
 This means that if a sponsor asks for an update affecting all future events, the shared sponsor entry will be changed for all events without any intervention needed from local organizers who have listed that sponsor. This is a benefit to using the shared sponsor entry.
 

--- a/utilities/README.md
+++ b/utilities/README.md
@@ -60,7 +60,7 @@ If you want to update a sponsor's info, keep in mind that we don't want to retro
 
 Determine which sponsor is being discussed. For this example, we'll use Pivotal.
 
-Run the script `change_sponsor_logo.sh` in the `utilities` subdirectory, giving it the name of the sponsor (`pivotal`) and the path on disk to your new logo:
+Run the script `change_sponsor_logo.sh` in the `utilities` subdirectory, giving it the name of the sponsor (`pivotal`) and the **full path** on disk to your new logo:
 ```
 $ ./change_sponsor_logo.sh pivotal ~/Downloads/pivotal.png
 Modifying 2018-chicago.yml

--- a/utilities/README.md
+++ b/utilities/README.md
@@ -62,7 +62,7 @@ Determine which sponsor is being discussed. For this example, we'll use Pivotal.
 
 Run the script `change_sponsor_logo.sh` in the `utilities` subdirectory, giving it the name of the sponsor (`pivotal`) and the path on disk to your new logo:
 ```
-[don@zeus ~/devopsdays-web/utilities:don/bos-lightstep]  ./change_sponsor_logo.sh pivotal ~/Downloads/pivotal.png
+$ ./change_sponsor_logo.sh pivotal ~/Downloads/pivotal.png
 Modifying 2018-chicago.yml
 Modifying 2019-detroit.yml
 Modifying 2018-chicago/conduct/index.html

--- a/utilities/add_new_event.sh
+++ b/utilities/add_new_event.sh
@@ -1,22 +1,10 @@
 #!/bin/bash
 
-
 set -e
 
-cd `dirname ${0}`
+source common_code
 
-# Detect OS for correct 'sed' syntax
-OSNAME=`uname`
-GNUSED=$(which sed)
-SEDCMD(){
-  if [[ $OSNAME == 'Linux' ]]; then
-    sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
-    sed -i "$@"
-  else
-    sed -i '' "$@"
-  fi
-}
+cd `dirname ${0}`
 
 if [[ $(date +"%m") -ge 10 ]]; then
   default_year=$(echo $(echo `date +"%Y"` + 1) | bc)
@@ -52,10 +40,10 @@ event_slug=$year-$city_slug
 # Update the redirection for a previous year of this event to the desired year
 if grep -q "^/$city_slug" "../static/_redirects";
 then
-    SEDCMD "/^\/$city_slug/ s/.\{4\}-$city_slug/$event_slug/" "../static/_redirects"
+    sedcmd "/^\/$city_slug/ s/.\{4\}-$city_slug/$event_slug/" "../static/_redirects"
 else
 # If a previous-year event does not exist, create the redirection for the desired year
-  SEDCMD -e '$a\' "../static/_redirects"
+  sedcmd -e '$a\' "../static/_redirects"
   echo "/$city_slug/*            /events/$event_slug/:splat           302" >> "../static/_redirects"
 fi
 
@@ -63,24 +51,24 @@ fi
 eventdatafile="../data/events/$event_slug.yml"
 cp examples/data/events/yyyy-city.yml $eventdatafile
 
-SEDCMD "s/YYYY/$year/" $eventdatafile
-SEDCMD "s/City/$city/" $eventdatafile
-SEDCMD "s/yourlocation/$city/" $eventdatafile
-SEDCMD "s/yyyy-city/$event_slug/" $eventdatafile
-SEDCMD "s/devopsdayscityabbr/$twitter/" $eventdatafile
+sedcmd "s/YYYY/$year/" $eventdatafile
+sedcmd "s/City/$city/" $eventdatafile
+sedcmd "s/yourlocation/$city/" $eventdatafile
+sedcmd "s/yyyy-city/$event_slug/" $eventdatafile
+sedcmd "s/devopsdayscityabbr/$twitter/" $eventdatafile
 
 # Name the email list
-SEDCMD "s/city_email/$city_slug/" $eventdatafile
+sedcmd "s/city_email/$city_slug/" $eventdatafile
 
 # Seed initial files for event
 cp -r examples/content/events/yyyy-city ../content/events/$event_slug
 
 # Setting the creation date at the time the event is instantiated
 datestamp=$(date +%Y-%m-%dT%H:%M:%S%z | sed 's/^\(.\{22\}\)/\1:/')
-SEDCMD "s/2000-01-01T01:01:01-06:00/$datestamp/" ../content/events/$event_slug/*.md
-SEDCMD "s/yyyy-city/$event_slug/" ../content/events/$event_slug/welcome.md
-SEDCMD "s/CITY/$city/" ../content/events/$event_slug/*.md
-SEDCMD "s/YYYY/$year/" ../content/events/$event_slug/*.md
+sedcmd "s/2000-01-01T01:01:01-06:00/$datestamp/" ../content/events/$event_slug/*.md
+sedcmd "s/yyyy-city/$event_slug/" ../content/events/$event_slug/welcome.md
+sedcmd "s/CITY/$city/" ../content/events/$event_slug/*.md
+sedcmd "s/YYYY/$year/" ../content/events/$event_slug/*.md
 
 echo " "
 echo "Check your event at http://localhost:1313/events/$event_slug/"

--- a/utilities/add_new_event.sh
+++ b/utilities/add_new_event.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-source common_code
-
 cd `dirname ${0}`
+source common_code
 
 if [[ $(date +"%m") -ge 10 ]]; then
   default_year=$(echo $(echo `date +"%Y"` + 1) | bc)

--- a/utilities/add_organizers.sh
+++ b/utilities/add_organizers.sh
@@ -6,20 +6,6 @@ cd `dirname ${0}`
 
 OUT=$(mktemp /tmp/output.XXXXXXXXXX) || { echo "Failed to create temp file"; exit 1; }
 
-
-# Detect OS for correct 'sed' syntax
-OSNAME=`uname`
-GNUSED=$(which sed)
-SEDCMD(){
-  if [[ $OSNAME == 'Linux' ]]; then
-    sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
-    sed -i "$@"
-  else
-    sed -i '' "$@"
-  fi
-}
-
 # Get year
 default_year=$(date +"%Y")
 if [[ ! -z $DOD_YEAR ]] ; then

--- a/utilities/add_organizers.sh
+++ b/utilities/add_organizers.sh
@@ -3,6 +3,7 @@
 set -e
 
 cd `dirname ${0}`
+source common_code
 
 OUT=$(mktemp /tmp/output.XXXXXXXXXX) || { echo "Failed to create temp file"; exit 1; }
 

--- a/utilities/add_program.sh
+++ b/utilities/add_program.sh
@@ -2,20 +2,9 @@
 
 set -e
 
-cd `dirname ${0}`
+source common_code
 
-# Detect OS for correct 'sed' syntax
-OSNAME=`uname`
-GNUSED=$(which sed)
-SEDCMD(){
-  if [[ $OSNAME == 'Linux' ]]; then
-    sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
-    sed -i "$@"
-  else
-    sed -i '' "$@"
-  fi
-}
+cd `dirname ${0}`
 
 # Get year
 default_year=$(date +"%Y")
@@ -50,14 +39,14 @@ fi
 
 
 # uncomment link to program page
-SEDCMD "s/#  - name: program/  - name: program/" ../data/events/$event_slug.yml
+sedcmd "s/#  - name: program/  - name: program/" ../data/events/$event_slug.yml
 
 # Append program to datafile
 cat examples/templates/program.yml >> ../data/events/$event_slug.yml
 
 # set correct start and end dates (manual intervention needed for events that aren't two-day)
-SEDCMD "s/day1/$day1/g" ../data/events/$event_slug.yml
-SEDCMD "s/day2/$day2/g" ../data/events/$event_slug.yml
+sedcmd "s/day1/$day1/g" ../data/events/$event_slug.yml
+sedcmd "s/day2/$day2/g" ../data/events/$event_slug.yml
 
 
 # Display available speakers
@@ -70,12 +59,12 @@ read -p "Enter your number of full-talk speakers (default: 8)): " num
 for talknumber in $(seq 1 $num);
 do
   read -p "Enter speaker $talknumber in firstname-lastname form; use CTRL+C to stop... " speaker_slug
-  SEDCMD "s/talk-$talknumber/$speaker_slug/" ../data/events/$event_slug.yml
+  sedcmd "s/talk-$talknumber/$speaker_slug/" ../data/events/$event_slug.yml
 done
 
 # Create empty program page file (will be auto-filled for display)
 programpage="../content/events/$event_slug/program.md"
 cp examples/templates/program.md $programpage
-SEDCMD "s/CITY/$city/" $programpage
-SEDCMD "s/YYYY/$year/" $programpage
+sedcmd "s/CITY/$city/" $programpage
+sedcmd "s/YYYY/$year/" $programpage
 

--- a/utilities/add_speakers.sh
+++ b/utilities/add_speakers.sh
@@ -2,20 +2,9 @@
 
 set -e
 
-cd `dirname ${0}`
+source common_code
 
-# Detect OS for correct 'sed' syntax
-OSNAME=`uname`
-GNUSED=$(which sed)
-SEDCMD(){
-  if [[ $OSNAME == 'Linux' ]]; then
-    sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
-    sed -i "$@"
-  else
-    sed -i '' "$@"
-  fi
-}
+cd `dirname ${0}`
 
 # Get year
 default_year=$(date +"%Y")
@@ -45,11 +34,11 @@ mkdir -p ../static/events/$event_slug/speakers
 # Create empty speakers page file (will be auto-filled for display)
 speakerspage="../content/events/$event_slug/speakers.md"
 cp examples/templates/speakers.md $speakerspage
-SEDCMD "s/CITY/$city/" $speakerspage
-SEDCMD "s/YYYY/$year/" $speakerspage
+sedcmd "s/CITY/$city/" $speakerspage
+sedcmd "s/YYYY/$year/" $speakerspage
 
 # uncomment link to speakers page
-SEDCMD "s/#  - name: speakers/  - name: speakers/" ../data/events/$event_slug.yml
+sedcmd "s/#  - name: speakers/  - name: speakers/" ../data/events/$event_slug.yml
 
 
 # Prompt for inputting speakers
@@ -67,20 +56,20 @@ speaker_slug=$(echo $speakername | tr -dc '[:alpha:][:blank:]' | tr '[:upper:]' 
 speakerfile="../content/events/$event_slug/speakers/$speaker_slug.md"
 cp examples/templates/speakers-speaker-full-name.md $speakerfile
 
-SEDCMD "s/SPEAKERNAME/$speakername/" $speakerfile
-SEDCMD "s/SPEAKERSLUG/$speaker_slug/" $speakerfile
+sedcmd "s/SPEAKERNAME/$speakername/" $speakerfile
+sedcmd "s/SPEAKERSLUG/$speaker_slug/" $speakerfile
 
 # twitter handle
 read -p "Enter speaker twitter handle (return for none): " twitter
 [ -z "${twitter}" ] && twitter=''
 # remove @ if they added it
 twitter=$(echo $twitter | sed 's/@//')
-SEDCMD "s/SPEAKERTWITTER/$twitter/" $speakerfile
+sedcmd "s/SPEAKERTWITTER/$twitter/" $speakerfile
 
 # bio
 read -p "Enter speaker bio (return for none): " bio
 [ -z "${bio}" ] && bio=''
-SEDCMD "s/SPEAKERBIO/$bio/" $speakerfile
+sedcmd "s/SPEAKERBIO/$bio/" $speakerfile
 
 ####################
 # Populate talk file
@@ -88,17 +77,17 @@ SEDCMD "s/SPEAKERBIO/$bio/" $speakerfile
 talkfile="../content/events/$event_slug/program/$speaker_slug.md"
 cp examples/templates/program-speaker-full-name.md $talkfile
 
-SEDCMD "s/SPEAKERSLUG/$speaker_slug/" $talkfile
+sedcmd "s/SPEAKERSLUG/$speaker_slug/" $talkfile
 
 # talk title
 read -p "Enter speaker talk title (return for none): " title
 [ -z "${title}" ] && title=''
-SEDCMD "s/TALKTITLE/$title/" $talkfile
+sedcmd "s/TALKTITLE/$title/" $talkfile
 
 # talk description
 read -p "Enter speaker talk description (return for none): " abstract
 [ -z "${abstract}" ] && abstract=''
-SEDCMD "s/ABSTRACT/$abstract/" $talkfile
+sedcmd "s/ABSTRACT/$abstract/" $talkfile
 
 #######################
 # Set speaker image
@@ -109,7 +98,7 @@ read -p "Enter path to speaker image PNG: " speakerimage
 
 if [ $speakerimage ]; then
   cp "$speakerimage" ../static/events/$event_slug/speakers/$speaker_slug.png
-  SEDCMD "s/image = \"\"/image = \"$speaker_slug.png\"/" $speakerfile
+  sedcmd "s/image = \"\"/image = \"$speaker_slug.png\"/" $speakerfile
 else
   echo "Put speaker image at ../static/events/$event_slug/speakers/$speaker_slug.png before creating the pull request, if desired."
 fi

--- a/utilities/add_speakers.sh
+++ b/utilities/add_speakers.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+cd `dirname ${0}`
 source common_code
 
 cd `dirname ${0}`

--- a/utilities/add_sponsors.sh
+++ b/utilities/add_sponsors.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-source common_code
-
 cd `dirname ${0}`
+source common_code
 
 # Get year
 default_year=$(date +"%Y")

--- a/utilities/add_sponsors.sh
+++ b/utilities/add_sponsors.sh
@@ -2,19 +2,9 @@
 
 set -e
 
+source common_code
+
 cd `dirname ${0}`
-# Detect OS for correct 'sed' syntax
-OSNAME=`uname`
-GNUSED=$(which sed)
-SEDCMD(){
-  if [[ $OSNAME == 'Linux' ]]; then
-    sed -i "$@"
-  elif [[ $OSNAME == 'Darwin' && $GNUSED == '/usr/local/bin/sed' ]]; then
-    sed -i "$@"
-  else
-    sed -i '' "$@"
-  fi
-}
 
 # Get year
 default_year=$(date +"%Y")
@@ -68,8 +58,8 @@ read -p "Enter path to PNG logo (must be at least 200px wide & have white or tra
 # Populate data file
 cp examples/data/sponsors/sponsorname.yml $sponsorfile
 
-SEDCMD "s/SPONSORNAME/$sponsorname/" $sponsorfile
-SEDCMD "s%URL%$url%" $sponsorfile
+sedcmd "s/SPONSORNAME/$sponsorname/" $sponsorfile
+sedcmd "s%URL%$url%" $sponsorfile
 
 if ! [ -z "${twitter}" ]; then
   echo "twitter: \"${twitter}\"" >> $sponsorfile

--- a/utilities/change_sponsor_logo.sh
+++ b/utilities/change_sponsor_logo.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+##
+# This script takes in a sponsor name, and path to a new logo. It replaces
+# all occurrences of the "old" logo in "old" events with an "old" sponsor
+# definition, and adds the new logo in its place for this year's events.
+##
+
+source common_code
+SPONSOR_NAME=${1:-}
+IMAGE_TO_COPY=${2:-}
+TODAY=$(date +%Y%m%d)
+
+# Make sure we have everything we need to run.
+
+if [ $# -ne 2 ]; then
+  echo "Update a sponsor logo, retroactively changing any past events to use the old logo."
+  echo "USAGE: sponsor_name path/to/new/image.png"
+  exit 1
+fi
+
+IMAGE_FILE="$(gitroot)/static/img/sponsors/$SPONSOR_NAME.png"
+if [ ! -f "$IMAGE_FILE" ]; then
+  echo "Couldn't find a sponsor image at $IMAGE_FILE."
+  exit 1
+fi
+
+SPONSOR_FILE="$(gitroot)/data/sponsors/$SPONSOR_NAME.yml"
+if [ ! -f "$SPONSOR_FILE" ]; then
+  echo "Couldn't find a sponsor definition at $SPONSOR_FILE."
+  exit 1
+fi
+
+if [ ! -f "$IMAGE_TO_COPY" ]; then
+  echo "Couldn't find new sponsor image at $IMAGE_TO_COPY."
+  exit 1
+fi
+
+# Start by copying the existing definitions as the "old" definitions
+
+OLD_IMAGE_FILE=$(gitroot)/static/img/sponsors/$SPONSOR_NAME-before-$TODAY.png
+OLD_SPONSOR_FILE=$(gitroot)/data/sponsors/$SPONSOR_NAME-before-$TODAY.yml
+
+cp "$IMAGE_FILE" "$OLD_IMAGE_FILE"
+cp "$SPONSOR_FILE" "$OLD_SPONSOR_FILE"
+
+# Find all events with this sponsor in years other than this year, excluding existing renames
+SPONSOR_REGEX="id:[ ]+$SPONSOR_NAME[ $]*"
+pushd "$(gitroot)/data/events" > /dev/null
+EVENTS_TO_MODIFY=($(grep -E "$SPONSOR_REGEX" * | grep -v "^$(date +%Y)" | cut -d ':' -f 1))
+
+# Modify the events.
+for event_file in "${EVENTS_TO_MODIFY[@]}"; do
+  echo "Modifying $event_file"
+  sedcmd -E "s/$SPONSOR_REGEX/id: $SPONSOR_NAME-before-$TODAY/" $event_file
+done
+popd > /dev/null
+
+# Put the new image in place.
+cp "$IMAGE_TO_COPY" "$IMAGE_FILE"
+
+# Modify any archived events.
+pushd "$(gitroot)/static/events" > /dev/null
+ARCHIVED_FILES_TO_MODIFY=($(grep -r "sponsors/$SPONSOR_NAME.png" * | cut -d ':' -f 1))
+for archived_file in "${ARCHIVED_FILES_TO_MODIFY[@]}"; do
+  echo "Modifying $archived_file"
+  sedcmd "s/sponsors\/$SPONSOR_NAME.png/sponsors\/$SPONSOR_NAME-before-$TODAY.png/g" $archived_file
+done
+popd > /dev/null

--- a/utilities/change_sponsor_logo.sh
+++ b/utilities/change_sponsor_logo.sh
@@ -7,7 +7,9 @@ set -euo pipefail
 # definition, and adds the new logo in its place for this year's events.
 ##
 
+cd `dirname ${0}`
 source common_code
+
 SPONSOR_NAME=${1:-}
 IMAGE_TO_COPY=${2:-}
 TODAY=$(date +%Y%m%d)
@@ -16,7 +18,7 @@ TODAY=$(date +%Y%m%d)
 
 if [ $# -ne 2 ]; then
   echo "Update a sponsor logo, retroactively changing any past events to use the old logo."
-  echo "USAGE: sponsor_name path/to/new/image.png"
+  echo "USAGE: sponsor_name /full/path/to/new/image.png"
   exit 1
 fi
 

--- a/utilities/common_code
+++ b/utilities/common_code
@@ -1,0 +1,18 @@
+# Get the absolute path of the root of the repo
+function gitroot() {
+  git rev-parse --show-toplevel
+}
+
+# Detect OS for correct 'sed' syntax
+function sedcmd() {
+  local osname=`uname`
+  local gnused=$(which sed)
+
+  if [[ $osname == 'Linux' ]]; then
+    sed -i "$@"
+  elif [[ $osname == 'Darwin' && $gnused == '/usr/local/bin/sed' ]]; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}


### PR DESCRIPTION
This script implements the process defined in the [instructions for updating a sponsor image](https://github.com/devopsdays/devopsdays-web/blob/master/utilities/README.md#updating-a-sponsor-image-or-data). I also library-ified `sedcmd`, as I wanted it in my script, but didn't want to copy-paste it.

The output of this script can be seen at #9903.

**Note that I only tested this on a Linux box.** I don't know that I haven't broken any functionality on macOS.