### PR TITLE
[BUF-2022] Pull Roni Dover slot to earlier in the day.

### DIFF
--- a/data/events/2022-buffalo.yml
+++ b/data/events/2022-buffalo.yml
@@ -193,15 +193,15 @@ program:
     start_time: "14:00"
     end_time: "14:45"
     block: "ignite"
-  - title: "Open Spaces"
-    type: open-space
-    date: 2022-09-29
-    start_time: "14:45"
-    end_time: "16:30"
   - title: "roni-dover"
     type: talk
     date: 2022-09-29
-    start_time: "16:30"
+    start_time: "14:45"
+    end_time: "15:15"
+  - title: "Open Spaces"
+    type: open-space
+    date: 2022-09-29
+    start_time: "15:15"
     end_time: "17:00"
   - title: "Closing Remarks"
     type: custom


### PR DESCRIPTION
- Due to a miscommunication and issues with flights, pulling Roni Dover's speaker slot to earlier today.
