### PR TITLE
[CLT-2022] Add sponsors for Charlotte 2022

### DIFF
--- a/data/events/2022-charlotte.yml
+++ b/data/events/2022-charlotte.yml
@@ -94,6 +94,10 @@ sponsors:
     level: gold
   - id: tidelift
     level: gold
+  - id: datadog
+    level: gold
+  - id: harness
+    level: gold
   - id: phoenixnap
     level: silver
   - id: dynatrace


### PR DESCRIPTION
Add datadog and harness as sponsors for Charlotte 2022 at gold level