### PR TITLE
[BOS-2021] Launch Darkly sponsorship

### DIFF
--- a/data/events/2021-boston.yml
+++ b/data/events/2021-boston.yml
@@ -118,6 +118,8 @@ sponsors:
     level: platinum
   - id: coralogix
     level: platinum
+  - id: launch-darkly
+    level: alacarte
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 
@@ -131,7 +133,7 @@ sponsor_levels:
   - id: community
     label: Community
   - id: alacarte
-    label: A la carte
+    label: Captioning and Live Graphics
   - id: academic
     label: Academic
 


### PR DESCRIPTION
Launch Darkly is sponsoring our captioning and live graphics.