### PR TITLE
[BOS-2022] Update sponsorship details; add location

### DIFF
--- a/content/events/2022-boston/location.md
+++ b/content/events/2022-boston/location.md
@@ -1,0 +1,66 @@
++++
+Title = "Location"
+Type = "event"
+Description = "Location for DevOps Days Boston 2022"
++++
+
+## [The Cyclorama at Boston Center for the Arts](http://www.bcaonline.org/venues/cyclorama.html) - 539 Tremont St, Boston, MA 02116
+
+The Cyclorama at Boston Center for the Arts is an impressive and historic venue located in the stylish South End neighborhood of Boston. Surrounded by the largest collection of Victorian brownstones in New England and representing the height of urban industrial chic, the Cyclorama offers inspiration and limitless possibilities for all kinds of events.
+
+Featuring a dazzling copper skylight dome atop a round, brick-lined 23,000-square foot space, the Cyclorama can host from 100 to 1000 guests (up to 875 seated).
+<img style="max-width: 500px;margin: 0px 25px 25px 0px" src="/events/2017-boston/cycloramaskylight.jpg">
+
+The elegant simplicity of the building, which was opened in 1884 and is included on the National Register of Historic Places, makes a stunning statement on its own.
+
+### Here's what [Wikipedia has to say about it](https://en.wikipedia.org/wiki/Cyclorama_Building):
+
+The Classical Revival style Victorian building was commissioned by Charles F. Willoughby's Boston Cyclorama Company to house the Cyclorama of the Battle of Gettysburg, a 400-by-50 foot cyclorama painting of the Battle of Gettysburg. It was designed by Charles A. Cummings and Willard T. Sears. The central space is a 127'-diameter steel-trussed dome which, when it was built, was the largest dome in the country after the United States Capitol building. Visitors entered through the crenelated archway, proceeded along a dark winding passage, and then ascended a winding staircase to an elevated viewing platform. Skylights lit the scene by day, and it was illuminated by a system of 25 arc lamps by night.[2]
+
+In 1889, a new cyclorama painting Custer's Last Fight, was installed, but by 1890, the fashion for cycloramas had ended, and the new owner of the building, John Gardner (father-in-law of Isabella Stewart Gardner), converted it to a venue for popular entertainment, including a carousel, roller skating, boxing tournaments (including an 1894 fight of John L. Sullivan), horseback riding, bicycling, and so on.
+
+By 1899, it had become an industrial space, used by the New England Electric Vehicle Company, the Tremont Garage, the Buick Automobile Agency, and Albert Champion Company. Albert Champion is said to have invented the spark plug here before he moved to Flint, Michigan.
+
+When the Boston Flower Exchange bought the building in 1923, it added a new entrance and covered central dome with a skylight. The Flower Exchange occupied the building until 1970.
+
+# How to get there
+## Public Transportation
+The BCA is easily accessible by public transportation.
+
+### MBTA Orange Line to Back Bay Station
+
+Take the Clarendon Street exit and walk with traffic (Clarendon Street is one-way). Walk approximately 500 yards to Tremont Street. Take a left onto Tremont Street. The BCA is on the first block on the left.
+
+### MBTA Green Line to Copley
+
+Continue along Boylston Street with traffic (Boylston Street is one-way). Take a right onto Clarendon Street and walk approximately 750 yards to Tremont Street. Take a left onto Tremont Street. The BCA is on the first block on the left.
+
+### MBTA Silver Line SL4 & SL5
+
+Exit at either East Berkeley Street or Union Park. Walk towards Tremont Street by following the direction of traffic on either Berkeley or Union Park. From Berkeley, turn left onto Tremont; from Union Park turn right onto Tremont.
+
+### MBTA Bus #43
+
+Bus route 43 travels along Tremont Street between Ruggles, on the Orange line, and Park Street, on the Green and Red lines. Please ask the driver for the proper stop.
+
+## Parking
+On-street parking is very limited in the immediate area.
+
+### Atelier 505 Parking Garage
+
+Located under the Calderwood Pavilion. Enter on Warren Ave, at the rear of the building.
+
+### Garage @ 100 Clarendon Street
+
+Located on Clarendon Street between Stuart Street and Columbus Ave, just before Back Bay Station.
+Regular Evening Rate - $ 9 from 5pm until 7am the following morning - Seven days per week – No validation required
+Special BCA visitor parking rate:
+$17 All day Saturdays and Sundays – Visit the Calderwood Pavilion Box Office to have your ticket validated
+
+### Corner of Shawmut and East Berkeley Streets
+
+### Open Lots on Berkeley
+
+There are two open parking lots on Berkeley Street at Columbus Avenue. Open until 10pm.
+
+{{< event_map >}}

--- a/content/events/2022-boston/sponsor.md
+++ b/content/events/2022-boston/sponsor.md
@@ -1,0 +1,178 @@
++++
+Title = "Sponsor"
+Type = "event"
+Description = "Sponsor DevOpsDays Boston 2022"
++++
+
+<hr/>
+<div class="container-fluid">
+<div class="row justify-content-start">
+<div class="col-md-9">
+<div>
+<h3>Join the community</h3>
+
+
+<p><strong>DevOpsDays Boston Virtual</strong> is a two-day technology community conference that will return this year on September 12th-13th in its “traditional” physical form to the Boston Center for the Arts’ (BCA) Cyclorama and Calderwood Pavilion Theaters in Boston’s historic South End. The conference will also be streamed online.</p>
+<p>DevOpsDays is a grassroots event organized and operated by technology professionals to promote networking and the sharing of ideas, challenges, and solutions related to DevOps, IT management, and technology in general. It is organized by peers who care about and believe in improving the culture of technology work, process automation, and the creation of sustained value delivery in an environment of inclusion.</p>
+<h3>Why Sponsor DevOpsDays Boston?</h3>
+<p><strong>DevOpsDays Boston</strong> is part of a global phenomenon that is reshaping the technology industry. DevOpsDays
+conferences around the world bring together the highest quality speakers, subject matter experts, and contributors for a day of &quot;Teaching and Learning.&quot;</p>
+<p>As a DevOpsDays Boston sponsor, you will be branding your company as ambassadors to the Boston DevOps Community. Your company will be recognized as a Boston technology leader, exposing your brand, products, and services to our top tech talent.</p>
+</div>
+
+<div class="table-responsive">
+<table class="table table-bordered table-hover table-responsive-md">
+<thead class="thead-light">
+<tr>
+<th scope="col">
+Sponsorship Packages
+</th>
+<th scope="col"></th>
+<th scope="col">
+<center>Platinum</center>
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<th scope="row">Total Number Available</th>
+<td></td>
+<td>
+<center>20</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Contribution Cost</th>
+<td></td>
+<td>
+<center>$9,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Table Size</th>
+<td></td>
+<td>
+<center>6' x 2.5'</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Virtual Exhibition Space (Custom Channel)</th>
+<td></td>
+<td>
+<center>✓</center>
+</td>
+</tr>
+<tr>
+<th scope="row"># of Conference Passes</th>
+<td></td>
+<td>
+<center>4 on-site / unlimited virtual</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Company logo on DevOpsDays website</th>
+<td></td>
+<td>
+<center>Large</center>
+</td>
+</tr>
+<th scope="row">Company logo on digital signage / video loops</th>
+<td></td>
+<td>
+<center>Large</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Mentions via social media (Twitter / LinkedIn)</th>
+<td></td>
+<td>
+<center>✓</center>
+</td>
+</tr>
+<tr></tr>
+<tr>
+<th scope="row">Additional, a la carte sponsorships<br /><br /><span style="font-weight: normal;">The following may be purchased in lieu of, or in addition to, the sponsorships above.</span></th>
+<th>
+<center># Available</center>
+</th>
+<th>
+<center>Cost</center>
+</th>
+</tr>
+<tr>
+<th scope="row">Live Captioning</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$8,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Digital Graphic Recordings (Live Drawings)</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$6,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Evening event</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$12,500</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Wi-fi</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$5,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Badges and Lanyards</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$5,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Startup Alley</th>
+<td>
+<center>4</center>
+</td>
+<td>
+<center>$1,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Donations to Underrepresentation Partners</th>
+<td>
+<center>-</center>
+</td>
+<td>
+<center>$2,000</center>
+</td>
+</tr>
+</tbody>
+</table>
+<div>
+
+
+</div>
+</div>
+</div>
+<div class="col-md-3 col-sm-12">
+<h3>Read our <a href="https://assets.devopsdays.org/events/2022/boston/devopsdays-boston-2022-prospectus.pdf">sponsor prospectus</a>:</h3>
+<a href="https://assets.devopsdays.org/events/2022/boston/devopsdays-boston-2022-prospectus.pdf"><img src="https://assets.devopsdays.org/events/2022/boston/prospectus-thumbnail.png" class="img-fluid" style="border: 2px solid black;"></a>
+</div>
+
+</div>

--- a/content/events/2022-boston/welcome.md
+++ b/content/events/2022-boston/welcome.md
@@ -24,7 +24,11 @@ h1.welcome-page { text-transform: initial; }
     </div>
     <div class="row">
       <div class="col-md-2"><strong>Location</strong></div>
-      <div class="col-md-8">Boston (TBD)</div>
+      <div class="col-md-8">{{< event_location >}}</div>
+    </div>
+    <div class="row">
+      <div class="col-md-2"><strong>Sponsors</strong></div>
+      <div class="col-md-8">{{< event_link page="sponsor" text="Sponsor the conference!" >}}</div>
     </div>
     <div class="row">
       <div class="col-md-2"><strong>Contact</strong></div>

--- a/data/events/2022-boston.yml
+++ b/data/events/2022-boston.yml
@@ -28,14 +28,14 @@ registration_link: "" # If you have a custom registration link, enter it here. T
 
 # Location
 #
-coordinates: "" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
-location: "Boston" # Defaults to city, but you can make it the venue name.
+coordinates: "42.344447, -71.071291" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+location: "The Cyclorama at the Boston Center for the Arts" # Defaults to city, but you can make it the venue name.
 #
-location_address: "" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+location_address: "539 Tremont St, Boston, MA 02116" # Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
  # - name: propose
- # - name: location
+  - name: location
  # - name: registration
  # - name: program
  # - name: speakers


### PR DESCRIPTION
Mostly adding back 2019 assets that were removed from our 2020/2021 events.