### PR TITLE
[BOI-2022] Replace email submission with PaperCall link

### DIFF
--- a/content/events/2022-boise/propose.md
+++ b/content/events/2022-boise/propose.md
@@ -27,9 +27,4 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+<strong><a href="https://www.papercall.io/devopsdaysboise2022">Submit your talk on PaperCall!</a></strong>


### PR DESCRIPTION
Per the title, this removes the email organizers CTA and adds the PaperCall link.