### PR TITLE
[Detroit 2020] canceled

### DIFF
--- a/data/events/2020-detroit.yml
+++ b/data/events/2020-detroit.yml
@@ -10,7 +10,7 @@ ga_tracking_id: "UA-94092408-1" # If you have your own Google Analytics tracking
 #   variable: 2019-01-05T23:59:59+02:00
 # Note: we allow 2020-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-# cancel: "true"
+cancel: "true"
 startdate: 2020-11-11T00:00:00+02:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
 enddate: 2020-11-12T23:59:59+02:00 # The end date of your event. Leave blank if you don't have a venue reserved yet. date of your event. Leave blank if you don't have a venue reserved yet.
 


### PR DESCRIPTION
Hi @rexroof - in https://github.com/devopsdays/devopsdays-web/pull/9945 you canceled the Detroit 2020 event, but you did not properly mark it so it would stop showing up as an upcoming event. This PR corrects that so it no longer displays as upcoming.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
