### PR TITLE
[RIO/2022] new organizer

### DIFF
--- a/data/events/2022-rio-de-janeiro.yml
+++ b/data/events/2022-rio-de-janeiro.yml
@@ -62,6 +62,8 @@ team_members: # Name is the only required field for team members.
     image: "lays-rodrigues.jpg"
   - name: "Eduardo Abreu"
     employer: "M4U"
+  - name: "Willian dos Santos"
+    employer: "AmbevTech"
   - name: "Marcelo Freire"
     image: "marcelo-freire.jpg"
 


### PR DESCRIPTION
*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
