### PR TITLE
[Boise 2022] redirect for 2022

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -14,7 +14,7 @@
 /birmingham/* /events/2021-birmingham/:splat		302
 /birmingham-uk/*		/events/2022-birmingham-uk/:splat		302
 /bogota/*		/events/2022-bogota/:splat		302
-/boise/*		/events/2021-boise/:splat		302
+/boise/*		/events/2022-boise/:splat		302
 /boston/*		/events/2022-boston/:splat		302
 /brasilia/*		/events/2017-brasilia/:splat		302
 /buenos-aires/*		/events/2020-buenos-aires/:splat	302


### PR DESCRIPTION
/cc @ksatirli 

Looks like Boise may have been configured manually instead of with the new-event script. This redirect will point https://devopsdays.org/boise at the current year.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
