### PR TITLE
[PDX-2021] Sponsor swap

### DIFF
--- a/data/events/2021-portland-or.yml
+++ b/data/events/2021-portland-or.yml
@@ -76,7 +76,7 @@ sponsors:
     level: gold
   - id: stackhawk
     level: silver
-  - id: trendmicro
+  - id: skycrafters
     level: gold
   - id: wehackpurple
     level: gold


### PR DESCRIPTION
TrendMicro is sponsoring on behalf of Skycrafters, asked us to swap the sponsor logo/link