### PR TITLE
[la 2022] add lightstep as sponsor

### DIFF
--- a/data/events/2022-los-angeles.yml
+++ b/data/events/2022-los-angeles.yml
@@ -92,6 +92,8 @@ organizer_email: "los-angeles@devopsdays.org" # Put your organizer email address
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
+  - id: lightstep
+    level: gold
   - id: blameless
     level: silver
   - id: scale


### PR DESCRIPTION
[la 2022] add lightstep as sponsor

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
