### PR TITLE
[MSP 2021] Add mattermost as silver sponsor

### DIFF
--- a/data/events/2021-minneapolis.yml
+++ b/data/events/2021-minneapolis.yml
@@ -125,6 +125,8 @@ sponsors:
     level: silver
   - id: hashicorp
     level: gold
+  - id: mattermost
+    level: silver
 
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link


### PR DESCRIPTION
Add Mattermost as silver sponsor for Minneapolis 2021
