### PR TITLE
[LDN-2022] Add missing sponsors

### DIFF
--- a/data/events/2022-london.yml
+++ b/data/events/2022-london.yml
@@ -102,11 +102,11 @@ sponsors:
   - id: teleport
     level: gold
   # silver sponsors
-  - id: civio
-    level: silver
   - id: harness
     level: silver
   - id: circleci
+    level: silver
+  - id: civo
     level: silver
   - id: firehydrant
     level: silver

--- a/data/events/2022-london.yml
+++ b/data/events/2022-london.yml
@@ -84,15 +84,35 @@ organizer_email: "london@devopsdays.org" # Put your organizer email address here
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
   # platinum sponsors
+  - id: coralogix
+    level: platinum
   # gold sponsors
   - id: chef
+    level: gold
+  - id: delphix
+    level: gold
+  - id: kosli
     level: gold
   - id : github
     level: gold
   - id: humio
     level: gold
+  - id: spacelift
+    level: gold
+  - id: teleport
+    level: gold
   # silver sponsors
+  - id: civio
+    level: silver
   - id: harness
+    level: silver
+  - id: circleci
+    level: silver
+  - id: firehydrant
+    level: silver
+  - id: spectrocloud
+    level: silver
+  - id: squaredup
     level: silver
   # bronze sponsors
   - id: conflux


### PR DESCRIPTION
I've added the remaining sponsors that've been missing for a while
(sorry sponsors).

Added:
- coralogix as platinum
- delphix as gold
- spacelift as gold
- teleport as gold
- kosli as gold
- civo as silver
- squaredup as silver
- circleci as silver
- spectro cloud as silver
- firehydrant as silver
