### PR TITLE
[BOS-2021] Preferred logo for Progress

### DIFF
--- a/data/events/2021-boston.yml
+++ b/data/events/2021-boston.yml
@@ -112,7 +112,7 @@ sponsors:
     level: platinum
   - id: capitalone
     level: platinum
-  - id: progress
+  - id: chef
     level: platinum
   - id: cloudtruth
     level: platinum


### PR DESCRIPTION
I have not followed the usual process of changing a sponsor logo, because Boston 2021 is the _only_ sponsorship for Progress so far.
