### PR TITLE
[ZRH-2021] Resheduled DevOpsDays ZRH 2021 to September due to COVID

### DIFF
--- a/data/events/2021-zurich.yml
+++ b/data/events/2021-zurich.yml
@@ -11,19 +11,19 @@ event_group: "Zürich"
 #   variable: 2021-09-09T23:59:59+02:00
 # Note: we allow 2021-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-startdate:  2021-04-21T00:00:00+02:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2021-04-22T23:59:59+02:00 # The end date of your event. Leave blank if you don't have a venue reserved yet. 
+startdate:  2021-09-07T00:00:00+02:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2021-09-08T23:59:59+02:00 # The end date of your event. Leave blank if you don't have a venue reserved yet. 
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  2019-11-18T00:00:00+02:00 # start accepting talk proposals.
-cfp_date_end:  2020-03-15T23:59:59+02:00 # close your call for proposals.
-cfp_date_announce: 2020-04-30T00:00:00+02:00 # inform proposers of status
+cfp_date_start:  2021-02-08T00:00:00+02:00 # start accepting talk proposals.
+cfp_date_end:  2021-05-31T23:59:59+02:00 # close your call for proposals.
+cfp_date_announce: 2020-06-01T00:00:00+02:00 # inform proposers of status
 
 cfp_open: "true"
 cfp_link: "https://sessionize.com/devopsdayszh-2020/" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2020-02-10T00:00:00+02:00
-registration_date_end: 2021-04-20T00:00:00+02:00
+registration_date_start: 2021-02-01T00:00:00+02:00
+registration_date_end: 2021-09-06T00:00:00+02:00
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://ti.to/dod/dodzh2020" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.


### PR DESCRIPTION
*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
