### PR TITLE
[AARHUS-2022] Fix misspelling of sponsor level

### DIFF
--- a/data/events/2022-aarhus.yml
+++ b/data/events/2022-aarhus.yml
@@ -112,10 +112,10 @@ sponsors:
   - id: 2022-humio
     level: gold
   - id: danske-commodities
-    level: Community
+    level: community
     url: https://danskecommodities.com/careers/it/
   - id: delegate
-    level: Community
+    level: community
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Misspelled community with a capital C which broke the link to the sponsors_levels list
