### PR TITLE
[ZRH-2021] set default Zurich event (redirect) to 2021

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -114,7 +114,7 @@
 /warsaw/*		/events/2019-warsaw/:splat		302
 /washington-dc/*	/events/2020-washington-dc/:splat	302
 /zaragoza/*		/events/2020-zaragoza/:splat		302
-/zurich/*		/events/2020-zurich/:splat		302
+/zurich/*		/events/2021-zurich/:splat		302
 /events/2009-ghent/*          http://legacy.devopsdays.org/events/2009-ghent/:splat     301!
 /events/2010*                 http://legacy.devopsdays.org/events/2010:splat            301!
 /blog/wp-content/*            http://legacy.devopsdays.org/blog/wp-content/:splat       301!


### PR DESCRIPTION
The event is over so this isn't a critical change, but I just noticed it, so…