### PR TITLE
[AMS-2013] close the <a> tag to fix spacing

### DIFF
--- a/content/events/2023-amsterdam/welcome.md
+++ b/content/events/2023-amsterdam/welcome.md
@@ -43,6 +43,7 @@ Description = "devopsdays Amsterdam will take place June 21-23, 2023! The group 
   <div class = "col-md-8">
     <a href="https://talx.devops.foundation/devopsdays-amsterdam-2023/cfp">
       Propose a talk!
+    </a>
   </div>
 </div>
 


### PR DESCRIPTION
Fixed a missing tag that breaks the spacing. 