### PR TITLE
[AMS-2022] General website tweaks

### DIFF
--- a/content/events/2022-amsterdam/registration.md
+++ b/content/events/2022-amsterdam/registration.md
@@ -9,7 +9,7 @@ Description = "Registration for devopsdays Amsterdam 2022"
 <div style="width:100%; text-align:left;">
 
 <div class = "col-md-12">
-  If you or your company is interested in paying us directly via an invoice for a bulk ticket order, please <a href="mailto:amsterdam@devopsdays.org?subject=devopsdays%20AMS%202019%20-%20Pay%20Direct%20with%20Invoice">contact us by sending us an email @ amsterdam@devopsdays.org</a>
+  If you or your company is interested in paying us directly via an invoice for a bulk ticket order, please <a href="mailto:amsterdam@devopsdays.org?subject=devopsdays%20AMS%202022%20-%20Pay%20Direct%20with%20Invoice">contact us by sending us an email @ amsterdam@devopsdays.org</a>
 </div>
 
 <br>

--- a/content/events/2022-amsterdam/welcome.md
+++ b/content/events/2022-amsterdam/welcome.md
@@ -27,14 +27,14 @@ Description = "devopsdays Amsterdam will take place June 22-24, 2022! The group 
   </div>
 </div>
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
     <strong>Register</strong>
   </div>
   <div class = "col-md-8">
     {{< event_link page="registration" text="Register to attend the conference!" >}}
   </div>
-</div> -->
+</div>
 
 <!-- <div class = "row">
   <div class = "col-md-2">
@@ -45,23 +45,23 @@ Description = "devopsdays Amsterdam will take place June 22-24, 2022! The group 
   </div>
 </div> -->
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
     <strong>Program</strong>
   </div>
   <div class = "col-md-8">
     View the {{< event_link page="program" text="program." >}}
   </div>
-</div> -->
+</div>
 
-<!-- <div class = "row">
+<div class = "row">
   <div class = "col-md-2">
     <strong>Speakers</strong>
   </div>
   <div class = "col-md-8">
     Check out the {{< event_link page="speakers" text="speakers!" >}}
   </div>
-</div> -->
+</div>
 
 <div class = "row">
   <div class = "col-md-2">
@@ -103,7 +103,7 @@ Description = "devopsdays Amsterdam will take place June 22-24, 2022! The group 
         </div>
         <div class="d-flex p-2">
           <a class="btn btn-primary btn-block"
-            style="margin-top: 10px; margin-bottom: 10px; background-color: #e6bd96; border-color: #e6bd96;"
+            style="margin-top: 10px; margin-bottom: 10px; background-color: #e59049; border-color: #e59049;"
             href="/events/2022-amsterdam/registration">
             <i class="fa fa-ticket fa-lg"></i>&nbsp;&nbsp;&nbsp;Buy a ticket
           </a>
@@ -124,7 +124,7 @@ Description = "devopsdays Amsterdam will take place June 22-24, 2022! The group 
       <br><br>
       devopsdays Amsterdam brings development, operations, QA, InfoSec, management, and leadership together to discuss the culture and tools to make better organizations and products. The 2022 event will be the seventh time we have held devopsdays Amsterdam, and it should be bigger and better than ever before!
       <br><br>
-      We expect 400 people this year and will be holding the event on June 22-24, 2022 at the <a href="/events/2022-amsterdam/location">Pakhuis de Zwijger</a> in the center of Amsterdam. Attendees will be required to follow local government policies & mandates regarding vaccination status & ability to attend. 
+      We expect 400 people this year and will be holding the event on June 22-24, 2022 at the <a href="/events/2022-amsterdam/location">Pakhuis de Zwijger</a> in the center of Amsterdam. Attendees will be required to follow local government policies & mandates regarding vaccination status & ability to attend.
       <br><br>
       The format of devopsdays Amsterdam includes a single track of 30 minute talks in the morning of each event, followed by Ignite talks (5 minute, auto forwarding). We spend the rest of the afternoon in Open Spaces, which are considered a key portion of the event. For those not interested in the Open Spaces, we continue offering the single track around a specific theme (previously around Security and HumanOps).
     </div>
@@ -164,7 +164,7 @@ Description = "devopsdays Amsterdam will take place June 22-24, 2022! The group 
     <div class="row">
       <div class="alert alert-secondary" role="alert">
         <h3>COVID Policy</h3>
-        <p>All attendees, sponsors, and everyone on site are encouraged to have up to date COVID Vaccines. We will be adhering to any local mandates in effect during the event. We ask that anyone sick with COVID or with recent exposure to COVID-positive individuals not attend in person. This can be coordinated through our organizers and will include a full refund.</p>
+        <p>All attendees, sponsors, and everyone on site are encouraged to have up to date COVID Vaccines. We will be adhering to any local mandates set by the City of Amsterdam and/or <a href="https://www.government.nl/topics/coronavirus-covid-19/tackling-new-coronavirus-in-the-netherlands/coronavirus-measures-and-advice-in-brief">Dutch Government</a> which may be effect during the event. We ask that anyone sick with COVID or with recent exposure to COVID-positive individuals not attend in person. This can be coordinated through our organizers and will include a full refund.</p>
         <p>Please direct questions to {{< email_organizers >}}</p>
       </div>
     </div>


### PR DESCRIPTION
- Uncomment links on main page to program, registration, speakers
- Link to Dutch COVID policy (english language)
- Pop ticket button a bit more
- Fix 2019 to 2022 in invoice email link (every year Yvo, every year). 

Signed-off-by: yvovandoorn <yvo.vandoorn@gmail.com>

