### PR TITLE
[ATL-2022] Added Neuvector and Chef to Gold Sponsors

### DIFF
--- a/data/events/2022-atlanta.yml
+++ b/data/events/2022-atlanta.yml
@@ -108,6 +108,10 @@ sponsors:
     level: gold
   - id: roostai
     level: gold
+  - id: neuvector
+    level: gold
+  - id: chef
+    level: gold
 
 sponsors_accepted : "no" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Added Neuvector and Chef [potentially have to remove Chef] as a sponsor. 
Cheers,
-Ravi
