### PR TITLE
Ams sponsor update

### DIFF
--- a/data/events/2022-amsterdam.yml
+++ b/data/events/2022-amsterdam.yml
@@ -128,6 +128,8 @@ sponsors:
   # gold
   - id: armo
     level: gold
+  - id: solo
+    level: gold
   # tshirt
   # lanyard
   # recharge

--- a/data/events/2022-amsterdam.yml
+++ b/data/events/2022-amsterdam.yml
@@ -126,13 +126,10 @@ sponsors:
   # gala
   # coffee
   # gold
-  - id: vmware-tanzu
-    level: gold
   - id: armo
     level: gold
   # tshirt
   # lanyard
-  # wristband
   # recharge
   # silver
   - id: fullstaq


### PR DESCRIPTION
- Vmware backed out
- Solo.io added as Gold