### PR TITLE
[About] Update the list of active organizers and co-chairs

### DIFF
--- a/data/core.toml
+++ b/data/core.toml
@@ -1,17 +1,17 @@
 active = [
-"Yvo van Doorn (co-chair)",
 "Matt Stratton (co-chair)",
+"Dan Maher (co-chair)",
+"Katie McLaughlin (co-chair)",
 "Serhat Can",
 "Floor Drees",
 "Bernd Erk",
 "Rafael Gomes",
 "Marco Júnior",
 "Mine Heck",
-"Dan Maher",
-"Katie McLaughlin",
 "Adrian Moisey",
 "Ken Mugrage",
 "Mike Rosado",
+"Yvo van Doorn",
 "Jason Yee"
 ]
 


### PR DESCRIPTION
Based on [devopsdays-policies/pull/6](https://github.com/devopsdays/devopsdays-policies/pull/6)

Add as co-chairs:  @phrawzty and @glasnt

Removes @yvovandoorn as a co-chair, remains an active organizer

Signed-off-by: Nathen Harvey <nathenharvey@google.com>
