### PR TITLE
[LDN-2022] Add StormForge and DoIT

### DIFF
--- a/content/events/2022-london/sponsor.md
+++ b/content/events/2022-london/sponsor.md
@@ -58,13 +58,13 @@ Description = "Sponsor DevOpsDays London 2022"
                 <center><span class="badge badge-success">Available</span></center>
               </th>
               <th>
-                <center><span class="badge badge-success">Available</span></center>
+                <center><span class="badge badge-warning">Not Available</span></center>
               </th>
               <th>
                 <center><span class="badge badge-warning">Not Available</span></center>
               </th>
               <th>
-                <center><span class="badge badge-success">Available</span></center>
+                <center><span class="badge badge-warning">Not Available</span></center>
               </th>
             </tr>
             <tr>

--- a/data/events/2022-london.yml
+++ b/data/events/2022-london.yml
@@ -118,6 +118,10 @@ sponsors:
     level: silver
   - id: postman
     level: silver
+  - id: stormforge
+    level: silver
+  - id: doit
+    level: silver
   # bronze sponsors
   - id: conflux
     level: bronze


### PR DESCRIPTION
We've got two new silver sponsors that we need to add. These already exist in data/sponsors and therefore I don't need to add them/update them.

- StormForge
- DoiT International

Edit: I've also moved the `Available` status on the Sponsor table to be `Not Available` due to us having no Silver, Gold, Platinum packages left.
