### PR TITLE
[CLT-2022] Organizer name update

### DIFF
--- a/data/events/2022-charlotte.yml
+++ b/data/events/2022-charlotte.yml
@@ -54,7 +54,7 @@ team_members: # Name is the only required field for team members.
   - name: "Jacob Maggio"
   - name: "Meka Hayes"
   - name: "Brock Woodring"
-  - name: "Quitra Radney"
+  - name: "Vonquitra Bebee-Thomas"
   - name: "Yates Spearman"
     linkedin: "https://www.linkedin.com/in/yates-spearman-822828168"
     github: "YatesSpearman"


### PR DESCRIPTION
Updating an organizer's name. Just sent the email to core with subject Charlotte 2022 organizer update