### PR TITLE
[DC-2022] Update target URL for Excella sponsorship

### DIFF
--- a/data/sponsors/excella.yml
+++ b/data/sponsors/excella.yml
@@ -1,3 +1,3 @@
 name: excella
-url: http://www.excella.com/
+url: https://solutions.excella.com/excella-transforming-organizations-with-devops
 twitter: excellaco


### PR DESCRIPTION
Change the URL for Excella's sponsorship to point to a new location. 

@pburkholder, I confirmed the change with Excella's marketing team.
