### PR TITLE
[Kraków-2021] add missing team member

### DIFF
--- a/data/events/2021-krakow.yml
+++ b/data/events/2021-krakow.yml
@@ -59,6 +59,7 @@ team_members: # Name is the only required field for team members.
   - name: "Jakub Barć"
   - name: "Piotr Godowski"
   - name: "Konrad Gądek"
+  - name: "Janusz Kamieński"
   - name: "Adam Kozłowski"
   - name: "Marcin Lewandowski"
   - name: "Michał Różycki"


### PR DESCRIPTION
In the event stub in devopsdays/devopsdays-web#10114, I've missed Janusz from the list.