### PR TITLE
[DC 2022] It's `D.C.` and 2022

### DIFF
--- a/content/events/2022-washington-dc/conduct.md
+++ b/content/events/2022-washington-dc/conduct.md
@@ -1,7 +1,7 @@
 +++
 Title = "Code of Conduct"
 Type = "event"
-Description = "Code of conduct for DevOpsDays Washington, DC 2019"
+Description = "Code of conduct for DevOpsDays Washington, D.C. 2022"
 +++
 
 ## Conference Code of Conduct

--- a/content/events/2022-washington-dc/location.md
+++ b/content/events/2022-washington-dc/location.md
@@ -1,11 +1,11 @@
 +++
 Title = "Location"
 Type = "event"
-Description = "Location for DevOpsDays Washington, DC 2022"
+Description = "Location for DevOpsDays Washington, D.C. 2022"
 +++
 
 DevOpsDays DC 2022 will be held at the
-[Ronald Reagan Building and International Trade Center](https://itcdc.com/) at 1300 Pennsylvania Ave NW, Washington, DC 20004.
+[Ronald Reagan Building and International Trade Center](https://itcdc.com/) at 1300 Pennsylvania Ave NW, Washington, D.C. 20004.
 
 {{< event_map >}}
 


### PR DESCRIPTION
* Fixes a year typo s/2019/2022
* Fixes a few instances of `DC` that should be `D.C.` for consistency

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>
