### PR TITLE
[DFW-2022] Adding Blameless as Silver sponsor

### DIFF
--- a/data/events/2022-dallas.yml
+++ b/data/events/2022-dallas.yml
@@ -239,6 +239,8 @@ sponsors:
     level: silver
   - id: improving
     level: silver
+  - id: blameless
+    level: silver
   - id: arresteddevops
     level: media
   - id: devopslive


### PR DESCRIPTION
Signed-off-by: Mike Rosado <mikerostx@gmail.com>

*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
