### PR TITLE
[#9784] Add ability for speakers' twitch.tv

### DIFF
--- a/themes/devopsdays-theme/REFERENCE.md
+++ b/themes/devopsdays-theme/REFERENCE.md
@@ -299,6 +299,7 @@ Pages of the type `speaker` have a few additional frontmatter elements available
 | `linkedin` | No       | Speaker's LinkedIn URL                                                                                                                                                                                     | "https://www.linkedin.com/in/mattstratton/" |
 | `github`   | No       | Speakers' GitHub username.                                                                                                                                                                                 | "mattstratton"                              |
 | `gitlab`   | No       | Speakers' GitLab username.                                                                                                                                                                                 | "mattstratton"                              |
+| `twitch`   | No       | Speakers' Twitch username.                                                                                                                                                                                 | "mattstratton"                              |
 | `image`    | No       | The image for the speaker. This image is relative to the `static/events/YYYY-CITY/speakers` directory. It can be either .png or .jpg. It is recommended to be 600px square.  | "matt-stratton.jpg"                         |
 
 ### Program Page Fields

--- a/themes/devopsdays-theme/layouts/speaker/single.html
+++ b/themes/devopsdays-theme/layouts/speaker/single.html
@@ -93,6 +93,15 @@
       </a>
       {{- end -}}
     {{- end -}}
+    {{- if isset .Params "twitch" -}}
+      {{- if ne .Params.twitch "" -}}
+        <a href = "https://twitch.tv/{{ .Params.twitch }}"><i class="fa fa-twitch fa-2x" aria-hidden="true"></i>&nbsp;
+      {{- if $e.speakers_verbose -}}
+        {{ .Params.twitch }}<br />
+      {{- end -}}
+      </a>
+      {{- end -}}
+    {{- end -}}
   </div>
 </div>
 {{ partial "sponsors.html" . }}

--- a/themes/devopsdays-theme/layouts/talk/single.html
+++ b/themes/devopsdays-theme/layouts/talk/single.html
@@ -187,6 +187,12 @@
         <a href = "https://pronoun.is/{{ .Params.pronouns }}"><i class="fa fa-user fa-2x" aria-hidden="true"></i>&nbsp;</a>
       {{- end -}}
     {{- end -}}
+    {{- if isset .Params "twitch" -}}
+      {{- if ne .Params.twitch "" -}}
+        <a href = "https://twitch.tv/{{ .Params.twitch }}"><i class="fa fa-twitch fa-2x" aria-hidden="true"></i>&nbsp;</a>
+      {{- end -}}
+    {{- end -}}
+
     <br />
           <span class="talk-page content-text">
           {{- if ge (countrunes .Content ) 200 -}}


### PR DESCRIPTION
This pull request resolves #9784

I've got a bit of free time so pickig up a few low hanging fruit from issues:

- Added blocks for twitch in talk and speaker within the theme.
- Added reference to twitch in `REFERENCE.md`

Could possibly add this to organizers too I guess..