### PR TITLE
Update bham-uk with proper email alias

### DIFF
--- a/data/events/2022-birmingham-uk.yml
+++ b/data/events/2022-birmingham-uk.yml
@@ -63,7 +63,7 @@ team_members: # Name is the only required field for team members.
     image: "anais-urlichs.jpg"
     twitter: "@urlichsanais"
 
-organizer_email: "birmingham@devopsdays.org" # Put your organizer email address here
+organizer_email: "birmingham-uk@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
Due to namespace conflict with Birmingham, AL