### PR TITLE
Add ukraine and kiev redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -55,6 +55,7 @@
 /kazan/*		/events/2018-kazan/:splat		302
 /kiel/*			/events/2018-kiel/:splat		302
 /krakow/*		/events/2020-krakow/:splat		302
+/kiev/*			/events/2022-kyiv/:splat		302
 /kyiv/*			/events/2022-kyiv/:splat		302
 /ljubljana/*		/events/2015-ljubljana/:splat		302
 /london/*		/events/2022-london/:splat		302
@@ -110,6 +111,7 @@
 /texas/*		/events/2021-texas/:splat		302
 /tokyo/*		/events/2021-tokyo/:splat		302
 /toronto/*		/events/2020-toronto/:splat		302
+/ukraine/*			/events/2022-kyiv/:splat		302
 /vancouver/*		/events/2020-vancouver/:splat		302
 /victoria/*		/events/2019-victoria/:splat		302
 /vitoria/*		/events/2022-vitoria/:splat		302


### PR DESCRIPTION
Just makes sure that the older used spelling still works, but also makes `/ukraine` point to the event
