### PR TITLE
[LDN-2022] Add new organizers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ staging
 
 # local configuration
 .envrc
+.direnv
+shell.nix
 
 # Icon must end with two \r
 Icon

--- a/data/events/2022-london.yml
+++ b/data/events/2022-london.yml
@@ -68,6 +68,10 @@ team_members: # Name is the only required field for team members.
     twitter: "PaulaLKennedy"
   - name: "Sophie Weston"
     twitter: "srwestons"
+  - name: "Rob Barnes"
+    twitter: "devops_rob"
+  - name: "Jessica Cregg"
+    twitter: "JessicaCregg"
 
 organizer_email: "london@devopsdays.org" # Put your organizer email address here
 


### PR DESCRIPTION
We've added two new organizers to the team for 2022. These are Rob and Jessica. This will also serve as the PR for the new organizers before Sophie gets in touch about adding them.

I've also added to the .gitignore with this commit as I now use NixOS full time and have written a shell.nix file for dependencies within this project. I don't expect others to use nix and therefore probably shouldn't commit the shell.nix or .direnv. I can take this change out if required and just ignore them locally. (Please let me know on this point)

Signed-off-by: Chris Mills <7100370+chriscoffee@users.noreply.github.com>
