### PR TITLE
[DC-2022] Add PayPal buttons for sponsorships

### DIFF
--- a/content/events/2022-washington-dc/sponsor.md
+++ b/content/events/2022-washington-dc/sponsor.md
@@ -56,9 +56,30 @@ The following chart outlines our sponsorship packages.
   </tr>
   <tr class="hed2">
     <td></td>
-    <td><strong>$1,500 USD</strong></td>
-    <td><strong>$4,000 USD</strong></td>
-    <td><strong>$6,000 USD</strong></td>
+    <td><strong>$1,500 USD</strong>
+      <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+        <input type="hidden" name="cmd" value="_s-xclick">
+        <input type="hidden" name="hosted_button_id" value="WQSA8VZ3PHHKE">
+        <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_buynowCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+        <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+      </form>
+    </td>
+    <td><strong>$4,000 USD</strong>
+      <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+        <input type="hidden" name="cmd" value="_s-xclick">
+        <input type="hidden" name="hosted_button_id" value="JW6VLNEQKJMQG">
+        <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_buynowCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+        <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+      </form>
+    </td>
+    <td><strong>$6,000 USD</strong>
+      <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+        <input type="hidden" name="cmd" value="_s-xclick">
+        <input type="hidden" name="hosted_button_id" value="RYMPY96YMWJUW">
+        <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_buynowCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+        <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+      </form>
+    </td>
     <!--
     <td><strong class="stamp">TBD</strong></td>
     <td><strong class="stamp">TBD</strong></td>
@@ -68,8 +89,8 @@ The following chart outlines our sponsorship packages.
     <tr>
     <td>Available sponsorships</td>
     <td class="yes">5</td>
-    <td class="yes">5</td>
-    <td class="yes">15</td>
+    <td class="yes"><s>5</s> 3</td>
+    <td class="yes"><s>15</s> 13</td>
   </tr>
   <tr>
     <td>Logo on shared slide, rotating during breaks</td>


### PR DESCRIPTION
Add PayPal buttons to pay for sponsorships. And add strikethroughs to reflect current number of available sponsorships at each level.