### PR TITLE
Added Capital One and removed NeuVector as Sponsors

### DIFF
--- a/data/events/2022-atlanta.yml
+++ b/data/events/2022-atlanta.yml
@@ -108,7 +108,7 @@ sponsors:
     level: gold
   - id: roostai
     level: gold
-  - id: neuvector
+  - id: capitalone
     level: gold
   - id: progresschef
     level: gold


### PR DESCRIPTION
Howdy buds, swapping out NeuVector for Capital One for DoD ATL 2022. 

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
