### PR TITLE
[DC-2021] Push event date to November

### DIFF
--- a/content/events/2021-washington-dc/announcement.md
+++ b/content/events/2021-washington-dc/announcement.md
@@ -6,7 +6,7 @@ Description = "Organizer Announcement for devopsdays Washington, D.C. 2021"
 
 DevOpsDays DC Community--
 
-During these difficult and different times, we are trying to create the best possible event for you because you deserve it. We recently decided we needed a little bit of extra time, thought, and effort to do that. As we started the plannig for this year's event, our discussions and feedback we received from some of you indicated feelings of exhaustion with virtual conferences this year and a general sense of “meh” with them recently. All the more reason to give ourselves more time and space to create the kind of event you'll be excited to attend.
+During these difficult and different times, we are trying to create the best possible event for you because you deserve it. We recently decided we needed a little bit of extra time, thought, and effort to do that. As we started the planning for this year's event, our discussions and feedback we received from some of you indicated feelings of exhaustion with virtual conferences this year and a general sense of “meh” with them recently. All the more reason to give ourselves more time and space to create the kind of event you'll be excited to attend.
 
 For all those reasons, we decided to move the event from its original two-day format on September 16-17 to one day on November 4. By moving the date back, we will have more time to put together an impactful and exciting program you've come to expect from us in past years.
 

--- a/content/events/2021-washington-dc/announcement.md
+++ b/content/events/2021-washington-dc/announcement.md
@@ -1,0 +1,20 @@
++++
+Title = "DevOpsDays DC Organizer Announcement"
+Type = "event"
+Description = "Organizer Announcement for devopsdays Washington, D.C. 2021"
++++
+
+DevOpsDays DC Community--
+
+During these difficult and different times, we are trying to create the best possible event for you because you deserve it. We recently decided we needed a little bit of extra time, thought, and effort to do that. As we started the plannig for this year's event, our discussions and feedback we received from some of you indicated feelings of exhaustion with virtual conferences this year and a general sense of “meh” with them recently. All the more reason to give ourselves more time and space to create the kind of event you'll be excited to attend.
+
+For all those reasons, we decided to move the event from its original two-day format on September 16-17 to one day on November 4. By moving the date back, we will have more time to put together an impactful and exciting program you've come to expect from us in past years.
+
+If you have any ideas or feedback you’d like to share about the event or our decision, we would love to hear from you. 
+
+Thank you so much for your support, patience and partnership with us, and most importantly, for being a part of this amazing community that means so much to us.
+
+We look forward to seeing all of you in November!
+
+--The DevOpsDays DC 2021 Organizers
+

--- a/content/events/2021-washington-dc/welcome.md
+++ b/content/events/2021-washington-dc/welcome.md
@@ -10,9 +10,11 @@ Description = "DevOpsDays Washington, D.C. 2021"
     {{< event_logo >}}
   </span>
 
-  After a pandemic-induced year off, DevOpsDays DC is returning in September 2021. We'll be virtual this year and hope (fingers crossed) to be back in person in 2022.
+  After a pandemic-induced year off, DevOpsDays DC is returning for a one-day event in November 2021. We'll be virtual this year and hope (fingers crossed) to be back in person in 2022.
 
-  The Call for Proposals is now <a href="https://devopsdaysdc2021.busyconf.com/proposals/new">OPEN</a>!
+  The Call for Proposals is now <a href="https://devopsdaysdc2021.busyconf.com/proposals/new">OPEN</a>! You have a great story and we want to hear from you -- especially if you haven't shared your voice with us before. If you'd like some help from the organizers in talking through your ideas or even shaping your presentation, we'd love to do that. Just get in touch with the organizers and let us know.
+
+  You may have noticed we changed our original event dates from September 16-17 to November 4. We share more about that change in this {{< event_link page="announcement" text="announcement" >}}.
 </p>
 
 <div class = "row">
@@ -20,7 +22,7 @@ Description = "DevOpsDays Washington, D.C. 2021"
     <strong>Dates</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_start >}} - {{< event_end >}}
+    {{< event_start >}}
   </div>
 </div>
 

--- a/data/events/2021-washington-dc.yml
+++ b/data/events/2021-washington-dc.yml
@@ -10,13 +10,13 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 #   variable: 2019-01-05T23:59:59+02:00
 # Note: we allow 2021-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-startdate:  2021-09-16T08:00:00-04:00
-enddate:  2021-09-17T19:00:00-04:00
+startdate:  2021-11-04T08:00:00-04:00
+enddate:  2021-11-04T19:00:00-04:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  2021-07-26T00:00:00-04:00
-cfp_date_end:  2021-08-09T23:59:59-04:00
-cfp_date_announce:  2021-08-19T23:59:59-04:00
+cfp_date_end:  2021-09-13T23:59:59-04:00
+cfp_date_announce:  2021-09-27T23:59:59-04:00
 
 cfp_open: "true"
 cfp_link: "https://devopsdaysdc2021.busyconf.com/proposals/new"


### PR DESCRIPTION
We made a decision to push the event date from September 16-17 to November 4. We extended the CFP and added an announcement explaining the shift.