### PR TITLE
[PDX-2021] Adding a Watch Live page

### DIFF
--- a/content/events/2021-portland-or/program.md
+++ b/content/events/2021-portland-or/program.md
@@ -9,6 +9,12 @@ Icons = "false"
   <div class = "col">
     <hr />
     If Open Spaces are new to you, you may be interested in <a href="/pages/open-space-format">more details about Open Space</a>.
+  </div>
+</div>
+<div class = "row">
+  <div class = "col">
+    <hr />
+    Once the event has started, you can watch along <a href="/events/2021-portland-or/watchlive/">here</a>! Want to join in the conversation? Registration is still open and free!
     <hr />
   </div>
 </div>

--- a/content/events/2021-portland-or/watchlive.md
+++ b/content/events/2021-portland-or/watchlive.md
@@ -1,0 +1,27 @@
++++
+Title = "Watch Live"
+Type = "event"
+Description = "Watch DevOpsDays Portland 2021 Live"
++++
+
+You should see the YouTube stream for the event and the closed captioning
+stream below. In case any of that doesn't work, [this is the YouTube
+link](https://www.youtube.com/channel/UCxzmx6LKP5PmcR1wVUj1dxw/live) and [this
+is the captioning](https://www.streamtext.net/player?event=DevOpsPortland).
+Thanks for joining!
+
+<div style="height:600px;width:100%;overflow:hidden;resize:both">
+    <iframe 
+        src=""
+        description="Live DevOpsDays PDX 2021 stream"
+        style="height:100%;width:100%">
+    </iframe>
+</div>
+<br />
+<div style="height:300px;width:100%;overflow:hidden;resize:both">
+    <iframe
+        src="https://www.streamtext.net/player?event=DevOpsPortland"
+        description="Live captions for the DevOpsDays PDX 2021 stream"
+        style="height:100%;width:100%">
+    </iframe>
+</div>

--- a/content/events/2021-portland-or/welcome.md
+++ b/content/events/2021-portland-or/welcome.md
@@ -7,7 +7,7 @@ Description = "devopsdays Portland 2021"
 
 
 <div style="text-align:center;">
-  We're going to have a two day online event September 20-21. Talks will be streamed and online via Youtube, and discussion will be via Discord. We hope you join us!
+  We're going to have a two day online event September 20-21. Talks will be <a href="/events/2021-portland-or/watchlive/">streamed and online via Youtube</a>, and discussion will be via Discord. We hope you join us!
 </div>
 
 <div class = "row">

--- a/data/events/2021-portland-or.yml
+++ b/data/events/2021-portland-or.yml
@@ -39,6 +39,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: registration
   - name: program
  #   url: https://devopsdayspdx2021.busyconf.com/schedule
+  - name: watchlive
   - name: speakers
   - name: sponsor
   - name: contact


### PR DESCRIPTION
One of the embeds will have to be updated once the event starts, but this gets it into place. We would appreciate if this would be merged even in the slightly ugly state before the event.

"watchlive" as a top-level link is kind of gross but works. Eh. Suggestions appreciated :)