### PR TITLE
[DC-2022] Add the program and schedule for the event

### DIFF
--- a/content/events/2022-washington-dc/program.md
+++ b/content/events/2022-washington-dc/program.md
@@ -1,0 +1,16 @@
++++
+Title = "Program"
+Type = "program"
+Description = "Program for devopsdays DC 2022"
+Icons = "false"
++++
+
+<div class = "row">
+  <div class = "col">
+    <hr />
+    If Open Space is new to you, you may be interested in <a href="/pages/open-space-format">more details about Open Space</a>.
+    <hr />
+    <i>All times are in US Eastern Time</i>
+  </div>
+</div>
+<script type="text/javascript" src="https://sessionize.com/api/v2/aqm2ijyd/view/GridSmart"></script>

--- a/data/events/2022-washington-dc.yml
+++ b/data/events/2022-washington-dc.yml
@@ -35,7 +35,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
  # - name: propose
  - name: location
  - name: registration
- # - name: program
+ - name: program
  # - name: speakers
  - name: sponsor
  - name: contact


### PR DESCRIPTION
Add the program and schedule for the event. All of the times, talks, and speakers are in Sessionize.

DO NOT MERGE INTO MAIN YET. Need to get review and confirm one final speaker.