### PR TITLE
Fix Speaking page

### DIFF
--- a/themes/devopsdays-theme/layouts/speaking/single.html
+++ b/themes/devopsdays-theme/layouts/speaking/single.html
@@ -6,6 +6,6 @@
       {{ .Content }}
 </div>
 
-{{- partials "speaking.html" . -}}
+{{- partial "speaking.html" . -}}
 
 {{ end }}


### PR DESCRIPTION
The speaking page was broken, not showing events.

![Screenshot 2022-03-17 at 15 18 30](https://user-images.githubusercontent.com/1016505/158835002-6e4fe13e-2b60-47c5-8785-f9f723d7a651.png)

