### PR TITLE
[AMS-2022] Update the registration link to the actual tickets instead…

### DIFF
--- a/data/events/2022-amsterdam.yml
+++ b/data/events/2022-amsterdam.yml
@@ -24,7 +24,7 @@ registration_date_start: 2022-01-01T00:00:00+02:00 # start accepting registratio
 registration_date_end: 2022-06-21T23:59:59+02:00 # close registration. Leave blank if registration is not open yet.
 
 registration_closed: "true" #set this to true if you need to manually close registration before your registration end date
-registration_link: "https://dodams2022.eventbrite.com" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
+registration_link: "https://www.eventbrite.com/e/devopsdays-amsterdam-2022-tickets-255486305417" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 
 # Location
 #


### PR DESCRIPTION
Update the AMS registration link to the actual tickets and not the event overview page.