### PR TITLE
[CHA-2022] Fixing registration link

### DIFF
--- a/content/events/2022-chattanooga/propose.md
+++ b/content/events/2022-chattanooga/propose.md
@@ -9,8 +9,8 @@ Description = "Propose a talk for devopsdays Chattanooga 2022"
 
 There are three ways to propose a topic at devopsdays:
 <ol>
-  <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
-  <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
+  <li><strong><em>A 30-minute talk (technical or culture) </em></strong> presented during the conference. We stagger these throughout the day.</li>
+  <li><strong><em>An Ignite/lightning talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> that are typically closer to the end of the day. These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
   <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
 </ol>
 
@@ -27,9 +27,4 @@ Choosing talks is part art, part science; here are some factors we consider when
 
 <hr>
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+<strong>How to submit a proposal:</strong> Head over to <a href="https://sessionize.com/chattanooga-devopsdays-2022/"> our Sessionize page </a> and fill out a submission form.

--- a/content/events/2022-chattanooga/registration.md
+++ b/content/events/2022-chattanooga/registration.md
@@ -11,4 +11,4 @@ Description = "Registration for devopsdays Chattanooga 2022"
 </div>
 <br/>
 
-You can always use the following link: [https://ti.to/chattanooga-devopsdays/2022](https://ti.to/devopsdays-portugal/devopsdays-portugal-2022)
+You can always use the following link: [https://ti.to/chattanooga-devopsdays/2022](https://ti.to/chattanooga-devopsdays/2022)

--- a/data/events/2022-chattanooga.yml
+++ b/data/events/2022-chattanooga.yml
@@ -16,7 +16,7 @@ enddate:  2022-11-14T18:00:00-04:00 # The end date of your event. Leave blank if
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2022-08-08T12:00:00-4:00 # start accepting talk proposals.
 cfp_date_end: 2022-09-07T00:00:00-4:00 # close your call for proposals.
-cfp_date_announce: 2022-09-23T00:00:00-4:00 # inform proposers of status
+cfp_date_announce:  # inform proposers of status
 
 cfp_link: "https://sessionize.com/chattanooga-devopsdays-2022/" # if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
@@ -34,7 +34,6 @@ location: "Chattanooga" # Defaults to city, but you can make it the venue name.
 location_address: "1 Carter St, Chattanooga, TN 37402 " #Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-# - name: propose
   - name: location
   - name: registration
 # - name: program

--- a/data/events/2022-chattanooga.yml
+++ b/data/events/2022-chattanooga.yml
@@ -14,8 +14,8 @@ startdate: 2022-11-14T08:00:00-04:00 # The start date of your event. Leave blank
 enddate:  2022-11-14T18:00:00-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: 2022-08-08T12:00:00-4:00 # start accepting talk proposals.
-cfp_date_end: 2022-09-07T00:00:00-4:00 # close your call for proposals.
+cfp_date_start: 2022-08-08T12:00:00-04:00 # start accepting talk proposals.
+cfp_date_end: 2022-09-07T00:00:00-04:00 # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
 cfp_link: "https://sessionize.com/chattanooga-devopsdays-2022/" # if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/data/events/2022-chattanooga.yml
+++ b/data/events/2022-chattanooga.yml
@@ -10,12 +10,12 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 #   variable: 2019-01-05T23:59:59+02:00
 # Note: we allow 2022-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
-startdate: 2022-11-14T08:00:00-05:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
-enddate:  2022-11-14T18:00:00-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
+startdate: 2022-11-14T08:00:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.
+enddate:  2022-11-14T18:00:00-04:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2022-08-08T12:00:00-4:00 # start accepting talk proposals.
-cfp_date_end:  2022-09-07T00:00:00-4:00 # close your call for proposals.
+cfp_date_end: 2022-09-07T00:00:00-4:00 # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
 cfp_link: "https://sessionize.com/chattanooga-devopsdays-2022/" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/data/events/2022-chattanooga.yml
+++ b/data/events/2022-chattanooga.yml
@@ -16,9 +16,9 @@ enddate:  2022-11-14T18:00:00-04:00 # The end date of your event. Leave blank if
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2022-08-08T12:00:00-4:00 # start accepting talk proposals.
 cfp_date_end: 2022-09-07T00:00:00-4:00 # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_announce: 2022-09-23T00:00:00-4:00 # inform proposers of status
 
-cfp_link: "https://sessionize.com/chattanooga-devopsdays-2022/" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_link: "https://sessionize.com/chattanooga-devopsdays-2022/" # if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2022-07-26T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
 registration_date_end: # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
@@ -34,11 +34,11 @@ location: "Chattanooga" # Defaults to city, but you can make it the venue name.
 location_address: "1 Carter St, Chattanooga, TN 37402 " #Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- # - name: propose
+# - name: propose
   - name: location
   - name: registration
- # - name: program
- # - name: speakers
+# - name: program
+# - name: speakers
   - name: sponsor
   - name: contact
   - name: conduct

--- a/data/events/2022-chattanooga.yml
+++ b/data/events/2022-chattanooga.yml
@@ -14,11 +14,11 @@ startdate: 2022-11-14T08:00:00-05:00 # The start date of your event. Leave blank
 enddate:  2022-11-14T18:00:00-05:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:  # close your call for proposals.
+cfp_date_start: 2022-08-08T12:00:00-4:00 # start accepting talk proposals.
+cfp_date_end:  2022-09-07T00:00:00-4:00 # close your call for proposals.
 cfp_date_announce:  # inform proposers of status
 
-cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_link: "https://sessionize.com/chattanooga-devopsdays-2022/" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: 2022-07-26T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
 registration_date_end: # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
@@ -42,6 +42,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: sponsor
   - name: contact
   - name: conduct
+  - name: propose
 # - name: example
 #   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/
 #   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site


### PR DESCRIPTION
Registration link was borked. Updating it to be correct.

Also squeezing in some proposal info.