### PR TITLE
[Montreal 2022] Adding event group

### DIFF
--- a/data/events/2018-montreal.yml
+++ b/data/events/2018-montreal.yml
@@ -4,6 +4,7 @@ city: "Montreal" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsmontreal" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "devopsdays is coming to Montreal! / devopsdays arrive en ville!" # Edit this to suit your preferences
 ga_tracking_id: "UA-118473645-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Montréal"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:   variable: 2016-01-05T01:02:03-05:00
 startdate: 2018-10-10T00:00:00-04:00 # The start date of your event. Leave blank if you don't have a venue reserved yet.

--- a/data/events/2019-montreal.yml
+++ b/data/events/2019-montreal.yml
@@ -4,6 +4,7 @@ city: "Montreal" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsmontreal" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Montreal!" # Edit this to suit your preferences
 ga_tracking_id: "UA-144570307-1" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Montréal"
 
 # All dates are in unquoted YYYY-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2020-montreal.yml
+++ b/data/events/2020-montreal.yml
@@ -4,6 +4,7 @@ city: "Montreal" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsmontreal" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "2020 is cancelled. Hope to see you next year." # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Montréal"
 
 # All dates are in unquoted 2020-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2021-montreal.yml
+++ b/data/events/2021-montreal.yml
@@ -4,6 +4,7 @@ city: "Montreal" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsmontreal" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "2021 is cancelled. But we're already planning for 2022!" # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Montréal"
 
 # All dates are in unquoted 2021-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00

--- a/data/events/2022-montreal.yml
+++ b/data/events/2022-montreal.yml
@@ -4,6 +4,7 @@ city: "Montréal" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsmontreal" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to Montreal! The current CFP round is now closed." # Edit this to suit your preferences
 ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+event_group: "Montréal"
 
 # All dates are in unquoted 2022-MM-DDTHH:MM:SS+TZ:TZ, like this:
 #   variable: 2019-01-04T00:00:00+02:00


### PR DESCRIPTION
Adding event group to tie together events with and without accents in the spelling. (Note: by default, cancelled events don't show up in past events, but I'm adding it to all years for completeness.)

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
