### PR TITLE
[BOS-2022] Sponsor true-up

### DIFF
--- a/data/events/2022-boston.yml
+++ b/data/events/2022-boston.yml
@@ -135,7 +135,7 @@ sponsors:
   - id: tonic
     level: platinum
   - id: vivanti
-    level: platinum
+    level: startupalley
   - id: firehydrant
     level: lanyard
   - id: atomiccoffeeroasters
@@ -149,6 +149,10 @@ sponsors:
   - id: edge-delta
     level: platinum
   - id: mattermost
+    level: platinum
+  - id: opscruise
+    level: startupalley
+  - id: kosli
     level: platinum
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
@@ -166,3 +170,5 @@ sponsor_levels:
   - id: coffee
     label: Coffee
     max: 1
+  - id: startupalley
+    label: Startup Alley


### PR DESCRIPTION
1. Kosli is a net-new sponsor.
2. Vivanti is misattributed as a platinum sponsor, but they're coming in
   on startup alley.
3. Opscruise is a net-new sponsor.