### PR TITLE
[BUF-2022] Extend post-lunchtime sponsor slot to 10 min.

### DIFF
--- a/data/events/2022-buffalo.yml
+++ b/data/events/2022-buffalo.yml
@@ -176,11 +176,11 @@ program:
     type: custom
     date: 2022-09-29
     start_time: "12:10"
-    end_time: "13:25"
+    end_time: "13:20"
   - title: "Sponsors"
     type: custom
     date: 2022-09-29
-    start_time: "13:25"
+    start_time: "13:20"
     end_time: "13:30"
   - title: "jeremy-meiss"
     type: talk
@@ -252,11 +252,11 @@ program:
     type: custom
     date: 2022-09-30
     start_time: "12:10"
-    end_time: "13:25"
+    end_time: "13:20"
   - title: "Sponsors"
     type: custom
     date: 2022-09-30
-    start_time: "13:25"
+    start_time: "13:20"
     end_time: "13:30"
   - title: "stephen-shary"
     type: talk


### PR DESCRIPTION
Extending post-lunchtime sponsor slot from 5 min to 10 min on both conference days.
