### PR TITLE
Sponsor levels with `max: 1` are suffixed with plurals

### DIFF
--- a/data/events/2016-amsterdam.yml
+++ b/data/events/2016-amsterdam.yml
@@ -106,22 +106,22 @@ sponsors:
 sponsor_levels:
   - id: bbq
     label: BBQ
-    max: "1"
+    max: 1
   - id: preevent
     label: "Pre Event"
-    max: "1"
+    max: 1
   - id: beer
     label: Beer
-    max: "1"
+    max: 1
   - id: gold
     label: Gold
-    max: "8"
+    max: 8
   - id: silver
     label: Silver
-    max: "4"
+    max: 4
   - id: bronze
     label: Bronze
-    max: "4"
+    max: 4
   - id: community
     label: Community
 

--- a/data/events/2016-capetown.yml
+++ b/data/events/2016-capetown.yml
@@ -63,22 +63,22 @@ sponsors: # List all of your sponsors here along with what level of sponsorship 
 sponsor_levels: # In this section, list the level of sponsorships and the label to use.
   - id: platinum
     label: Platinum
-    max: "1"
+    max: 1
   - id: gold
     label: Gold
-    max: "3"
+    max: 3
   - id: silver
     label: Silver
-    max: "3"
+    max: 3
   - id: bronze
     label: Bronze
-    max: "3"
+    max: 3
   - id: eventdinner
     label: "Event dinner"
-    max: "1"
+    max: 1
   - id: closingevent
     label: "Closing drinks"
-    max: "1"
+    max: 1
 
 speakers:
   - id: "daniel-maher"

--- a/data/events/2017-amsterdam.yml
+++ b/data/events/2017-amsterdam.yml
@@ -127,19 +127,19 @@ sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: bbq
     label: "Evening Event"
-    max: "1"
+    max: 1
   - id: preevent
     label: "Pre Event Social"
-    max: "1"
+    max: 1
   - id: beer
     label: Beer
-    max: "1"
+    max: 1
   - id: gold
     label: Gold
-    max: "8"
+    max: 8
   - id: silver
     label: Silver
-    max: "4"
+    max: 4
   - id: bronze
     label: Bronze
-    max: "8"
+    max: 8

--- a/data/events/2017-cuba.yml
+++ b/data/events/2017-cuba.yml
@@ -89,28 +89,28 @@ sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels: # In this section, list the level of sponsorships and the label to use.
 #  - id: platinum
 #    label: Platinum
-#    max: "0"
+#    max: 0
 #  - id: gold
 #    label: Gold
-#    max: "0"
+#    max: 0
 #  - id: silver
 #    label: Silver
-#    max: "0"
+#    max: 0
   - id: bronze
     label: Bronze
-    max: "0"
+    max: 0
   - id: honorary
     label: Honorary
-    max: "2"
+    max: 2
   - id: media
     label: Media
-    max: "6"
+    max: 6
   - id: community
     label: Community
-    max: "6"
+    max: 6
   - id: sticker
     label: Sticker
-    max: "1"
+    max: 1
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.

--- a/data/events/2017-riga.yml
+++ b/data/events/2017-riga.yml
@@ -109,28 +109,28 @@ sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: venue
     label: Venue
-    max: "1"
+    max: 1
   - id: lunch
     label: Lunch and break
-    max: "1"
+    max: 1
   #- id: party
   #  label: Party
-  #  max: "1"
+  #  max: 1
   #- id: dinners
   #  label: Dinners with speakers
-  #  max: "1"
+  #  max: 1
   #- id: beer
   #  label: Beer
-  #  max: "1"
+  #  max: 1
   - id: platinum
     label: Platinum
-    max: "5"
+    max: 5
   - id: gold
     label: Gold
-    max: "8"
+    max: 8
   - id: silver
     label: Silver
-    max: "12"
+    max: 12
   - id: transport
     label: Official Transport
     max: 1
@@ -138,7 +138,7 @@ sponsor_levels:
   #  label: Student tickets
   #- id: lanyards
   #  label: Lanyards
-  #  max: "1"
+  #  max: 1
   - id: friends
     label: Friends, media partners and other
 

--- a/data/events/2018-amsterdam.yml
+++ b/data/events/2018-amsterdam.yml
@@ -167,22 +167,22 @@ sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: coffee
     label: "Coffee"
-    max: "1"
+    max: 1
   - id: beer
     label: Beer
-    max: "1"
+    max: 1
   - id: gold
     label: Gold
-    max: "10"
+    max: 10
   - id: recharge
     label: "Power recharge"
-    max: "1"
+    max: 1
   - id: silver
     label: Silver
-    max: "7"
+    max: 7
   - id: lanyard
     label: "Lanyard"
-    max: "1"
+    max: 1
   - id: bronze
     label: Bronze
 

--- a/data/events/2018-riga.yml
+++ b/data/events/2018-riga.yml
@@ -101,19 +101,19 @@ sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: platinum
     label: Platinum
-    max: "3"
+    max: 3
   - id: gold
     label: Gold
-    max: "8"
+    max: 8
   - id: beer
     label: Beer
-    max: "1"
+    max: 1
   - id: silver
     label: Silver
-    max: "12"
+    max: 12
   - id: lanyard
     label: Lanyard
-    max: "1"
+    max: 1
   - id: friends
     label: Friends, media partners and other
 

--- a/data/events/2019-amsterdam.yml
+++ b/data/events/2019-amsterdam.yml
@@ -182,31 +182,31 @@ sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: BBQ
     label: BBQ
-    max: "1"
+    max: 1
   - id: beer
     label: Beer
-    max: "1"
+    max: 1
   - id: coffee
     label: Coffee
-    max: "1"
+    max: 1
   - id: gold
     label: Gold
-    max: "8"
+    max: 8
   - id: silver
     label: Silver
-    max: "7"
+    max: 7
   - id: recharge
     label: "Power recharge"
-    max: "1"
+    max: 1
   - id: lanyard
     label: Lanyard
-    max: "1"
+    max: 1
   - id: foodtrucks
     label: "Food Trucks"
-    max: "3"
+    max: 3
   - id: wine
     label: "Wine"
-    max: "1"
+    max: 1
   - id: bronze
     label: Bronze
 

--- a/data/events/2020-amsterdam.yml
+++ b/data/events/2020-amsterdam.yml
@@ -105,16 +105,16 @@ sponsors:
 sponsor_levels:
   - id: media
     label: Media
-    max: "1"
+    max: 1
   - id: gold
     label: Gold
-    max: "3"
+    max: 3
   - id: silver
     label: Silver
-    max: "8"
+    max: 8
   - id: bronze
     label: Bronze
-    max: "10"
+    max: 10
 
 program:
   ## keynotes

--- a/data/events/2022-amsterdam.yml
+++ b/data/events/2022-amsterdam.yml
@@ -200,34 +200,34 @@ sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: BBQ
     label: BBQ
-    max: "1"
+    max: 1
   - id: beer
     label: Beer
-    max: "1"
+    max: 1
   - id: coffee
     label: Coffee
-    max: "1"
+    max: 1
   - id: tshirt
     label: T-Shirt
-    max: "1"
+    max: 1
   - id: gold
     label: Gold
-    max: "8"
+    max: 8
   - id: lanyard
     label: Lanyard
-    max: "1"
+    max: 1
   - id: recharge
     label: "Power recharge"
-    max: "1"
+    max: 1
   - id: foodtrucks
     label: "Food Trucks"
-    max: "4"
+    max: 4
   - id: silver
     label: Silver
-    max: "8"
+    max: 8
   - id: bronze
     label: Bronze
-    max: "5"
+    max: 5
 program:
   # Workshop Day
   - title: "Registration, Breakfast, Sponsors"

--- a/data/events/2022-eindhoven.yml
+++ b/data/events/2022-eindhoven.yml
@@ -131,22 +131,22 @@ sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 sponsor_levels:
   - id: socialevent
     label: "Social event"
-    max: "1"
+    max: 1
   - id: beer
     label: Beverage
-    max: "1"
+    max: 1
   - id: gold
     label: Gold
-    max: "6"
+    max: 6
   - id: lunch
     label: Lunch
-    max: "2"
+    max: 2
   - id: lanyard
     label: Lanyard
-    max: "1"
+    max: 1
   - id: silver
     label: Silver
-    max: "4"
+    max: 4
   - id: bronze
     label: Bronze
-    max: "6"
+    max: 6

--- a/themes/devopsdays-theme/layouts/partials/sponsors.html
+++ b/themes/devopsdays-theme/layouts/partials/sponsors.html
@@ -7,7 +7,7 @@
       <div class="row cta-row">
           <!--first sponsor row-->
           <div class="col-md-12">
-            {{- if eq $level.max "1" -}}
+            {{- if eq $level.max 1 -}}
               <h4 class="sponsor-cta">{{ $level.label }} Sponsor</h4>
             {{- else -}}
               <h4 class="sponsor-cta">{{ $level.label }} Sponsors</h4>


### PR DESCRIPTION
I noticed when working on #11449 that sponsors with the `max: 1` flag set still are described as "Sponsors", rather than "Sponsor". The comparison is for the string `"1"` rather than the integer `1`. I chose to change the comparison to `1` and update events that had used `"1"`, because there are many more events using `1` than `"1"` today.

```
[don@zeus ~/devopsdays-web/data/events:main] egrep 'max: [0-9]+$' * | wc -l
738
[don@zeus ~/devopsdays-web/data/events:main] egrep 'max: "[0-9]+"$' * | wc -l
82
```

Before:
![Screenshot from 2022-07-01 18-42-45](https://user-images.githubusercontent.com/8206137/176975902-b4014eb2-a5f1-4c13-a6dc-208adcc94de0.png)

After:
![Screenshot from 2022-07-01 18-42-56](https://user-images.githubusercontent.com/8206137/176975917-8e59eadf-fb67-411a-ab41-c2f1afdc3349.png)
