### PR TITLE
Marking old 2021 & 2022 events as cancelled

### DIFF
--- a/data/events/2020-buenos-aires.yml
+++ b/data/events/2020-buenos-aires.yml
@@ -4,6 +4,7 @@ city: "Buenos Aires" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysbsas" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "1st Edition of DevOpsDays is coming to Buenos Aires!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-ciudad-mexico.yml
+++ b/data/events/2020-ciudad-mexico.yml
@@ -4,6 +4,7 @@ city: "Ciudad de México" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdays" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Ciudad de México!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-columbus.yml
+++ b/data/events/2020-columbus.yml
@@ -5,6 +5,7 @@ event_twitter: "devopsdayscbus" # Change this to the twitter handle for your eve
 description: "Devopsdays is coming to Columbus!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: "Columbus"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-edinburgh.yml
+++ b/data/events/2020-edinburgh.yml
@@ -4,6 +4,7 @@ city: "Edinburgh" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysedi" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Edinburgh in 2020!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2020-01-04T00:00:00+02:00

--- a/data/events/2020-eindhoven.yml
+++ b/data/events/2020-eindhoven.yml
@@ -6,6 +6,7 @@ description: "Devopsdays is coming to Eindhoven for the FIRST TIME!" # Edit this
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 masthead_background: "skyline-eindhoven.jpg"
 sharing_image: "logo-rectangle.png"
+cancel: "true"
 
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:

--- a/data/events/2020-florianopolis.yml
+++ b/data/events/2020-florianopolis.yml
@@ -4,6 +4,7 @@ city: "Florianópolis"
 event_twitter: "devopsdaysfln"
 description: "A revolução já começou!"
 ga_tracking_id: ""
+cancel: "true"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
 startdate: # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2020-lagos.yml
+++ b/data/events/2020-lagos.yml
@@ -4,6 +4,7 @@ city: "Lagos" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdayslag" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Lagos!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-lima.yml
+++ b/data/events/2020-lima.yml
@@ -4,6 +4,7 @@ city: "lima" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdays" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to lima!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-saint-louis.yml
+++ b/data/events/2020-saint-louis.yml
@@ -3,6 +3,7 @@ year: "2020" # The year of the event. Make sure it is in quotes.
 city: "Saint Louis" # The displayed city name of the event. Capitalize it.
 status: "current" # Options are "past" or "current". Use "current" for upcoming.
 description: "DevOpsDays is coming to Saint Louis in 2020! It'll be a great opportunity to share knowledge, socialize, and have fun with other members of our great technical community." # A short blurb of text to describe your event, defaults to common DevOpsDays description
+cancel: "true"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2020-01-04T00:00:00+02:00

--- a/data/events/2020-salt-lake-city.yml
+++ b/data/events/2020-salt-lake-city.yml
@@ -5,6 +5,7 @@ event_twitter: "devopsdaysslc" # Change this to the twitter handle for your even
 event_logo: "logo-square.jpg"
 description: "Salt Lake City DevOpsDays" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2020-01-04T00:00:00+02:00

--- a/data/events/2020-santiago.yml
+++ b/data/events/2020-santiago.yml
@@ -5,6 +5,7 @@ event_twitter: "devopsdaysSCL" # Change this to the twitter handle for your even
 description: "DevOpsDays is coming to Santiago in March/April of 2020! More updates will be available soon." # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 masthead_background: "santiago-chile.jpg"
+cancel: "true"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-singapore.yml
+++ b/data/events/2020-singapore.yml
@@ -4,6 +4,7 @@ city: "Singapore" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysSG" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is returning to Singapore for a 5th year!" # Edit this to suit your preferences
 ga_tracking_id: "UA-157812456-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-toronto.yml
+++ b/data/events/2020-toronto.yml
@@ -4,6 +4,7 @@ city: "Toronto" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysTO" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "We're very sorry to announce that DevOpsDays Toronto 2020 will not be happening in April as planned" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-zaragoza.yml
+++ b/data/events/2020-zaragoza.yml
@@ -4,6 +4,7 @@ city: "Zaragoza" # The displayed city name of the event. Capitalize it.
 event_twitter: "" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Zaragoza!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-aarhus.yml
+++ b/data/events/2021-aarhus.yml
@@ -5,6 +5,7 @@ event_twitter: "devopsdayscph" # Change this to the twitter handle for your even
 description: "Devopsdays is coming to Aarhus!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_group: "Danish"
+cancel: "true"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-boise.yml
+++ b/data/events/2021-boise.yml
@@ -4,6 +4,7 @@ city: "Boise" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysboise" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Boise DevOps Days is postponed till 2022 Spring" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2021-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-dallas.yml
+++ b/data/events/2021-dallas.yml
@@ -4,6 +4,7 @@ city: "Dallas" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysdfw" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-guadalajara.yml
+++ b/data/events/2021-guadalajara.yml
@@ -4,6 +4,7 @@ city: "guadalajara" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysgdl" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to guadalajara!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2021-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-melbourne.yml
+++ b/data/events/2021-melbourne.yml
@@ -4,6 +4,7 @@ city: "Melbourne" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdownunder" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Our 2021 event has been cancelled. Stay tuned for our early 2022 event" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2021-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-moscow.yml
+++ b/data/events/2021-moscow.yml
@@ -3,6 +3,7 @@ year: "2021"
 city: "Moscow"
 event_twitter: "DevOpsDaysMSK"
 description: "DevOpsDays is a worldwide series of technical conferences covering topics of software development, IT infrastructure operations, and the intersection between them. It’s both a technical conference and a conference focusing on culture, processes and structure within organizations. We encourage both technologists and business people to attend, learn and share experiences."
+cancel: "true"
 
 
 startdate: # The start date of your event

--- a/data/events/2021-new-york-city.yml
+++ b/data/events/2021-new-york-city.yml
@@ -7,6 +7,7 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 event_group: "New York City"
 event_logo: "logo-square.png"
 masthead_background: "nyc-skyline.jpg"
+cancel: "true"
 
 # All dates are in unquoted 2021-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-paris.yml
+++ b/data/events/2021-paris.yml
@@ -4,6 +4,7 @@ city: "Paris" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsrex" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Votre conférence 100% devops à Paris !" # Edit this to suit your preferences
 ga_tracking_id: "UA-81620980-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2021-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-prague.yml
+++ b/data/events/2021-prague.yml
@@ -4,6 +4,7 @@ city: "Prague" # The displayed city name of the event. Capitalize it.
 event_twitter: "DevOpsDaysPrg" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Prague!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+cancel: "true"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00


### PR DESCRIPTION
A lot of cities forgot to add the cancel tag once an event was decided to be cancelled. This flag was added in late 2020 due to the result of the cancellations of many events due to the pandemic. 

