### PR TITLE
Do not show cancelled events in the event lists

### DIFF
--- a/themes/devopsdays-theme/layouts/partials/past.html
+++ b/themes/devopsdays-theme/layouts/partials/past.html
@@ -7,11 +7,13 @@ Chomping .year has the nice effect of turning an int into string. */}}
   {{- $r_year := . -}}
   {{- range $.Site.Data.events -}}
     {{- if .startdate -}}
+    {{- if ne .cancel "true" -}}
     {{- $my_year := string ((dateFormat "2006" .enddate )) -}}
       {{- if and (eq $my_year (string $r_year)) ( lt (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now))) -}}
         {{- $.Scratch.SetInMap "active_years" (print (chomp $my_year)) (print (chomp $my_year)) -}}
         {{- $.Scratch.SetInMap (print (chomp $my_year)) .enddate (.name) -}}
       {{- end -}}
+    {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -32,12 +34,14 @@ Chomping .year has the nice effect of turning an int into string. */}}
   Chomping here in order to convert int to string */}}
     {{- range sort $.Site.Data.events "startdate" -}}
     {{- if .startdate -}}
+    {{- if ne .cancel "true" -}}
       {{- if eq ( print (chomp (dateFormat "2006" .startdate))) (print (chomp ($.Scratch.Get "the_year"))) -}}
         {{- $.Scratch.Set "citydisplay" .city -}}
         <a href="{{ (printf "/events/%s" .name) }}" class = "events-page-event">{{ $.Scratch.Get "citydisplay" }}</a>
         <br/>
       {{- end -}}
 
+    {{- end -}}
     {{- end -}}
     {{- end -}}
     </div>


### PR DESCRIPTION
This change was spawned from a [Slack thread](https://devopsdays.slack.com/archives/C07T0BHHN/p1658539934998329) regarding why some cancelled events show up in the event lists, but some do not. (It was actually due to one event having a start date, and one not, but the bigger issue is that past events aren't respecting the cancel flag.)

Before (note presence of Philadelphia in 2020):
![Screenshot from 2022-07-22 21-38-35](https://user-images.githubusercontent.com/8206137/180585750-e0b6edc4-3f9a-4820-aa91-b62248372890.png)

After (note absence of Philadelphia from 2020):
![Screenshot from 2022-07-22 21-39-37](https://user-images.githubusercontent.com/8206137/180585751-767e3631-de5c-462c-ba6f-c9d406da4555.png)
