### PR TITLE
[TPA-2019] Updating 2019 with correct messaging

### DIFF
--- a/content/events/2019-tampa/welcome.md
+++ b/content/events/2019-tampa/welcome.md
@@ -5,8 +5,6 @@ aliases = ["/events/2019-tampa/"]
 Description = "DevOpsDays Tampa Bay 2019"
 +++
 
-Latest news for DevOpsDays Tampa Bay - A few seats left, register now!
-===
 
 <div style="text-align:center;">
   {{< event_logo >}}
@@ -33,14 +31,6 @@ Latest news for DevOpsDays Tampa Bay - A few seats left, register now!
     {{< event_location >}}
   </div>
 </div> 
-<div class = "row">
-  <div class = "col-md-2">
-    <strong>Register</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="registration" text="Register to attend the conference!" >}}
-  </div>
-</div>
 <div class = "row">
   <div class = "col-md-2">
     <strong>Program</strong>

--- a/data/events/2019-tampa.yml
+++ b/data/events/2019-tampa.yml
@@ -41,7 +41,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: location
     icon: "map-o"
     url: /events/2019-tampa/location
-  - name: registration
+#  - name: registration
   - name: program
   - name: speakers
   - name: sponsor


### PR DESCRIPTION
Removing the register button for 2019 and wording on register now on the main page as the event is over. 
