### PR TITLE
bump 0.92.0 to 0.102.3. Never fall too far behind

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.81.0'
+          hugo-version: '0.102.3'
           # extended: true
 
       - name: Build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 install:
 #  Install Hugo from chocolatey and display the version number
 - cmd: >-
-    choco install hugo --version=0.92.0
+    choco install hugo --version=0.102.3
 
     hugo version
 

--- a/hugoserver.ps1
+++ b/hugoserver.ps1
@@ -5,4 +5,4 @@ $MyPath = $PSScriptRoot
 
 docker stop hugo-server
 docker rm hugo-server
-docker run -tip 1313:1313 -v $(pwd):/home/circleci/project:cached -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.92.0 hugo server --watch --bind ""
+docker run -tip 1313:1313 -v $(pwd):/home/circleci/project:cached -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.102.3 hugo server --watch --bind ""

--- a/hugoserver.sh
+++ b/hugoserver.sh
@@ -16,4 +16,4 @@ fi
 
 docker stop hugo-server
 docker rm   hugo-server
-docker run -tip 1313:1313 -u $(id -u) -v $(pwd):/home/circleci/project:$MOUNT_OPTION -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.92.0 hugo server --watch --bind ""
+docker run -tip 1313:1313 -u $(id -u) -v $(pwd):/home/circleci/project:$MOUNT_OPTION -e HUGO_THEME=devopsdays-theme -e HUGO_BASEURL="http://localhost:1313" --name hugo-server --entrypoint "" cibuilds/hugo:0.102.3 hugo server --watch --bind ""

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,11 +15,11 @@
   skip_processing = true
 
 [context.production.environment]
-   HUGO_VERSION = "0.92.0"
+   HUGO_VERSION = "0.102.3"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.92.0"
+  HUGO_VERSION = "0.102.3"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.92.0"
+  HUGO_VERSION = "0.102.3"
 


### PR DESCRIPTION
Netlify's build command has been updated to also take this into consideration. 

On my personal machines (Linux and Mac), I saw nothing unusual but in one instance the typical home page sort problem we have. 