### PR TITLE
Remove duplicate sponsor to get rid of hugo info message

### DIFF
--- a/data/sponsors/linuxtips.yaml
+++ b/data/sponsors/linuxtips.yaml
@@ -1,3 +1,0 @@
-name: "LinuxTips"
-url: "https://linuxtips.io"
-twitter: LINUXtipsBR

--- a/data/sponsors/linuxtips.yml
+++ b/data/sponsors/linuxtips.yml
@@ -1,2 +1,3 @@
-name: "linuxtips"
-url: "https://www.linuxtips.com.br/"
+name: "LinuxTips"
+url: "https://linuxtips.io"
+twitter: LINUXtipsBR


### PR DESCRIPTION
An `INFO` message from Hugo said the following:

```
INFO 2022/09/08 14:59:54 Data for key 'url' in path 'sponsors/linuxtips.yml' is overridden by higher precedence data already in the data tree
INFO 2022/09/08 14:59:54 Data for key 'name' in path 'sponsors/linuxtips.yml' is overridden by higher precedence data already in the data tree
```

This was due to the fact that there were two linuxtips files, one called `linuxtips.yaml` and the other `linuxtips.yml`. 

```
grep -ri "linuxtips" ./data/sponsors/*
./data/sponsors/linuxtips.yaml:name: "LinuxTips"
./data/sponsors/linuxtips.yaml:url: "https://linuxtips.io"
./data/sponsors/linuxtips.yaml:twitter: LINUXtipsBR
./data/sponsors/linuxtips.yml:name: "linuxtips"
./data/sponsors/linuxtips.yml:url: "https://www.linuxtips.com.br/"
```

I visited both, they are in fact the same. So I've removed one and renamed the .yaml to .yml. 

