### PR TITLE
[GCP Sponsor] Update URL to cloud.google.com/devops

### DIFF
--- a/data/sponsors/googlecloud.yml
+++ b/data/sponsors/googlecloud.yml
@@ -1,3 +1,3 @@
 name: "Google Cloud"
-url: "https://cloud.google.com/?utm_source=web&utm_campaign=devopsdays"
+url: "https://cloud.google.com/devops/?utm_source=web&utm_campaign=devopsdays"
 twitter: "gcpcloud"


### PR DESCRIPTION
This landing page is more appropriate for the DevOpsDays community.

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>
