### PR TITLE
[BOS-2021] 2021 CFP

### DIFF
--- a/content/events/2021-boston/sponsor.md
+++ b/content/events/2021-boston/sponsor.md
@@ -10,7 +10,7 @@ Description = "Sponsor DevOpsDays Boston 2021"
 <div class="col-md-9">
 <div>
 <h3>Join the community</h3>
-<p><strong>DevOpsDays Boston Virtual</strong> is a one-day online technology community conference that will be held this year on September 27 using a virtual conference platform.</p>
+<p><strong>DevOpsDays Boston Virtual</strong> is an online technology community conference that will be held this year on September 27 using a virtual conference platform.</p>
 <p>The conference is designed to promote awareness around bridging gaps and breaking down silos between development, operations, and security teams and their related business organizations.</p>
 <p>DevOpsDays is a grassroots event for professionals in technology to network and share ideas and challenges relating to DevOps, IT management, and technology in general. It is organized by peers who care about and believe in improving the culture of technology work, process automation, metrics, and sharing in an environment of inclusion.</p>
 <h3>Why Sponsor DevOpsDays Boston?</h3>

--- a/content/events/2021-boston/welcome.md
+++ b/content/events/2021-boston/welcome.md
@@ -19,7 +19,7 @@ h1.welcome-page { text-transform: initial; }
   <div class="col-md-6">
     <div class="row">
       <div class="col-md-2"><strong>Dates</strong></div>
-      <div class="col-md-8">{{< event_start >}}</div>
+      <div class="col-md-8">{{< event_start >}}-{{< event_end >}}</div>
     </div>
     <div class="row">
       <div class="col-md-2"><strong>Location</strong></div>

--- a/data/events/2021-boston.yml
+++ b/data/events/2021-boston.yml
@@ -11,14 +11,14 @@ ga_tracking_id: "UA-137417319-4" # If you have your own Google Analytics trackin
 # Note: we allow 2021-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
 startdate: "2021-09-27T09:00:00-04:00" # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate: "2021-09-27T17:00:00-04:00"  # The end date of your event. Leave blank if you don't have a venue reserved yet.
+enddate: "2021-09-28T17:00:00-04:00"  # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:  # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_start: "2021-02-17T00:00:00Z" # start accepting talk proposals.
+cfp_date_end: "2021-04-02T23:59:00Z" # close your call for proposals.
+cfp_date_announce: "2021-02-17T00:00:00Z" # inform proposers of status
 
-cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_link: "https://www.papercall.io/dodbos21" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
 registration_date_end: # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.


### PR DESCRIPTION
Update the site to reflect that our CFP is live.

We've dropped the explicit one-day verbiage where applicable, to take a
conservative stance on:
1. Ensuring that speakers are prepared to speak either day.
2. Not explicitly calling out that sponsorship is a two-day affair.
...as we are still in the process of evaluating whether to run a one-
or two-day event virtually this year.