### PR TITLE
[buf-2020] Link directly to ti.to/ reg. page

### DIFF
--- a/content/events/2020-buffalo/welcome.md
+++ b/content/events/2020-buffalo/welcome.md
@@ -46,7 +46,7 @@ Description = "devopsdays Buffalo 2020"
     <strong>Register</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_link page="registration" text="Register to attend the conference!" >}}
+    <a href="https://ti.to/devops-days-buffalo/2020">Register to attend the conference!</a>
   </div>
 </div>
 


### PR DESCRIPTION
Rather than bounce people through a page that consists entirely of one
link to ti.to/..., just link them directly there from the main page and
skip the /registration page.