### PR TITLE
[HOU-2021] Matt's talk is now a workshop

### DIFF
--- a/data/events/2021-houston.yml
+++ b/data/events/2021-houston.yml
@@ -402,11 +402,10 @@ program:
     start_time: "16:00"
     end_time: "16:30"
   - title: "matthew-ostlind"
-    type: "workshop"
+    type: "talk"
     date: 2021-09-22
-    start_time: "16:00"
-    end_time: "16:55"
-    comments: "&nbsp; &nbsp; *Where*: Studio Movie Grill"
+    start_time: "13:35"
+    end_time: "14:15"
   - title: "rob-richardson"
     type: talk
     date: 2021-09-22


### PR DESCRIPTION
@skryukova PTAL

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
