### PR TITLE
[2022-AMS] Remove Albert Heijn from 2022 sponsors.

### DIFF
--- a/data/events/2022-amsterdam.yml
+++ b/data/events/2022-amsterdam.yml
@@ -186,8 +186,6 @@ sponsors:
     level: bronze
   - id: ministerievandefensie
     level: bronze
-  - id: albert-heijn
-    level: bronze
 
 sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Removing Albert Heijn from sponsors. The parent company, Ahold Delhaize, has incredibly petty invoice rules that were not communicated up front. 