### PR TITLE
[BLN-2022] Add initial list of confirmed speakers

### DIFF
--- a/content/events/2022-berlin/speakers/andriy-bilous.md
+++ b/content/events/2022-berlin/speakers/andriy-bilous.md
@@ -1,0 +1,13 @@
++++
+title = "Andriy Bilous"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["andriy-bilous"]
++++
+
+I am a DevOps leader with over 10 years of experience working in different IT companies.
+I am loving DevOps culture and trying to spread it across organizations.
+Knowledge sharing and public speaking are some of my favorite hobbies.

--- a/content/events/2022-berlin/speakers/christian-hueser.md
+++ b/content/events/2022-berlin/speakers/christian-hueser.md
@@ -1,0 +1,23 @@
++++
+title = "Christian Hüser"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["christian-hueser.md"]
++++
+
+With 10 years of experience in the area of software development, software
+testing, software architecture, and DevOps the speaker is a versatile Research
+Software Engineer (RSE) with a strong preference for DevOps technologies and
+practices. Products that he developed were web applications such as seminar,
+course, learning and campus management systems. During the last couple of years
+DevOps moved more and more into the focus of his work. As an RSE and
+DevOps-Engineer at the Helmholtz-Zentrum Dresden-Rossendorf (HZDR, hzdr.de) he
+and his colleagues were recently working on a GitLab service (called "the
+Helmholtz Codebase") - a free self-hosted version of the popular software
+project management and DevOps platform - that everyone in the Helmholtz
+Association can use free of charge. The Helmholtz Codebase is offered as part
+of the Helmholtz Cloud (https://helmholtz.cloud) and made available by the
+Helmholtz Federated IT Services (HIFIS, hifis.net) platform.

--- a/content/events/2022-berlin/speakers/florian-haas.md
+++ b/content/events/2022-berlin/speakers/florian-haas.md
@@ -1,0 +1,11 @@
++++
+title = "Florian Haas"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["florian-haas"]
++++
+
+I help people understand complex technology. Professional open source person since 2007. I keep a blog at https://xahteiwi.eu.

--- a/content/events/2022-berlin/speakers/iris-hunkeler.md
+++ b/content/events/2022-berlin/speakers/iris-hunkeler.md
@@ -1,0 +1,16 @@
++++
+title = "Iris Hunkeler"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["iris-hunkeler"]
++++
+
+Iris is a passionate software engineer with experience from multiple launches
+of software solutions for clients in public administration, e-commerce and
+banking. She has worked not only as a developer, but also as scrum master,
+project manager, business analyst and requirements engineer. Her motivation
+stems from finding achievable and elegant solutions to complex problems which
+help her clients reach their individual goals.

--- a/content/events/2022-berlin/speakers/jemma-bolland.md
+++ b/content/events/2022-berlin/speakers/jemma-bolland.md
@@ -1,0 +1,14 @@
++++
+title = "Jemma Bolland"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["jemma-bolland"]
++++
+
+Jemma runs operations, people and finance at The Scale Factory. She has 15+
+years’ experience in operational, strategic and marketing roles with start-ups
+and SMEs in the UK and Australia. She has a passion for building cohesive,
+resilient teams and championing D&I initiatives.

--- a/content/events/2022-berlin/speakers/jorge-castro.md
+++ b/content/events/2022-berlin/speakers/jorge-castro.md
@@ -1,0 +1,25 @@
++++
+title = "Jorge Castro"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["jorge-castro"]
++++
+
+Jorge is an agilist, DevOps Program Manager, Test Manager, Agile Coach and
+global speaker who feels passion for Testing Automation, Agile, DevOps and
+business agility. He enjoys research and learning about business agility and
+working with cutting-edge technologies. He has been learning continuously for
+more than 12 years and is still learning new ways to foster business agility
+and team greatness. He has worked in several roles (developer, tester, IT
+program manager, Software engineering in Test manager, QA manager, agile coach)
+which helps him to see the big picture and operational and team members
+dynamics happening inside organizations. This experience lets him help teams
+design, build and implement digital, DevOps and agile transformation
+strategies. He encourages focus on: People, Productivity, Continuous
+improvement, Innovation and having fun to enjoy success in our agile journeys.
+Jorge has been speaker in Agile and DevOps events organized in Peru, Canada,
+UK, Netherlands, India, Mexico, Colombia, Nigeria, Panama, Nigeria, Azerbaijan,
+Australia, US among other countries.

--- a/content/events/2022-berlin/speakers/kris-buytaert.md
+++ b/content/events/2022-berlin/speakers/kris-buytaert.md
@@ -1,0 +1,14 @@
++++
+title = "Kris Buytaert"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["kris-buytaert"]
++++
+
+Kris Buytaert is a long time Linux and Open Source Consultant. He's one of
+instigators of the devops movement, currently working for Inuits/o11y.
+
+People curse at him when they realize it's DNS.

--- a/content/events/2022-berlin/speakers/marcel-britsch.md
+++ b/content/events/2022-berlin/speakers/marcel-britsch.md
@@ -1,0 +1,16 @@
++++
+title = "Marcel Britsch"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["marcel-britsch"]
++++
+
+Marcel Britsch is an independent Digital Consultant, Product Owner and Agile Transformation specialist. Born in Germany, he has been living and working in London for over 20 years. He has worked with creatively and technically focused agencies and clients across retail, conservation, automotive, finance, healthcare and energy. He helps organisations build solid products and services in a sustainable way by facilitation, pairing, coaching or hands-on product management.
+
+Marcel believes that project success is strongly linked to happy teams, value-focused decision-making and fast feedback cycles. He is passionate about finding the best tools and techniques to optimise team culture, ways of working and solution design. He considers projects that follow classic waterfall / big-design-up-front practices to be too likely doomed to go anywhere near them, but loves to help organisations build products and transform in incremental evolutionary fashion.
+Outside of work he is interested in SciFi and comic books, Theravada Buddhist meditation and number theory.
+
+He is a regular speaker at conferences, blogs at www.thedigitalbusinessanalyst.com, co-hosts the https://www.theburnup.com podcast about ‘all things agile’, and can be found at https://www.beautifulabstraction.com.

--- a/content/events/2022-berlin/speakers/philipp-krenn.md
+++ b/content/events/2022-berlin/speakers/philipp-krenn.md
@@ -1,0 +1,11 @@
++++
+title = "Philipp Krenn"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["philipp-krenn"]
++++
+
+Philipp lives to demo interesting technology. Having worked as a web, infrastructure, and database engineer for over ten years, Philipp is now a developer advocate and EMEA team lead at Elastic — the company behind the Elastic Stack consisting of Elasticsearch, Kibana, Beats, and Logstash. Based in Vienna, Austria, he is constantly traveling Europe and beyond to speak and discuss open source software, search, databases, infrastructure, and security.

--- a/content/events/2022-berlin/speakers/radovan-bacovic.md
+++ b/content/events/2022-berlin/speakers/radovan-bacovic.md
@@ -1,0 +1,22 @@
++++
+title = "Radovan Baćović"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["radovan-bacovic"]
++++
+
+Radovan Bacovic is a Senior Data Engineer at the company GitLab.com coming from Serbia.
+
+Radovan is an experienced Data Engineer, "Certified Scrum Master", "Advanced
+Certified Scrum Master" and "Certified Scrum Professional" using modern
+technologies in an Agile environment with a strong application development
+background in large international companies. 
+
+He has a wide area of experience in the gambling business, agriculture,
+transport, financial, billing system for electric power in mid and large
+companies. As he says for himself: “Truly passionate data geek.”
+
+Passionate martial artist and probably the best father in the world.

--- a/content/events/2022-berlin/speakers/schlomo-schapiro.md
+++ b/content/events/2022-berlin/speakers/schlomo-schapiro.md
@@ -1,0 +1,15 @@
++++
+title = "Schlomo Schapiro"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["schlomo-schapiro"]
++++
+
+Schlomo Schapiro is an Agile IT and Open Source enthusiast dedicated to
+advancing an agile mindset and a DevOps-orientated culture in IT. He works as
+Principal Engineer at Forto in Berlin, is author of several Open Source
+projects, conference speaker and regularly publishes blog and magazine
+articles. See https://schlomo.schapiro.org/ for his blog and publications.

--- a/content/events/2022-berlin/speakers/swathi-poddar.md
+++ b/content/events/2022-berlin/speakers/swathi-poddar.md
@@ -1,0 +1,10 @@
++++
+title = "Swathi Poddar"
+twitter = ""
+linkedin = ""
+website = ""
+image = ""
+type = "speaker"
+linktitle = ["swathi-poddar"]
++++
+


### PR DESCRIPTION
First set of speakers for the Berlin 2022 event in preparation of the program.
All these speakers have confirmed the acceptance of their talk in pretalx.