### PR TITLE
[BOS-2021] Change a-la-carte sponsorship tiers

### DIFF
--- a/content/events/2021-boston/sponsor.md
+++ b/content/events/2021-boston/sponsor.md
@@ -41,7 +41,6 @@ Sponsorship Packages
 </tr>
 <tr>
 <th scope="row">Minutes on virtual stage during conference</th>
-</td>
 <td></td>
 <td>
 <center>5</center>
@@ -105,7 +104,7 @@ Sponsorship Packages
 <center>1</center>
 </td>
 <td>
-<center>$8,000</center>
+<center>$2,500</center>
 </td>
 </tr>
 <tr>
@@ -114,27 +113,8 @@ Sponsorship Packages
 <center>1</center>
 </td>
 <td>
-<center>$5,000</center>
-</td>
-</tr>
-<tr>
-<th scope="row">Videography & post-processing</th>
-<td>
-<center>1</center>
-</td>
-<td>
-<center>$5,000</center>
-</td>
-</tr>
-<tr>
-<th scope="row">Pre-event Hangout</th>
-<td>
-<center>1</center>
-</td>
-<td>
 <center>$2,500</center>
 </td>
-</tr>
 </tr>
 <tr>
 <th scope="row">Donations to Underrepresentation Partners</th>


### PR DESCRIPTION
We are updating our a-la-carte sponsorship tiers to be more amenable
to the needs of a fully virtual conference, where sponsors cannot
justify a $5k or $8k price tag without screen time. We are also
dropping the pre-event hangout entirely, as it is not feasible to run
virtually with a sponsor, plus the videography, which is a built-in
of the virtual platform.
