### PR TITLE
Permissions fix on Linux

### DIFF
--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -16,4 +16,4 @@ fi
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tip 1313:1313 -v $(pwd):/home/circleci/project:$MOUNT_OPTION -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.92.0 hugo server --watch --bind ""
+docker run -tip 1313:1313 -u $(id -u) -v $(pwd):/home/circleci/project:$MOUNT_OPTION -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.92.0 hugo server --watch --bind ""


### PR DESCRIPTION
This stems from a conversation in Slack:
https://devopsdays.slack.com/archives/C07T0BHHN/p1645462365591559

What we know so far is that Linux hosts run into a permissions issue when running `hugoserver.sh`:

```
[don@zeus ~/devopsdays-web:main] ./hugoserver.sh
hugo-server
hugo-server
Start building sites …
hugo v0.92.0-B3549403+extended linux/amd64 BuildDate=2022-01-12T08:23:18Z VendorInfo=gohugoio
Error: Error building site: failed to acquire a build lock: open /home/circleci/project/.hugo_build.lock: permission denied
Built in 10837 ms
```

Commit 8aa741d added the lockfile, but it may be a symptom of the lockfile being necessary to build, rather than a mistake. Removing the lockfile altogether does not result in a successful build - the lock file must be present.

Since it's not possible to check in a file to Git with 777, I've added a workaround that makes the file writable by running with the UID of the user who checked the file out (thanks @rexroof for the workaround).

I tested this both on Linux (Fedora 35) and macOS (Catalina).