### PR TITLE
[BOS-2022] Replace PlanetScale with Roost.ai

### DIFF
--- a/data/events/2022-boston.yml
+++ b/data/events/2022-boston.yml
@@ -113,8 +113,6 @@ sponsors:
     level: platinum
   - id: couchbase
     level: platinum
-  - id: planetscale
-    level: platinum
   - id: dynatrace
     level: platinum
   - id: circleci
@@ -152,6 +150,8 @@ sponsors:
   - id: sonatype
     level: platinum
   - id: zerto
+    level: platinum
+  - id: roostai
     level: platinum
 
 


### PR DESCRIPTION
PlanetScale had to bow out of sponsorship; we refunded them and gave this sponsorship slot to Roost.ai instead.
