### PR TITLE
[AMS-2022] Put tshirt higher than gold, as its more in €

### DIFF
--- a/data/events/2022-amsterdam.yml
+++ b/data/events/2022-amsterdam.yml
@@ -181,12 +181,12 @@ sponsor_levels:
   - id: coffee
     label: Coffee
     max: "1"
-  - id: gold
-    label: Gold
-    max: "8"
   - id: tshirt
     label: T-Shirt
     max: "1"
+  - id: gold
+    label: Gold
+    max: "8"
   - id: lanyard
     label: Lanyard
     max: "1"


### PR DESCRIPTION
Signed-off-by: yvovandoorn <yvo.vandoorn@gmail.com>

tshirt needs to be above gold, fixed. 