### PR TITLE
[BOS-2021] Remove Start-up Alley tier

### DIFF
--- a/content/events/2021-boston/sponsor.md
+++ b/content/events/2021-boston/sponsor.md
@@ -48,7 +48,7 @@ Sponsorship Packages
 </td>
 </tr>
 <tr>
-<th scope="row">Dedicated Breakous w/ Main Stage Reminders</th>
+<th scope="row">Dedicated Breakouts w/ Main Stage Reminders</th>
 <td></td>
 <td>
 <center>1hr</center>
@@ -135,14 +135,6 @@ Sponsorship Packages
 <center>$2,500</center>
 </td>
 </tr>
-<tr>
-<th scope="row">StartUp Alley</th>
-<td>
-<center>4</center>
-</td>
-<td>
-<center>$1,000</center>
-</td>
 </tr>
 <tr>
 <th scope="row">Donations to Underrepresentation Partners</th>

--- a/data/events/2021-boston.yml
+++ b/data/events/2021-boston.yml
@@ -122,7 +122,5 @@ sponsor_levels:
     label: Community
   - id: alacarte
     label: A la carte
-  - id: startup
-    label: Start-up alley
   - id: academic
     label: Academic


### PR DESCRIPTION
We're not going to be running the startup alley tier virtually
this year, as the value add is not there for sponsors at this tier.
