### PR TITLE
[DET-2022] Remove Sharing Images for Now

### DIFF
--- a/content/events/2022-detroit/speakers/chris-short.md
+++ b/content/events/2022-detroit/speakers/chris-short.md
@@ -2,7 +2,6 @@
 Title = "Chris Short"
 Twitter = "@ChrisShort"
 image = "chris-short.png"
-sharing_image = "chris-short.png"
 type = "speaker"
 linktitle = "chris-short"
 

--- a/content/events/2022-detroit/speakers/ell-marquez.md
+++ b/content/events/2022-detroit/speakers/ell-marquez.md
@@ -2,7 +2,6 @@
 Title = "Ell Marquez"
 Twitter = "@Ell_o_Punk"
 image = "ell-marquez.png"
-sharing_image = "ell-marquez.png"
 type = "speaker"
 linktitle = "ell-marquez"
 linkedin = "https://www.linkedin.com/in/ellmarquez/"

--- a/content/events/2022-detroit/speakers/fatima-sarah-khalid.md
+++ b/content/events/2022-detroit/speakers/fatima-sarah-khalid.md
@@ -2,7 +2,6 @@
 Title = "Fatima Sarah Khalid"
 Twitter = "@sugaroverflow"
 image = "fatima-sarah-khalid.png"
-sharing_image = "fatima-sarah-khalid.png"
 type = "speaker"
 linktitle = "fatima-sarah-khalid"
 linkedin = "https://www.linkedin.com/in/fatimasarahkhalid/"

--- a/content/events/2022-detroit/speakers/heidi-waterhouse.md
+++ b/content/events/2022-detroit/speakers/heidi-waterhouse.md
@@ -2,7 +2,6 @@
 Title = "Heidi Waterhouse"
 Twitter = "@wiredferret"
 image = "heidi-waterhouse.png"
-sharing_image = "heidi-waterhouse.png"
 type = "speaker"
 linktitle = "heidi-waterhouse"
 linkedin = "https://www.linkedin.com/in/heidiwaterhouse/"

--- a/content/events/2022-detroit/speakers/james-hunt.md
+++ b/content/events/2022-detroit/speakers/james-hunt.md
@@ -2,7 +2,6 @@
 Title = "James Hunt"
 Twitter = "@iamjameshunt"
 image = "james-hunt.png"
-sharing_image = "james-hunt.png"
 type = "speaker"
 linktitle = "james-hunt"
 linkedin = "https://linkedin.com/in/huntprod"

--- a/content/events/2022-detroit/speakers/jean-remi-beaudoin.md
+++ b/content/events/2022-detroit/speakers/jean-remi-beaudoin.md
@@ -2,7 +2,6 @@
 Title = "Jean-Rémi Beaudoin"
 Twitter = "@jiherr"
 image = "jean-remi-beaudoin.png"
-sharing_image = "jean-remi-beaudoin.png"
 type = "speaker"
 linktitle = "jean-remi-beaudoin"
 linkedin = "https://www.linkedin.com/in/jrbeaudoin"

--- a/content/events/2022-detroit/speakers/jim-barton.md
+++ b/content/events/2022-detroit/speakers/jim-barton.md
@@ -2,7 +2,6 @@
 Title = "Jim Barton"
 Twitter = "@jameshbarton"
 image = "jim-barton.png"
-sharing_image = "jim-barton.png"
 type = "speaker"
 linktitle = "jim-barton"
 linkedin = "https://www.linkedin.com/in/jameshbarton/"

--- a/content/events/2022-detroit/speakers/matan-cohen.md
+++ b/content/events/2022-detroit/speakers/matan-cohen.md
@@ -2,7 +2,6 @@
 Title = "Matan Cohen"
 Twitter = ""
 image = "matan-cohen.png"
-sharing_image = "matan-cohen.png"
 type = "speaker"
 linktitle = "matan-cohen"
 

--- a/content/events/2022-detroit/speakers/matty-stratton.md
+++ b/content/events/2022-detroit/speakers/matty-stratton.md
@@ -2,7 +2,6 @@
 Title = "Matty Stratton"
 Twitter = "@mattstratton"
 image = "matty-stratton.png"
-sharing_image = "matty-stratton.png"
 type = "speaker"
 linktitle = "matty-stratton"
 

--- a/content/events/2022-detroit/speakers/mofi-rahman.md
+++ b/content/events/2022-detroit/speakers/mofi-rahman.md
@@ -2,7 +2,6 @@
 Title = "Mofi Rahman"
 Twitter = "@moficodes"
 image = "mofi-rahman.png"
-sharing_image = "mofi-rahman.png"
 type = "speaker"
 linktitle = "mofi-rahman"
 linkedin = "https://linkedin.com/in/moficodes"

--- a/content/events/2022-detroit/speakers/nocnica-mellifera.md
+++ b/content/events/2022-detroit/speakers/nocnica-mellifera.md
@@ -2,7 +2,6 @@
 Title = "Nočnica Mellifera"
 Twitter = "@serverless_mom"
 image = "nocnica-mellifera.png"
-sharing_image = "nocnica-mellifera.png"
 type = "speaker"
 linktitle = "nocnica-mellifera"
 linkedin = "https://www.linkedin.com/in/serverlessmom/"

--- a/content/events/2022-detroit/speakers/rain-leander.md
+++ b/content/events/2022-detroit/speakers/rain-leander.md
@@ -2,7 +2,6 @@
 Title = "Rain Leander"
 Twitter = "@rainleander"
 image = "rain-leander.png"
-sharing_image = "rain-leander.png"
 type = "speaker"
 linktitle = "rain-leander"
 linkedin = "https://www.linkedin.com/in/rainleander/"

--- a/content/events/2022-detroit/speakers/ray-welker.md
+++ b/content/events/2022-detroit/speakers/ray-welker.md
@@ -2,7 +2,6 @@
 Title = "Ray Welker"
 Twitter = ""
 image = "ray-welker.png"
-sharing_image = "ray-welker.png"
 type = "speaker"
 linktitle = "ray-welker"
 linkedin = "https://www.linkedin.com/in/ray-welker/"

--- a/content/events/2022-detroit/speakers/rizel-scarlett.md
+++ b/content/events/2022-detroit/speakers/rizel-scarlett.md
@@ -2,7 +2,6 @@
 Title = "Rizel Scarlett"
 Twitter = "@blackgirlbytes"
 image = "rizel-scarlett.png"
-sharing_image = "rizel-scarlett.png"
 type = "speaker"
 linktitle = "rizel-scarlett"
 linkedin = "https://www.linkedin.com/in/rizel-bobb-semple/"

--- a/content/events/2022-detroit/speakers/steve-mcghee.md
+++ b/content/events/2022-detroit/speakers/steve-mcghee.md
@@ -2,7 +2,6 @@
 Title = "Steve McGhee"
 Twitter = "@stevemcghee"
 image = "steve-mcghee.png"
-sharing_image = "steve-mcghee.png"
 type = "speaker"
 linktitle = "steve-mcghee"
 linkedin = "https://www.linkedin.com/in/stevemcghee"

--- a/content/events/2022-detroit/speakers/whitney-lee.md
+++ b/content/events/2022-detroit/speakers/whitney-lee.md
@@ -2,7 +2,6 @@
 Title = "Whitney Lee"
 Twitter = "@wiggitywhitney"
 image = "whitney-lee.png"
-sharing_image = "whitney-lee.png"
 type = "speaker"
 linktitle = "whitney-lee"
 


### PR DESCRIPTION
Removing reference to sharing images until we have them to publish, don't want my mistake to throw off social posts.

