### PR TITLE
[BLN-2022] Add Linuxmagazin as media partner

### DIFF
--- a/data/events/2022-berlin.yml
+++ b/data/events/2022-berlin.yml
@@ -97,6 +97,8 @@ organizer_email: "berlin@devopsdays.org" # Put your organizer email address here
 sponsors:
   - id: netways
     level: partner
+  - id: linuxmagazin
+    level: partner
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
