### PR TITLE
[DC-2022] sponsor prospectus update

### DIFF
--- a/content/events/2022-washington-dc/sponsor.md
+++ b/content/events/2022-washington-dc/sponsor.md
@@ -4,63 +4,198 @@ Type = "event"
 Description = "Sponsor devopsdays Washington, D.C. 2022"
 +++
 
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please drop us an email at {{< email_organizers >}}.
+DevOpsDays is a self-organizing conference for DevOps practitioners that depends on your sponsorships.
+We do not have vendor booths, sell product presentations, or distribute attendee contact lists.
+Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during, and after the event.
+Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers.
+All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.
 
-<hr>
+The best thing to do is send practitioners to interact with their peers at DevOpsDays on their own terms.
 
-devopsdays is a self-organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
-<p>
-Gold sponsors get a full table and Silver sponsors a shared table where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.
-<p>
-The best thing to do is send engineers to interact with the experts at devopsdays on their own terms.
-<p>
+Please email the organizers at {{< email_organizers >}} with any questions you may have about sponsoring the event.
 
-<!--
+The following chart outlines our sponsorship packages.
+
+<style>
+  table.sponsorship            { border-collapse: collapse; }
+  table.sponsorship td         { text-align: left; border: 1px solid #000; padding: 3px; }
+  table.sponsorship tr.hed1 td { border-bottom: 0px; text-align: center; }
+  table.sponsorship tr.hed2 td { border-top: 0px; text-align: center; }
+  table.sponsorship td.yes     { text-align: center; }
+  .stamp {
+    box-shadow: 0 0 0 3px blue, 0 0 0 2px blue inset;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    display: inline-block;
+    padding: 5px 2px;
+    line-height: 22px;
+    color: blue;
+    font-size: 24px;
+    text-transform: uppercase;
+    text-align: center;
+    opacity: 0.4;
+    width: 130px;
+    transform: rotate(-5deg);
+  }
+</style>
+
+<table class="sponsorship">
+  <tbody>
+  <tr class="hed1">
+    <td><strong>Packages</strong></td>
+    <td><strong>Silver</strong></td>
+    <td><strong>Gold</strong></td>
+    <td><strong>Platinum</strong></td>
+    <!--
+    <td><strong><span style="text-decoration: line-through;">Community</span></strong></td>
+    <td><strong><span style="text-decoration: line-through;">Media</span></strong></td>
+    <td><strong><span style="text-decoration: line-through;">Live Captions</span></strong></td>
+    -->
+  </tr>
+  <tr class="hed2">
+    <td></td>
+    <td><strong>$1,500 USD</strong></td>
+    <td><strong>$4,000 USD</strong></td>
+    <td><strong>$6,000 USD</strong></td>
+    <!--
+    <td><strong class="stamp">TBD</strong></td>
+    <td><strong class="stamp">TBD</strong></td>
+    <td><strong class="stamp">TBD</strong></td>
+    -->
+  </tr>
+  <tr>
+    <td>Logo on shared slide, rotating during breaks</td>
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    <!--
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    -->
+  </tr>
+  <tr>
+    <td>Logo on DevOpsDays DC 2022 event website</td>
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    <!--
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    -->
+  </tr>
+  <tr>
+    <td>Mentioned on all email communication</td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    <!--
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+    -->
+  </tr>
+  <tr>
+    <td>Shared table for swag/marketing during conference</td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+    <td class="no"> </td>
+    <!--
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    -->
+  </tr>
+    <td>Full table for swag/marketing during conference</td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+    <!--
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+    -->
+  </tr>
+  <tr>
+    <td>1 minute pitch to full audience</td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+    <!--
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    -->
+  </tr>
+  <tr>
+    <td>1 included ticket total</td>
+    <td class="yes">&#9989;</td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <!--
+    <td class="yes">&#9989;</td>
+    <td class="yes">&#9989;</td>
+    <td class="no"> </td>
+    -->
+  </tr>
+  <tr>
+    <td>2 included tickets total</td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+    <td class="no"> </td>
+    <!-- <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="no"> </td> -->
+  </tr>
+  <!-- <tr>
+    <td>3 included tickets total</td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+  </tr> -->
+  <tr>
+    <td>4 included tickets total</td>
+    <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="yes">&#9989;</td>
+    <!-- <td class="no"> </td>
+    <td class="no"> </td>
+    <td class="no"> </td> -->
+  </tr>
+  </tbody>
+</table>
+
 <hr/>
 
-<div style="width:590px">
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>packages</i></th>
-    <th><center><b><u>Bronze<br />1000 usd</u></center></b></th>
-    <th><center><b><u>Silver<br />3000 usd</u></center></b></th>
-    <th><center><b><u>Gold<br />5000 usd</u></center></b></th>
-    <th></th>
-  </tr>
-<tr><td>2 included tickets</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on event website</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on shared slide, rotating during breaks</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on all email communication</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>logo on its own slide, rotating during breaks</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>1 minute pitch to full audience (including streaming audience)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr></tr>
-<tr><td>2 additional tickets (4 in total)</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>4 additional tickets (6 in total)</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-<tr><td>shared table for swag</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td>booth/table space</td><td>&nbsp;</td><td>&nbsp;</td><td bgcolor="gold">&nbsp;</td></tr>
-</table>
-<hr/>
-There are also opportunities for exclusive special sponsorships. We'll have sponsors for various events with special privileges for the sponsors of these events. If you are interested in special sponsorships or have a creative idea about how you can support the event, send us an email.
-<br/>
-<br/>
+### Silver - Price $1,500 USD
 
-<br>
-<br>
-<table border=1 cellspacing=1>
-  <tr>
-    <th><i>Sponsor FAQ</i></th>
-    <th><center><b>Answers to questions frequently asked by sponsors&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</center></b></th>
-    <th></th>
-  </tr>
-<tr><td>What dates/times can we set up and tear down?</td><td></td></tr>
-<tr><td>How do we ship to the venue?</td><td></td></tr>
-<tr><td>How do we ship from the venue?</td><td></td></tr>
-<tr><td>Whom should we send?</td><td></td></tr>
-<tr><td>What should we expect regarding electricity? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>What should we expect regarding WiFi? (how much, any fees, etc)</td><td></td></tr>
-<tr><td>How do we order additional A/V equipment?</td><td></td></tr>
-<tr><td>Additional important details</td><td></td></tr>
-</table>
-</div>
+* 1 included ticket
+* 10% discount code to share with your community
+* Logo on shared slide, rotating during breaks
+* Logo on DevOpsDays DC 2022 event website
 
--->
+Registration coming soon!
+
+### Gold - Price $4,000 USD
+
+* All benefits of Silver sponsors
+* Mentioned on all email communication
+* 1 additional ticket, 2 in total
+* Shared table for swag/marketing/staffing
+
+Registration coming soon!
+
+### Platinum - Price $6,000 USD
+
+* All benefits of Gold sponsors
+* 1 minute pitch to full audience, including streaming audience (provided we are able to stream the videos)
+* 2 additional tickets, 4 in total
+* Full table for swag/marketing/staffing
+
+Registration coming soon!
+
 <hr/>

--- a/data/events/2022-washington-dc.yml
+++ b/data/events/2022-washington-dc.yml
@@ -250,13 +250,13 @@ sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 # unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
 # sponsorship for a specific level, it is best to remove the level.
 sponsor_levels:
+  - id: platinum
+    label: Platinum
   - id: gold
     label: Gold
 #    max: 10
   - id: silver
     label: Silver
     max: 0 # This is the same as omitting the max limit.
-  - id: bronze
-    label: Bronze
-  - id: community
-    label: Community
+  # - id: community
+  #   label: Community


### PR DESCRIPTION
Basic levels and pricing. Registration links pending.

Based on 2019 sponsor page. Keeping Media, Community, and Captions sponsorships invisible until details about them are finalized.