### PR TITLE
[SEA-2021] Add sonatype as a silver sponsor

### DIFF
--- a/data/events/2021-seattle.yml
+++ b/data/events/2021-seattle.yml
@@ -84,6 +84,8 @@ sponsors:
     level: gold
   - id: styra
     level: silver
+  - id: sonatype
+    level: silver
   - id: mattermost
     level: bronze
   - id: opsdrill


### PR DESCRIPTION
Adding sonatype as a silver sponsor for Seattle 2021
