### PR TITLE
[AMS-2022] Bring registration back to the website

### DIFF
--- a/content/events/2022-amsterdam/registration.md
+++ b/content/events/2022-amsterdam/registration.md
@@ -1,4 +1,6 @@
 +++
+City = "Amsterdam"
+Year = "2022"
 Title = "Registration"
 Type = "event"
 Description = "Registration for devopsdays Amsterdam 2022"
@@ -13,9 +15,23 @@ Description = "Registration for devopsdays Amsterdam 2022"
 <br>
 <br>
 
-<div class = "col-md-12">
-<iframe src="https://eventbrite.com/tickets-external?eid=255486305417&ref=etckt" frameborder="0" height="500" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe>
-<div style="font-family:Helvetica, Arial; font-size:12px; padding:10px 0 5px; margin:2px; width:100%; text-align:left;" >
-<a class="powered-by-eb" style="color: #ADB0B6; text-decoration: none;" target="_blank" href="https://www.eventbrite.com/">Powered by Eventbrite</a>
-</div>
-</div>
+<div id="eventbrite-widget-container-255486305417"></div>
+
+<script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
+
+<script type="text/javascript">
+    var exampleCallback = function() {
+        console.log('Order complete!');
+    };
+
+    window.EBWidgets.createWidget({
+        // Required
+        widgetType: 'checkout',
+        eventId: '255486305417',
+        iframeContainerId: 'eventbrite-widget-container-255486305417',
+
+        // Optional
+        iframeContainerHeight: 600,  // Widget height in pixels. Defaults to a minimum of 425px if not provided
+        onOrderComplete: exampleCallback  // Method called when an order has successfully completed
+    });
+</script>

--- a/content/events/2022-amsterdam/welcome.md
+++ b/content/events/2022-amsterdam/welcome.md
@@ -74,6 +74,15 @@ Description = "devopsdays Amsterdam will take place June 22-24, 2022! The group 
 
 <div class = "row">
   <div class = "col-md-2">
+    <strong>Get a ticket</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="registration" text="Buy a ticket to the conference" >}}
+  </div>
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
     <strong>Contact</strong>
   </div>
   <div class = "col-md-8">
@@ -90,6 +99,13 @@ Description = "devopsdays Amsterdam will take place June 22-24, 2022! The group 
             style="margin-top: 10px; margin-bottom: 10px; background-color: #96bfe6; border-color: #96bfe6;"
             href="/events/2022-amsterdam/sponsor">
             <i class="fa fa-money fa-lg"></i>&nbsp;&nbsp;&nbsp;Sponsor the Conference
+          </a>
+        </div>
+        <div class="d-flex p-2">
+          <a class="btn btn-primary btn-block"
+            style="margin-top: 10px; margin-bottom: 10px; background-color: #e6bd96; border-color: #e6bd96;"
+            href="/events/2022-amsterdam/registration">
+            <i class="fa fa-ticket fa-lg"></i>&nbsp;&nbsp;&nbsp;Buy a ticket
           </a>
         </div>
         <div class="d-flex p-2">

--- a/data/events/2022-amsterdam.yml
+++ b/data/events/2022-amsterdam.yml
@@ -21,10 +21,10 @@ cfp_date_announce: # inform proposers of status
 cfp_link: "https://sessionize.com/devopsdays-amsterdam-2022/" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2022-01-01T00:00:00+02:00 # start accepting registration. Leave blank if registration is not open yet
-registration_date_end: 2022-06-21T23:59:59+02:00 # close registration. Leave blank if registration is not open yet.
+registration_date_end: 2022-06-22T23:59:59+02:00 # close registration. Leave blank if registration is not open yet.
 
-registration_closed: "true" #set this to true if you need to manually close registration before your registration end date
-registration_link: "https://www.eventbrite.com/e/devopsdays-amsterdam-2022-tickets-255486305417" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
+registration_closed: "" #set this to true if you need to manually close registration before your registration end date
+# registration_link: "https://www.eventbrite.com/e/devopsdays-amsterdam-2022-tickets-255486305417" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 
 # Location
 #


### PR DESCRIPTION
Signed-off-by: yvovandoorn <yvo.vandoorn@gmail.com>

Registration was going directly to Eventbrite. Using embedded checkout instead so the registration flow stays on devopsdays.org. 