### PR TITLE
[HOU-2022] Adding Diamanti as a gold sponsor for Houston event in 2022

### DIFF
--- a/data/events/2022-houston.yml
+++ b/data/events/2022-houston.yml
@@ -114,6 +114,8 @@ sponsors:
     level: gold
   - id: stackhawk
     level: gold
+  - id: diamanti
+    level: gold
   - id: improving
     level: silver
   - id: edge-delta

--- a/data/sponsors/diamanti.yml
+++ b/data/sponsors/diamanti.yml
@@ -1,3 +1,3 @@
 name: "Diamanti"
 url: "https://diamanti.com/"
-twitter:
+twitter: "Diamanticom"


### PR DESCRIPTION
[HOU-2022] Adding Diamanti as a gold sponsor for Houston event in 2022