### PR TITLE
[BUF-2022] Add F5 as gold sponsor.

### DIFF
--- a/data/events/2022-buffalo.yml
+++ b/data/events/2022-buffalo.yml
@@ -83,6 +83,8 @@ organizer_email: "buffalo@devopsdays.org" # Put your organizer email address her
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
+  - id: f5
+    level: gold
   - id: mandtbank
     level: gold
   - id: vivanti


### PR DESCRIPTION
Adding F5 as gold sponsor.

I know there's already a different PR for Buffalo out there, but I wanted to keep this separate since the other one has already mostly been reviewed.