### PR TITLE
[DC-2022] Fix the registration link on the welcome page

### DIFF
--- a/content/events/2022-washington-dc/welcome.md
+++ b/content/events/2022-washington-dc/welcome.md
@@ -32,7 +32,7 @@ Description = "devopsdays Washington, D.C. 2022"
     <strong>Register</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_link page="registration" text="Register to attend the conference!" >}}
+    <a href="https://www.eventbrite.com/e/devopsdays-dc-2022-tickets-345684861727">Register to attend the conference!</a>
   </div>
 </div>
 


### PR DESCRIPTION
The link embedded in the welcome.md page was pointing to the wrong location. The top nav was correct. Changed page code to point to the right spot on Eventbrite.