### PR TITLE
[core] Nathen moves to Advisory role

### DIFF
--- a/data/core.toml
+++ b/data/core.toml
@@ -4,7 +4,6 @@ active = [
 "Jennifer Davis",
 "Bernd Erk",
 "Rafael Gomes",
-"Nathen Harvey",
 "Mine Heck",
 "Dan Maher",
 "Katie McLaughlin",
@@ -21,7 +20,8 @@ advisory = [
 "Kris Buytaert",
 "Matthew Jones",
 "Andrew Clay Shafer",
-"John Willis"
+"John Willis",
+"Nathen Harvey"
 ]
 
 emeritus = [


### PR DESCRIPTION
Recognizing current and likely future reality, I would like to move from 'Active' to 'Advisory'.

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>

