### PR TITLE
[LA-2022] Update site pages

### DIFF
--- a/content/events/2022-los-angeles/conduct.md
+++ b/content/events/2022-los-angeles/conduct.md
@@ -1,7 +1,7 @@
 +++
 Title = "Conduct"
 Type = "event"
-Description = "Code of conduct for devopsdays Los Angeles 2022"
+Description = "Code of conduct for DevOpsDays Los Angeles 2022"
 +++
 
 

--- a/content/events/2022-los-angeles/contact.md
+++ b/content/events/2022-los-angeles/contact.md
@@ -1,7 +1,7 @@
 +++
 Title = "Contact"
 Type = "event"
-Description = "Contact information for devopsdays Los Angeles 2022"
+Description = "Contact information for DevOpsDays Los Angeles 2022"
 +++
 
 If you'd like to contact us by email: {{< email_organizers >}}

--- a/content/events/2022-los-angeles/sponsor.md
+++ b/content/events/2022-los-angeles/sponsor.md
@@ -47,29 +47,4 @@ There are also opportunities for exclusive special sponsorships. We'll have spon
 <tr><td>booth/table space</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
 </table>
 <hr/>
-<!--
-There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
-<br/>
-<br/>
 
-<br>
-<br>
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>Sponsor FAQ</i></th>
-    <th><center><b>Answers to questions frequently asked by sponsors&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</center></b></th>
-    <th></th>
-  </tr>
-<tr><td>What dates/times can we set up and tear down?</td><td></td></tr>
-<tr><td>How do we ship to the venue?</td><td></td></tr>
-<tr><td>How do we ship from the venue?</td><td></td></tr>
-<tr><td>Whom should we send?</td><td></td></tr>
-<tr><td>What should we expect regarding electricity? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>What should we expect regarding WiFi? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>How do we order additional A/V equipment?</td><td></td></tr>
-<tr><td>Additional important details</td><td></td></tr>
-</table>
-</div>
-
--->
-<hr/>

--- a/content/events/2022-los-angeles/sponsor.md
+++ b/content/events/2022-los-angeles/sponsor.md
@@ -1,31 +1,39 @@
 +++
 Title = "Sponsor"
 Type = "event"
-Description = "Sponsor devopsdays los-angeles 2022"
+Description = "Sponsor DevOpsDays Los Angeles 2022"
 +++
+<h3>DevOpsDayLA - Become A Sponsor</h3>
 
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
-
-<hr>
-
-devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
 <p>
-Gold sponsors get a full table and Silver sponsors a shared table where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.
-<p>
-The best thing to do is send engineers to interact with the experts at devopsdays on their own terms.
-<p>
+Thank you for your interest! Below is an overview of the conference as well as our sponsor packages. Please email the organizing committee at [{{< email_organizers >}}] for additional information or to secure your package.
 
-<!--
-<hr/>
+<h3>About DevOpsDayLA</h3>
+
+<p>
+DevOpsDaysLA, now in its 10th year, is Southern California's only annual conference focused on the practice of DevOps. The conference provides a relaxed, casual, and diverse environment where sponsors connect with talent, demonstrate the latest tools, and offer world class services to facilitate organizations' DevOps journey. 
+
+<h3>DevOpsDayLA Conference Profile</h3> 
+
+- 500 to 800 Attendees (Our 2022 goal is 800-1000 attendees) - Typically composed of developers, experienced engineers, curious business leaders, students, and educators
+- 8 Speakers ( 5 Long Form Talks, 3 Lightning Talks - including John Willis, co-author of the DevOps Handbook in 2 of the last 4 conferences)
+  - 33% of Speakers are typically women 
+  - 18 Sponsors (90% gold packages + exclusives such as after-party, lunch, etc)
+
+<p>
+There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
+<p>
+<strong>Note:</strong> We do not share attendee lists.
+
+<h3>Packages</h3>
 
 <div style="width:590px">
 <table border=1 cellspacing=1>
   <tr>
-    <th><i>packages</i></th>
-    <th><center><b><u>Bronze<br />1000 usd</u></center></b></th>
-    <th><center><b><u>Silver<br />3000 usd</u></center></b></th>
-    <th><center><b><u>Gold<br />5000 usd</u></center></b></th>
     <th></th>
+    <th><center><b><u>Startup<br />1000 usd</u></center></b></th>
+    <th><center><b><u>Silver<br />2000 usd</u></center></b></th>
+    <th><center><b><u>Gold<br />3000 usd</u></center></b></th>
   </tr>
 <tr><td>2 included tickets</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
 <tr><td>logo on event website</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
@@ -39,6 +47,7 @@ The best thing to do is send engineers to interact with the experts at devopsday
 <tr><td>booth/table space</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
 </table>
 <hr/>
+<!--
 There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
 <br/>
 <br/>

--- a/content/events/2022-los-angeles/welcome.md
+++ b/content/events/2022-los-angeles/welcome.md
@@ -18,14 +18,14 @@ Description = "DevOpsDays Los Angeles 2022"
   </div>
 </div>
 
-<div class = "row">
+<!-- <div class = "row">
   <div class = "col-md-2">
     <strong>Location</strong>
   </div>
   <div class = "col-md-8">
     {{< event_location >}}
   </div>
-</div>
+</div> -->
 
 <div class = "row">
   <div class = "col-md-2">
@@ -38,14 +38,14 @@ Description = "DevOpsDays Los Angeles 2022"
   </div>
 </div>
 
-<div class = "row">
+<!-- <div class = "row">
   <div class = "col-md-2">
     <strong>Register</strong>
   </div>
   <div class = "col-md-8">
     {{< event_link page="registration" text="Register to attend the conference!" >}}
   </div>
-</div>
+</div> -->
 
 <!-- <div class = "row">
   <div class = "col-md-2">

--- a/content/events/2022-los-angeles/welcome.md
+++ b/content/events/2022-los-angeles/welcome.md
@@ -1,8 +1,8 @@
 +++
-Title = "devopsdays Los Angeles 2022"
+Title = "DevOpsDays Los Angeles 2022"
 Type = "welcome"
 aliases = ["/events/2022-los-angeles/"]
-Description = "devopsdays Los Angeles 2022"
+Description = "DevOpsDays Los Angeles 2022"
 +++
 
 <!-- <div style="text-align:center;">
@@ -24,6 +24,17 @@ Description = "devopsdays Los Angeles 2022"
   </div>
   <div class = "col-md-8">
     {{< event_location >}}
+  </div>
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Call For Papers</strong>
+  </div>
+  <div class = "col-md-8">
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSewxucXuZ5nmZYX-nBitrmnr1ZA-O7oc33kheNvoRw1ufEbgg/viewform">
+      Propose a talk!
+    </a>
   </div>
 </div>
 

--- a/data/events/2022-los-angeles.yml
+++ b/data/events/2022-los-angeles.yml
@@ -2,7 +2,7 @@ name: "2022-los-angeles" # The name of the event. Four digit year with the city 
 year: "2022" # The year of the event. Make sure it is in quotes.
 city: "Los Angeles" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdayla2022" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
-description: "Devopsdays is coming to Los Angeles!" # Edit this to suit your preferences
+description: "DevOpsDays is coming to Los Angeles!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2022-MM-DDTHH:MM:SS+TZ:TZ, like this:
@@ -14,9 +14,9 @@ startdate: 2022-03-04T08:00:00-08:00 # The start date of your event. Leave blank
 enddate: 2022-03-04T22:00:00-08:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:  # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_start: 2021-09-01T00:00:00-08:00 # start accepting talk proposals.
+cfp_date_end: 2021-11-30T00:00:00-08:00 # close your call for proposals.
+cfp_date_announce: 2020-01-15T00:00:00-08:00 # inform proposers of status
 cfp_link: "https://docs.google.com/forms/d/e/1FAIpQLSewxucXuZ5nmZYX-nBitrmnr1ZA-O7oc33kheNvoRw1ufEbgg/viewform" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2021-08-16T00:00:00-08:00 # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
@@ -34,9 +34,11 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   # - name: speakers
   # - name: volunteer
   - name: venue
-    url: https://www.socallinuxexpo.org/scale/18x/venue
+    url: https://www.socallinuxexpo.org/scale/19x/venue
   - name: registration
     url: https://register.socallinuxexpo.org/reg6/
+  - name: CFP
+    url: https://docs.google.com/forms/d/e/1FAIpQLSewxucXuZ5nmZYX-nBitrmnr1ZA-O7oc33kheNvoRw1ufEbgg/viewform
   - name: sponsor
   - name: contact
   - name: conduct
@@ -53,11 +55,10 @@ team_members: # Name is the only required field for team members.
     bio: "Co-Chair DevOpsDayLA"
     github: "brynak"
     linkedin: "https://www.linkedin.com/in/brynak"
-    image: "bryna-kirzner.jpg"
   - name: "Murriel Perez-McCabe"
     employer: "Google"
     linkedin: "https://www.linkedin.com/in/murrielperez/"
-    twitter: xmurriel
+    twitter: "xmurriel"
   - name: "Chris Webber"
     linkedin: "https://www.linkedin.com/in/cwebberops/"
     github: "cwebberops"
@@ -73,7 +74,6 @@ team_members: # Name is the only required field for team members.
     employer: "digitalr00ts"
     twitter: "digitalr00ts"
     bio: "Python Developer"
-    image: "carlos-meza.jpg"
     github: "cmeza99"
     linkedin: "https://www.linkedin.com/in/cmeza99"
     website: "https://www.digitalr00ts.com"
@@ -81,6 +81,7 @@ team_members: # Name is the only required field for team members.
   - name: "Omar Alva"
     github: "omargohan"
     twitter: "omargohan"
+    linkedin: "https://www.linkedin.com/in/omar-alva-60237919/"
 
 organizer_email: "los-angeles@devopsdays.org" # Put your organizer email address here
 
@@ -107,6 +108,6 @@ sponsor_levels:
     label: Silver
     max: 0 # This is the same as omitting the max limit.
   - id: bronze
-    label: Bronze
+    label: Startup
   - id: community
     label: Community


### PR DESCRIPTION
**Summary of changes:**

- Updating `Description` on all pages.
- Updating `sponsor`'s content.
- Adding `cfp` to welcome page.
- Updating data in `los-angeles-2022.yml` including cfp dates, links, team members info and `sponsor_levels`