### PR TITLE
[BOS-2022] Update reg links, GA code, and organizers

### DIFF
--- a/content/events/2022-boston/welcome.md
+++ b/content/events/2022-boston/welcome.md
@@ -27,6 +27,10 @@ h1.welcome-page { text-transform: initial; }
       <div class="col-md-8">{{< event_location >}}</div>
     </div>
     <div class="row">
+      <div class="col-md-2"><strong>Register</strong></div>
+      <div class="col-md-8"><a href="https://ti.to/devopsdaysbos/2022">Register to attend the conference!</a></div>
+    </div>
+    <div class="row">
       <div class="col-md-2"><strong>Sponsors</strong></div>
       <div class="col-md-8">{{< event_link page="sponsor" text="Sponsor the conference!" >}}</div>
     </div>

--- a/data/events/2022-boston.yml
+++ b/data/events/2022-boston.yml
@@ -3,7 +3,7 @@ year: "2022" # The year of the event. Make sure it is in quotes.
 city: "Boston" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdaysbos" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Boston!" # Edit this to suit your preferences
-ga_tracking_id: "UA-137417319-4" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+ga_tracking_id: "UA-137417319-10" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 
 # All dates are in unquoted 2022-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00
@@ -20,11 +20,11 @@ cfp_date_announce: "2022-05-15T00:00:00-00:00"  # inform proposers of status
 
 cfp_link: "https://www.papercall.io/dodbos22" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
-registration_date_end: # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
+registration_date_start: "2022-08-05T00:00:00-00:00" # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
+registration_date_end: "2022-09-11T00:00:00-00:00" # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
-registration_link: "" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
+registration_link: "https://ti.to/devopsdaysbos/2022" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 
 # Location
 #
@@ -36,53 +36,47 @@ location_address: "539 Tremont St, Boston, MA 02116" # Optional - use the street
 nav_elements: # List of pages you want to show up in the navigation of your page.
  # - name: propose
   - name: location
- # - name: registration
+  - name: registration
   - name: program
   - name: speakers
   - name: sponsor
   - name: contact
   - name: conduct
+#  - name: covid-19-policy # until next PR based on group discussions
 # - name: example
 #   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/
 #   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
 
 
 # These are the same people you have on the mailing list and Slack channel.
-team_members: # Name is the only required field for team members.                                   
-  - name: "Michael Thomas Clark"                                                                    
-    linkedin: http://www.linkedin.com/in/michaeltclark                                              
-    twitter: "michaeltclark"                                                                        
+team_members: # Name is the only required field for team members.
+  - name: "Michael Thomas Clark"
+    linkedin: http://www.linkedin.com/in/michaeltclark
+    twitter: "michaeltclark"
     bio: "Michael is a veteran systems management professional. He has worked across multiple industry verticals as a software trainer, a front-line technician, a back-office engineer, an enterprise architect, and a manager of large-scale, global computing environments. His passions encompass envisioning, designing, building, and improving business and organizational systems of all varieties and at every scale. He is particularly passionate about helping systems professionals develop better ways to work together, improve the products they deliver, and most importantly, the culture of the workplaces in which we all labor."
-    image: "michaelclark.jpg"                                                                       
-    employer: "Renaissance Tech & Media"                                                            
-                                                                                                    
-  - name: "Don Luchini"                                                                             
+    image: "michaelclark.jpg"
+    employer: "Renaissance Tech & Media"
+
+  - name: "Don Luchini"
     bio: "Don Luchini is a Boston-based DevOps engineer specializing in infrastructure management and deployment automation pipelines. Over the past ten years, he has acted in the corporate IT, quality assurance, software development, and release engineering spaces, encompassing a number of roles that now fall under the term DevOps. He currently works at SimpliSafe, a Boston-based manufacturer of connected home security systems. In his spare time, he is a martial artist, radio enthusiast, and hobby photographer."
-    github: "don-code"                                                                              
-    image: "donluchini.jpg"                                                                         
-                                                                                                    
-  - name: "Michael D'Aniello"                                                                       
-    twitter: "MikeDaniello"                                                                         
-    linkedin: "http://www.linkedin.com/in/michaeldaniello"                                          
+    github: "don-code"
+    image: "donluchini.jpg"
+
+  - name: "Michael D'Aniello"
+    twitter: "MikeDaniello"
+    linkedin: "http://www.linkedin.com/in/michaeldaniello"
     bio: "Michael works as a Site Reliability Engineer for Carbon Black, a SaaS security company in the Boston area. He has a passion for all things surrounding cloud design and architecture, building tools with Go, automating infrastructure provisioning, and deployment automation pipelines. While not tinkering with tech he can be found pressing arcade stick buttons, or banging on drums."
-    github: "MichaelDaniello"                                                                       
-    image: "michaelbio.jpg"                                                                         
-                                                                                                    
-  - name: "Paul Bruce"                                                                              
+    github: "MichaelDaniello"
+    image: "michaelbio.jpg"
+
+  - name: "Paul Bruce"
     bio: "Paul Bruce is a DevOps Advisor, helping to transform enterprise software teams and delivery practices. He currently serves in the role of Founder at Growgistics, is a working group member of IEEE P2675, daylights with the Neotys team as Dir. of Customer Engineer, moonlights as a Papa of two, and lives as a friend to all. He loves meat pies, picklebacks, and community work. His technical research wheelhouse includes cloud management, high availability service architecture, API design and experience, continuous testing at scale, and organizational learning frameworks. He writes, listens, and teaches about software delivery patterns in enterprises and key industries and F1000s around the world. You can learn more at: http://paulsbruce.io"
-    website: "http://paulsbruce.io"                                                                 
-    image: "paulsbruce.jpg"                                                                         
-                                                                                                    
-  - name: "Adam Blackwell"                                                                          
-    bio: "Adam is a DevOps Engineer at edX, he enjoys combining software and systems engineering to build and run large-scale fault-tolerant environments. Before joining edX, he spent time solving infrastructure and security problems at large and small financial organizations in Boston. When he's not at a laptop he can be found skiing tall mountains or exploring far away oceans."
-    linkedin: http://www.linkedin.com/in/adamblackwell                                              
-    twitter: "adzuci"                                                                               
-    github: "adzuci"                                                                                
-    image: "adamblackwell.jpg"                                                                      
-                                                                                                    
-  - name: "Derek Buckley"                                                                           
+    website: "http://paulsbruce.io"
+    image: "paulsbruce.jpg"
+
+  - name: "Derek Buckley"
     bio: "Derek is a Linux System Administrator with a passion for reducing waste and toil. With a background as a Lean certified Quality Inspector in manufacturing, he found a way to bring the joy of the Kaizen method to his passion of Linux and technological systems. He now works for PerkinElmer in the BioPharmacuitcal space to help accelerate the Scientists' research through making computational resources easy to obtain and use. Outside of the computer world he can be found doing photography with the Boston Area Photography group, cooking, or listening to a veriety of music."
-    gitlab: "dbuckley"                                                                              
+    gitlab: "dbuckley"
     image: "derekbuckley.jpg"
 
   - name: "Aaron Aldrich"
@@ -91,11 +85,6 @@ team_members: # Name is the only required field for team members.
     github: "crayzeigh"
     website: "https://speaking.crayzeigh.com/"
     image: "aaronaldritch.jpg"
-
-  - name: "Emily Zall"
-    bio: "Emily is a DevOps Detective and newly Kubernetes certified with CKA."
-    linkedin: https://www.linkedin.com/in/emily-zall/
-    image: "emilyzall.jpg"
 
   - name: "Kate Ruh"
     bio: "Kate works as a Site Reliability Engineer for Stavvy, a fintech company in the Boston area looking to modernize home closings. She has a passion for all things infrastructure and application security, and using emojis to get things done. While not at work, she’s working on a farm, playing with her two dogs, or biking through the streets of Massachusetts."
@@ -119,9 +108,9 @@ sponsors:
   - id: solo
     level: platinum
   - id: humio
-    level: platinum 
+    level: platinum
   - id: fairwinds
-    level: platinum 
+    level: platinum
   - id: couchbase
     level: platinum
   - id: planetscale


### PR DESCRIPTION
* Add registration links for Tito 2022
* Updated GA tracking code (note: UA- codes will no longer be valid June 2023)
* Remove no longer active organizers