### PR TITLE
[ATL-2022] Add custom styles to the program page for ATL

### DIFF
--- a/content/events/2022-atlanta/program.md
+++ b/content/events/2022-atlanta/program.md
@@ -16,9 +16,9 @@ Description = "Program for devopsdays Atlanta 2022"
 <b>Color Keys:</b>
 <div class="col-lg-2 col-md-3 program-element program-custom">General Session</div>
 <div class="col-lg-2 col-md-3 program-element program-talk">Keynote</div>
-<div class="col-lg-2 col-md-3 program-element">DevOps Track</div>
+<div class="col-lg-2 col-md-3 program-element" style="background:#d5c5ef;">DevOps Track</div>
 <div class="col-lg-2 col-md-3 program-element program-workshop">Security Track</div>
-<div class="col-lg-2 col-md-3 program-element ">SRE & Complexity Track</div>
+<div class="col-lg-2 col-md-3 program-element" style="background:#8ad0d3;">SRE & Complexity Track</div>
 <div class="col-lg-2 col-md-3 program-element program-ignite">Ignite Talk</div>
 <div class="col-lg-2 col-md-3 program-element program-open-space">Open Space Session</div>
 <br />

--- a/content/events/2022-atlanta/program/ajuna-kyaruzi.md
+++ b/content/events/2022-atlanta/program/ajuna-kyaruzi.md
@@ -7,4 +7,4 @@ Type = "talk"
 Speakers = ["ajuna-kyaruzi"]
 +++
 
-
+How you respond to production outages can affect both team morale and development velocity. With the proper Incident Response processes in place, it can reduce this stress, and make it easier to ramp up new teammates, and the focus on new features. This talk will look at Incident Management at its core, covering Incident Command and how to scale it with a growing organization. We’ll go over common areas of pain for Incident Responders and how to ease them to reduce friction between Product and SRE teams; such as best practices for playbooks, on-call rotations, error budgets, postmortems and incident communication to streamline incident resolution.

--- a/content/events/2022-atlanta/program/ajuna-kyaruzi.md
+++ b/content/events/2022-atlanta/program/ajuna-kyaruzi.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Sustainable Incident Management"
+Type = "talk"
+Speakers = ["ajuna-kyaruzi"]
++++
+
+

--- a/content/events/2022-atlanta/program/amber-vanderburg.md
+++ b/content/events/2022-atlanta/program/amber-vanderburg.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Building and Leading Remote Teams"
+Type = "talk"
+Speakers = ["amber-vanderburg"]
++++
+
+

--- a/content/events/2022-atlanta/program/amber-vanderburg.md
+++ b/content/events/2022-atlanta/program/amber-vanderburg.md
@@ -7,4 +7,12 @@ Type = "talk"
 Speakers = ["amber-vanderburg"]
 +++
 
+The world of work is constantly changing as we create new products, provide excellent service, and collaborate on new ventures. I’ll give you tools to overcome remote team challenges from confronting communication frustrations, setting expectations, and strategically building/equipping the right-fit remote team.
 
+You will be able to walk away with practical tools, tips, and tricks that you can implement within your team to help perform with more clarity and direction, more straightforward communication and expectations, and better performance individually and as a team. This high-energy chat will give you insights from a little bit of theory and case studies, a load of practical application, and lots of laughter. You will be able to walk away with the knowledge of how to:
+
+- Be strategic in building a team that can thrive in a remote environment
+- Equip and prepare your team with the tools that they need to be more successful working remotely
+- Aid in the logistical challenges of a remote team
+- Aid in the relational challenges of a remote team
+- How to best engage and motive a remote team

--- a/content/events/2022-atlanta/program/andre-henry.md
+++ b/content/events/2022-atlanta/program/andre-henry.md
@@ -7,4 +7,6 @@ Type = "talk"
 Speakers = ["andre-henry"]
 +++
 
+Resilience Engineering (RE) is the concept of preparing for the unforeseeable. But what happens when the unforeseeable is an ongoing global pandemic that has exacted physical, psychological and logistical toll on us all? Just how much resilience ought we plan for? Does it include the end of the world as we know it today? What is our breaking point?!
 
+In this session, I'll introduce some key concepts of Resiliency Engineering (RE) as defined by John Allspaw. While it will cover system resiliency, my main focus will be on the people and the org. The discussion will include examples of RE in the wild, as well as practical ways engineering practitioners at all levels can practice it. Most importantly, I'll discuss what happens when RE meets its limitations and how we can cope with that new reality.

--- a/content/events/2022-atlanta/program/andre-henry.md
+++ b/content/events/2022-atlanta/program/andre-henry.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Trust Nothing, Not Even This Talk!"
+Type = "talk"
+Speakers = ["andre-henry"]
++++
+
+

--- a/content/events/2022-atlanta/program/jj-ashgar.md
+++ b/content/events/2022-atlanta/program/jj-ashgar.md
@@ -7,4 +7,8 @@ Type = "talk"
 Speakers = ["jj-ashgar"]
 +++
 
+So your company has finally decided to move to the Cloud Native ecosystem. You’ve landed on containerization as your first step. You heard that all you needed to do was containerize your first app and then push it to Kubernetes/OpenShift/Nomad, and the cost savings just come. You’ve done this, and well, things have gone not as planned. Some of the tech didn’t do what you expected, and wait, what do you mean our OpEx has gone up? 
 
+Simply said: the promise of containerization or migrating to the Cloud Native ecosystem can be a lie if you don’t do your homework. Sadly most companies don’t. 
+
+In this talk, I’ll explain a few gotchas that a “few” enterprises, in the guise of AsgharLabs, hit moving towards the Cloud Native world, and hopefully, you’ll learn from their mistakes, so your trip down this path will be more comfortable and closer to the promise.

--- a/content/events/2022-atlanta/program/jj-ashgar.md
+++ b/content/events/2022-atlanta/program/jj-ashgar.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Migrating a monolith to Cloud-Native and the stumbling blocks that you don't know about"
+Type = "talk"
+Speakers = ["jj-ashgar"]
++++
+
+

--- a/content/events/2022-atlanta/program/john-willis.md
+++ b/content/events/2022-atlanta/program/john-willis.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "What Would Deming Do - Cyberwarfare"
+Type = "talk"
+Speakers = ["john-willis"]
++++
+
+

--- a/content/events/2022-atlanta/program/lesley-cordero.md
+++ b/content/events/2022-atlanta/program/lesley-cordero.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Trauma-informed Site Reliability Engineering"
+Type = "talk"
+Speakers = ["lesley-cordero"]
++++
+
+

--- a/content/events/2022-atlanta/program/lesley-cordero.md
+++ b/content/events/2022-atlanta/program/lesley-cordero.md
@@ -7,4 +7,4 @@ Type = "talk"
 Speakers = ["lesley-cordero"]
 +++
 
-
+This talk will talk about how principles from trauma-informed teaching & management can be applied to Site Reliability Engineering teams, making them more effective, productive, and happy. It will discuss both the concepts and implementation details of these concepts, making sure to highlight benefits and match them to existing SRE principles.

--- a/content/events/2022-atlanta/program/martin-rojas.md
+++ b/content/events/2022-atlanta/program/martin-rojas.md
@@ -7,4 +7,12 @@ Type = "talk"
 Speakers = ["martin-rojas"]
 +++
 
+You may have a great idea for an app. However, getting an app into production can be just as big a challenge. There are tons of decisions to be made in order for an app to run smoothly and be ready to scale. There are plenty of options in the market each one with its own pros and cons. Today we are going to talk about AWS Solution. I plan to go through the pros and cons that I have encountered in using Amplify to give you another tool for your next project.
 
+The talk focuses on the following sections: 
+- What is AWS Amplify 
+- How does it compare to similar services and what type of application works best for each one 
+- Getting Amplify set up on your system 
+- Explain Workflow from Dev -> Stage -> Prod as well as how to work in teams 
+- How to create DataModel and graphQL API 
+- How does that connect to the React Application

--- a/content/events/2022-atlanta/program/martin-rojas.md
+++ b/content/events/2022-atlanta/program/martin-rojas.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Production-ready apps on AWS simplified"
+Type = "talk"
+Speakers = ["martin-rojas"]
++++
+
+

--- a/content/events/2022-atlanta/program/mason-egger.md
+++ b/content/events/2022-atlanta/program/mason-egger.md
@@ -7,4 +7,8 @@ Type = "talk"
 Speakers = ["mason-egger"]
 +++
 
+Have you ever wanted to preconfigure your OS before deploying it to the cloud? Do you want an easy, reproducible way of creating custom cloud images? This is a job for Packer and Ansible. Packer is an open-source tool used to build automated machine images. 
 
+Packer allows you to specify the requirements for your image, from operating system to firstboot tasks, allowing you to be able to have reproducible cloud images. Packer also allows for provisioners, one of which being Ansible. 
+
+In this talk, we’ll pair Packer to build our image and Ansible to do an initial configuration of our image. Attendees will leave this session with an understanding of the benefits of custom cloud images, a knowledge of the tools to build custom images, and having seen these tools in action.

--- a/content/events/2022-atlanta/program/mason-egger.md
+++ b/content/events/2022-atlanta/program/mason-egger.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Build Custom Cloud Images with Packer & Ansible"
+Type = "talk"
+Speakers = ["mason-egger"]
++++
+
+

--- a/content/events/2022-atlanta/program/nivia-henry.md
+++ b/content/events/2022-atlanta/program/nivia-henry.md
@@ -7,4 +7,24 @@ Type = "talk"
 Speakers = ["nivia-henry"]
 +++
 
+Conways Law - the concept that your product resembles your org structure - is a double-edged sword. If your organization is intentionally structured to optimize your strengths, it’s great! 
 
+However, oftentimes organizations are the result of unintentional design; leading to accidental complexity and inability to maximize results. 
+
+Even when organizations are intentionally designed, they can optimize the wrong things - such as command and control, leading to clunky outcomes.
+
+Why does this happen? Is it preventable? How can you tell if this is happening in your organization?!
+
+The short answer is: YES! 
+
+In my current role as the Director of Engineering for our billion-dollar ads business, I and my team have been given the unique opportunity to redesign our organization for speed, collaboration and results. 
+
+We decided to put our principles into practice by using two system design principles to organize our 100-person team who support our hundreds of components: DDD (Domain Driven Design): “ a software development philosophy centered around the domain, or sphere of knowledge, of those that use it”; and BAPO (Business Architecture Process Organization): Jan Bosch’s expression of strategic organization design.
+
+Join me to discuss a real-world case study in applying these principles and how it’s progressing 6 months in!
+
+Learning Outcomes:
+- Signs that you’re shipping your org structure and why that may be suboptimal
+- What are DDD and BAPO; how they’re different from traditional system design
+- Why DDD and BAPO can lead to a more optimal organization and better outcomes
+- Practical steps to get started regardless of your role

--- a/content/events/2022-atlanta/program/nivia-henry.md
+++ b/content/events/2022-atlanta/program/nivia-henry.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "The Org That DDD & BAPO Built"
+Type = "talk"
+Speakers = ["nivia-henry"]
++++
+
+

--- a/content/events/2022-atlanta/program/rain-leander.md
+++ b/content/events/2022-atlanta/program/rain-leander.md
@@ -7,4 +7,12 @@ Type = "talk"
 Speakers = ["rain-leander"]
 +++
 
+On the road to becoming a unicorn, you need to go backwards to make progress. As we get older, we forget how to fall down, how to play, how to explore and be curious - and these are necessary skills to becoming the best unicorn you can be. 
 
+Most recently I’m diving into two new technologies - distributed databases and javascript and I invite you to join me and my inner child, who really wants to be a unicorn, as we explore rainbows, build mountains, and tear it all down again with joy, curiosity, and eagerness. I will provide specific examples, from using editors to troubleshooting issues, and conclude with practical recommendations on getting started, becoming a unicorn, and conquering the world.
+
+Key Points
+- How to Learn
+- Make Mistakes
+- Stay Curious
+- Become a Unicorn

--- a/content/events/2022-atlanta/program/rain-leander.md
+++ b/content/events/2022-atlanta/program/rain-leander.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Regress to Progress: A Child's Mindset for Growth"
+Type = "talk"
+Speakers = ["rain-leander"]
++++
+
+

--- a/content/events/2022-atlanta/program/rob-richardson.md
+++ b/content/events/2022-atlanta/program/rob-richardson.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Service Mess to Service Mesh"
+Type = "talk"
+Speakers = ["rob-richardson"]
++++
+
+

--- a/content/events/2022-atlanta/program/rob-richardson.md
+++ b/content/events/2022-atlanta/program/rob-richardson.md
@@ -7,4 +7,4 @@ Type = "talk"
 Speakers = ["rob-richardson"]
 +++
 
-
+In our quest to secure all the things, do we jump in too quickly? We’ll use Istio and Linkerd as example service meshes, and look at the features we would expect from a service mesh. We’ll dive into the day-1 experience with both Istio and Linkerd, and some advanced scenarios of using the service mesh. We’ll compare this to border security with an app gateway, and compare and contrast the security features, complexities, and implementation costs. You’ll leave with a concrete understanding of the benefits and tradeoffs you get when you pull in a service mesh, and be ready to justify the investment.

--- a/content/events/2022-atlanta/program/waldo-grunenwald.md
+++ b/content/events/2022-atlanta/program/waldo-grunenwald.md
@@ -7,4 +7,8 @@ Type = "talk"
 Speakers = ["waldo-grunenwald"]
 +++
 
+Have you ever gotten into an argument because the statement that you made wasn’t understood as you meant it? Have you ever seen a simple disagreement go rapidly off the rails, and turn into a shouting match?
 
+Rather than quipping at one-another (like UDP), there is a technique for resolving disputes or conflicts that is more akin to TCP. It is called “Active Listening”. 
+
+In this talk, I’ll show you how this technique reduces the likelihood of a shouting match by drastically slowing the escalation and forcing each side to listen & comprehend what the other person is trying to say.

--- a/content/events/2022-atlanta/program/waldo-grunenwald.md
+++ b/content/events/2022-atlanta/program/waldo-grunenwald.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Argue Better with Active Listening"
+Type = "talk"
+Speakers = ["waldo-grunenwald"]
++++
+
+

--- a/content/events/2022-atlanta/speakers/ajuna-kyaruzi.md
+++ b/content/events/2022-atlanta/speakers/ajuna-kyaruzi.md
@@ -1,10 +1,10 @@
 +++
 Title = "Ajuna Kyaruzi"
-Twitter = ""
+Twitter = "ajunaky"
 image = ""
 type = "speaker"
 linktitle = "ajuna-kyaruzi"
 
 +++
 
-
+Ajuna Kyaruzi works in Developer Relations at Datadog was born and raised in Dar es Salaam, Tanzania. She loves community building and volunteers with multiple mentorship programs aimed helping early career folks breaking into tech have successful careers. Previously she worked at Google for about four years as a Software Engineer on Google Maps and as a Site Reliability Engineer on Google Cloud.

--- a/content/events/2022-atlanta/speakers/ajuna-kyaruzi.md
+++ b/content/events/2022-atlanta/speakers/ajuna-kyaruzi.md
@@ -1,0 +1,10 @@
++++
+Title = "Ajuna Kyaruzi"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "ajuna-kyaruzi"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/amber-vanderburg.md
+++ b/content/events/2022-atlanta/speakers/amber-vanderburg.md
@@ -1,0 +1,10 @@
++++
+Title = "Amber Vanderburg"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "amber-vanderburg"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/amber-vanderburg.md
+++ b/content/events/2022-atlanta/speakers/amber-vanderburg.md
@@ -1,10 +1,10 @@
 +++
 Title = "Amber Vanderburg"
-Twitter = ""
+Twitter = "vanderburgamber"
 image = ""
 type = "speaker"
 linktitle = "amber-vanderburg"
 
 +++
 
-
+Amber Vanderburg is a multi award winning international businessperson, keynote speaker, and founder of The Pathwayz Group. In 2016, she left her job in corporate HR to become the only female, only American, and only blonde Academy elite football coach for the Adidas Gameday Academy/Paris Saint Germain Academy in Bangalore, India. She worked with an international team of coaches to transform the organizational design, training development, and corporate culture to cultivate a higher-performing team. Today, Amber and The Pathwayz Group work with international teams that struggle with co worker tension, inefficient processes, and unmet performance expectations in an action focused approach to guide teams in the path to becoming more effective, more efficient, and more enjoyable.

--- a/content/events/2022-atlanta/speakers/andre-henry.md
+++ b/content/events/2022-atlanta/speakers/andre-henry.md
@@ -1,10 +1,10 @@
 +++
 Title = "André Henry"
-Twitter = ""
+Twitter = "7grok"
 image = ""
 type = "speaker"
 linktitle = "andre-henry"
 
 +++
 
-
+André Henry is an Engineering Leader at HARRY’S and a lifelong hacker. He cares about leading engineers and enabling them to do their best work. André lives at the intersection of lasers, cats, and tech. You can find him at a bookstore, a conference or at home, with his cat Zuko, always learning and sharing.

--- a/content/events/2022-atlanta/speakers/andre-henry.md
+++ b/content/events/2022-atlanta/speakers/andre-henry.md
@@ -1,0 +1,10 @@
++++
+Title = "André Henry"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "andre-henry"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/jj-ashgar.md
+++ b/content/events/2022-atlanta/speakers/jj-ashgar.md
@@ -1,10 +1,16 @@
 +++
 Title = "J.J. Ashgar"
-Twitter = ""
+Twitter = "jjasghar"
 image = ""
 type = "speaker"
 linktitle = "jj-ashgar"
 
 +++
+
+JJ works as a Developer Advocate representing the IBM Cloud all over the world. He mainly focuses on the IBM Kubernetes Service and OpenShift trying to make companies and users have a successful onboarding to the Cloud Native ecosystem. He’s also been known in the DevOps tooling ecosystem and generalized Linux communities. If he isn’t building automation to make his work streamlined, he’s building the groundwork to do just that.
+
+He lives and grew up in Austin, Texas. A father and husband, trying to learn to balance his natural nerdiness with family life. He enjoys a good strong dark ale, hoppy IPA, some team building Artemis, and epic Gloomhaven campaigning.
+
+He has recently dove head-first into Fedora since IBM buying Redhat but still secretly wants FreeBSD everywhere. He’s always trying to become a better web technology developer, though normally just uses bash to get the job done.
 
 

--- a/content/events/2022-atlanta/speakers/jj-ashgar.md
+++ b/content/events/2022-atlanta/speakers/jj-ashgar.md
@@ -1,0 +1,10 @@
++++
+Title = "J.J. Ashgar"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "jj-ashgar"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/john-willis.md
+++ b/content/events/2022-atlanta/speakers/john-willis.md
@@ -1,0 +1,10 @@
++++
+Title = "John Willis"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "john-willis"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/john-willis.md
+++ b/content/events/2022-atlanta/speakers/john-willis.md
@@ -1,10 +1,10 @@
 +++
 Title = "John Willis"
-Twitter = ""
+Twitter = "botchagalupe"
 image = ""
 type = "speaker"
 linktitle = "john-willis"
 
 +++
 
-
+John Willis has worked in the IT management industry for more than 35 years. Currently, he is running a DevOps and Digital Practices at Botchagalupe Technologies. He was formerly Director of Ecosystem Development at Docker. Prior to Docker, Willis was the VP of Solutions for Socketplane (sold to Docker) and Enstratius (sold to Dell). Prior to Socketplane and Enstratius, Willis was the VP of Training and Services at Opscode, where he formalized the training, evangelism, and professional services function at the firm. Willis also founded Gulf Breeze Software, an award-winning IBM business partner, which specializes in deploying Tivoli technology for the enterprise. Willis has authored six IBM Redbooks on enterprise systems management and was the founder and chief architect at Chain Bridge Systems.

--- a/content/events/2022-atlanta/speakers/lesley-cordero.md
+++ b/content/events/2022-atlanta/speakers/lesley-cordero.md
@@ -1,0 +1,10 @@
++++
+Title = "Lesley Cordero"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "lesley-cordero"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/lesley-cordero.md
+++ b/content/events/2022-atlanta/speakers/lesley-cordero.md
@@ -1,10 +1,10 @@
 +++
 Title = "Lesley Cordero"
-Twitter = ""
+Twitter = "lesleyclovesyou"
 image = ""
 type = "speaker"
 linktitle = "lesley-cordero"
 
 +++
 
-
+Lesley Cordero is currently a tech lead at an edtech company, Teachers Pay Teachers. She has spent the majority of her career on edtech teams as an engineer, including Google for Education and other edtech startups. In her current role, she has focused on production readiness by bringing site reliability engineering practices such as SLOs, on-call improvements, and chaos engineering.

--- a/content/events/2022-atlanta/speakers/martin-rojas.md
+++ b/content/events/2022-atlanta/speakers/martin-rojas.md
@@ -1,0 +1,10 @@
++++
+Title = "Martin Rojas"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "martin-rojas"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/martin-rojas.md
+++ b/content/events/2022-atlanta/speakers/martin-rojas.md
@@ -1,10 +1,10 @@
 +++
 Title = "Martin Rojas"
-Twitter = ""
+Twitter = "martinrojas"
 image = ""
 type = "speaker"
 linktitle = "martin-rojas"
 
 +++
 
-
+Martin Rojas is a Web Designer and Developer with 10+ years of development across multiple platforms. He has worked on many technologies, but for the past four years, he has been working mostly in the REACT/REDUX (Preact) for Fortune 100 companies such as Cox Automotive and Coca-Cola.

--- a/content/events/2022-atlanta/speakers/mason-egger.md
+++ b/content/events/2022-atlanta/speakers/mason-egger.md
@@ -1,10 +1,10 @@
 +++
 Title = "Mason Egger"
-Twitter = ""
+Twitter = "masonegger"
 image = ""
 type = "speaker"
 linktitle = "mason-egger"
 
 +++
 
-
+Mason is currently a Sr. Developer Advocate at DigitalOcean who specializes in cloud infrastructure, distributed systems, and Python. Prior to his work at DigitalOcean he was an SRE helping build and maintain a highly available hybrid multi-cloud PaaS. He is an avid programmer, musician, educator, and writer/blogger at masonegger.com. In his spare time, he enjoys reading, camping, kayaking, and exploring new places.

--- a/content/events/2022-atlanta/speakers/mason-egger.md
+++ b/content/events/2022-atlanta/speakers/mason-egger.md
@@ -1,0 +1,10 @@
++++
+Title = "Mason Egger"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "mason-egger"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/nivia-henry.md
+++ b/content/events/2022-atlanta/speakers/nivia-henry.md
@@ -1,10 +1,20 @@
 +++
-Title = "Nivia Henry"
-Twitter = ""
+Title = "Nivia S. Henry"
+Twitter = "lanooba"
 image = ""
 type = "speaker"
 linktitle = "nivia-henry"
 
 +++
 
+Nivia is a technologist with 20 years of engineering and leadership experience.
 
+Her career path has included nearly every role in tech; but her true passion is inspiring people to do their best work. 
+
+These days Nivia plies her trade as a Director of Engineering for Spotify's billion-dollar Ads business. 
+
+Nivia gives back to the tech community by speaking at, chairing and attending tech conferences. 
+
+Her hobbies include: mentoring Black engineering leaders; reading; and chilling with her hubby Andre and their feline overlord Zuko.
+
+You can find her on Twitter as @lanooba or on LinkedIn.

--- a/content/events/2022-atlanta/speakers/nivia-henry.md
+++ b/content/events/2022-atlanta/speakers/nivia-henry.md
@@ -1,0 +1,10 @@
++++
+Title = "Nivia Henry"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "nivia-henry"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/rain-leander.md
+++ b/content/events/2022-atlanta/speakers/rain-leander.md
@@ -1,10 +1,10 @@
 +++
 Title = "Rain Leander"
-Twitter = ""
+Twitter = "rainleander"
 image = ""
 type = "speaker"
 linktitle = "rain-leander"
 
 +++
 
-
+Rain Leander is a systematic, slightly psychic, interdisciplinary developer evangelist with a Bachelor’s in dance and a Master’s in IT. An epic public speaker, they have disappeared within a box stuffed with swords, created life, and went skydiving with the Queen. Seriously. Rain is an active technical contributor with CockroachDB, OpenStack TripleO, Fedora, DjangoGirls, and Project DO. Come say hello. Bring cake.

--- a/content/events/2022-atlanta/speakers/rain-leander.md
+++ b/content/events/2022-atlanta/speakers/rain-leander.md
@@ -1,0 +1,10 @@
++++
+Title = "Rain Leander"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "rain-leander"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/rob-richardson.md
+++ b/content/events/2022-atlanta/speakers/rob-richardson.md
@@ -1,0 +1,10 @@
++++
+Title = "Rob Richardson"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "rob-richardson"
+
++++
+
+

--- a/content/events/2022-atlanta/speakers/rob-richardson.md
+++ b/content/events/2022-atlanta/speakers/rob-richardson.md
@@ -1,10 +1,10 @@
 +++
 Title = "Rob Richardson"
-Twitter = ""
+Twitter = "rob_rich"
 image = ""
 type = "speaker"
 linktitle = "rob-richardson"
 
 +++
 
-
+Rob Richardson is a software craftsman building web properties in ASP.NET and Node, React and Vue. He’s a Microsoft MVP, published author, frequent speaker at conferences, user groups, and community events, and a diligent teacher and student of high quality software development. You can find this and other talks on his blog at https://robrich.org/presentations and follow him on twitter at @rob_rich.

--- a/content/events/2022-atlanta/speakers/waldo-grunenwald.md
+++ b/content/events/2022-atlanta/speakers/waldo-grunenwald.md
@@ -1,10 +1,10 @@
 +++
 Title = "H. \"Waldo\" Grunenwald"
-Twitter = ""
+Twitter = "gwaldo"
 image = ""
 type = "speaker"
 linktitle = "waldo-grunenwald"
 
 +++
 
-
+Waldo is a Tech Evangelist for Datadog, which normally means that he gets to travel and meet people, and advocate on their behalf. He is a recovering SRE and Operations Engineer, has been active in the DevOps community for quite some time, and is keen on helping organizations stop hurting themselves. Despite being a raging introvert, he enjoys public speaking. In his spare time, he enjoys collecting hobbies that he doesn’t have the time to engage in. He hates writing about himself in the third person, and aspires to one day be a better bio writer.

--- a/content/events/2022-atlanta/speakers/waldo-grunenwald.md
+++ b/content/events/2022-atlanta/speakers/waldo-grunenwald.md
@@ -1,0 +1,10 @@
++++
+Title = "H. \"Waldo\" Grunenwald"
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "waldo-grunenwald"
+
++++
+
+

--- a/data/events/2022-atlanta.yml
+++ b/data/events/2022-atlanta.yml
@@ -1,6 +1,6 @@
 name: "2022-atlanta" # The name of the event. Four digit year with the city name in lower-case, with no spaces.
 year: "2022" # The year of the event. Make sure it is in quotes.
-city: "atlanta" # The displayed city name of the event. Capitalize it.
+city: "Atlanta" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysATL" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to the Georgia Aquarium, again!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
@@ -141,8 +141,8 @@ program:
     date: 2022-04-19
     start_time: "09:15"
     end_time: "09:25"
-  - title: "The Org that DDD & BAPO Built with Nivia S. Henry"
-    type: custom
+  - title: "nivia-henry"
+    type: talk
     date: 2022-04-19
     start_time: "09:25"
     end_time: "09:55"
@@ -153,33 +153,33 @@ program:
     start_time: "09:55"
     end_time: "10:25"
   
-  - title: "Build Custom Cloud Images with Packer & Ansible with Mason Egger"
-    type: custom
+  - title: "mason-egger"
+    type: talk
     date: 2022-04-19
     start_time: "10:25"
     end_time: "10:55"
     background_color: "#d5c5ef"
-  - title: "What Would Deming Do - Cyberwarfare with John Willis"
-    type: custom
+  - title: "john-willis"
+    type: talk
     date: 2022-04-19
     start_time: "10:25"
     end_time: "10:55"
     background_color: "#fffa99"
-  - title: "Trauma-informed Site Reliability Engineering with Lesley Cordero"
-    type: custom
+  - title: "lesley-cordero"
+    type: talk
     date: 2022-04-19
     start_time: "10:25"
     end_time: "10:55"
     background_color: "#8ad0d3"
   
-  - title: "Building and Leading Remote Teams with Amber Vanderburg"
-    type: custom
+  - title: "amber-vanderburg"
+    type: talk
     date: 2022-04-19
     start_time: "10:55"
     end_time: "11:25"
     background_color: "#d5c5ef"
-  - title: "Argue Better with Active Listening with H. \"Waldo\" Grunenwald"
-    type: custom
+  - title: "waldo-grunenwald"
+    type: talk
     date: 2022-04-19
     start_time: "10:55"
     end_time: "11:25"
@@ -265,8 +265,8 @@ program:
     date: 2022-04-20
     start_time: "09:15"
     end_time: "09:25"
-  - title: "Trust Nothing, Not Even This Talk! with André Henry"
-    type: custom
+  - title: "andre-henry"
+    type: talk
     date: 2022-04-20
     start_time: "09:25"
     end_time: "09:55"
@@ -277,27 +277,27 @@ program:
     start_time: "09:55"
     end_time: "10:25"
 
-  - title: "Migrating a monolith to Cloud-Native and the stumbling blocks that you don’t know about with J.J. Ashgar"
-    type: custom
+  - title: "jj-ashgar"
+    type: talk
     date: 2022-04-20
     start_time: "10:25"
     end_time: "10:55"
     background_color: "#d5c5ef"
-  - title: "Service Mess to Service Mesh with Rob Richardson"
-    type: custom
+  - title: "rob-richardson"
+    type: talk
     date: 2022-04-20
     start_time: "10:25"
     end_time: "10:55"
     background_color: "#fffa99"
-  - title: "Sustainable Incident Management with Ajuna Kyaruzi"
-    type: custom
+  - title: "ajuna-kyaruzi"
+    type: talk
     date: 2022-04-20
     start_time: "10:25"
     end_time: "10:55"
     background_color: "#8ad0d3"
   
   
-  - title: "Production-ready apps on AWS simplified with Martin Rojas"
+  - title: "martin-rojas"
     type: custom
     date: 2022-04-20
     start_time: "10:55"
@@ -309,8 +309,8 @@ program:
     start_time: "10:55"
     end_time: "11:25"
     background_color: "#fffa99"
-  - title: "Regress to Progress: A Child’s Mindset for Growth with Rain Leander"
-    type: custom
+  - title: "rain-leander"
+    type: talk
     date: 2022-04-20
     start_time: "10:55"
     end_time: "11:25"

--- a/data/events/2022-atlanta.yml
+++ b/data/events/2022-atlanta.yml
@@ -298,7 +298,7 @@ program:
   
   
   - title: "martin-rojas"
-    type: custom
+    type: talk
     date: 2022-04-20
     start_time: "10:55"
     end_time: "11:25"


### PR DESCRIPTION
Fixes the styles on the "key" for the program page, and adds speaker / talk pages.

Speakers still need images/bios, etc, and talks need descriptions.

Please do not merge without approval from ATL team
