### PR TITLE
[almaty-2022] fix sponsor references

### DIFF
--- a/data/events/2022-almaty.yml
+++ b/data/events/2022-almaty.yml
@@ -61,12 +61,10 @@ organizer_email: "almaty@devopsdays.org" # Put your organizer email address here
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
-  - id: data/sponsors/pskz.yml
+  - id: pskz
     level: general
-    url: https://ps.kz # Use this if you need to over-ride a sponsor URL.
-  - id: data/sponsors/yandexcloud.yml
+  - id: yandexcloud
     level: official
-    url: https://cloud.yandex.com
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Hello @tabu-a (et al.). I fixed the references to your sponsors in `data/events/2022-almaty.yml` so they will display on your event page now.