### PR TITLE
[MSP-2022] Added Delphix and Target as Silver sponsors

### DIFF
--- a/data/events/2022-minneapolis.yml
+++ b/data/events/2022-minneapolis.yml
@@ -154,6 +154,10 @@ sponsors:
     level: silver
   - id: harness
     level: silver
+  - id: delphix
+    level: silver
+  - id: target
+    level: silver
   - id: hackthegap
     level: community
 


### PR DESCRIPTION
*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
