### PR TITLE
[CHI-2020] Update program with youtube link

### DIFF
--- a/content/events/2020-chicago/program.md
+++ b/content/events/2020-chicago/program.md
@@ -7,4 +7,4 @@ icons = "TRUE"
 
 ### All times are CDT
 
-All talks can be viewed at [live.devopsdayschi.org](https://live.devopsdayschi.org).
+All talks can be viewed at [this YouTube playlist](https://www.youtube.com/playlist?list=PL4z5H5AKpft0cn5i05QfI_326pvjJRne3).


### PR DESCRIPTION
Points the program to the youtube link instead of the live event
