### PR TITLE
[BUF-2021] Fixed sponsorships

### DIFF
--- a/data/events/2021-buffalo.yml
+++ b/data/events/2021-buffalo.yml
@@ -101,11 +101,13 @@ sponsors:
     level: silver
   - id: pagerduty
     level: bronze
+  - id: redhat
+    level: bronze
   - id: torchio
     level: silver
   - id: circleci
     level: silver
-  - id: trendmicro
+  - id: skycrafters
     level: silver
   - id: starkandwayne
     level: gold


### PR DESCRIPTION
Changed TrendMicro to Skycrafters for the silver sponsorship.
Added RedHat as a bronze sponsor.
