### PR TITLE
Update core organizers

### DIFF
--- a/data/core.toml
+++ b/data/core.toml
@@ -1,7 +1,7 @@
 active = [
-"Matt Stratton (co-chair)",
 "Dan Maher (co-chair)",
 "Katie McLaughlin (co-chair)",
+"Yvo van Doorn (co-chair)",
 "Serhat Can",
 "Floor Drees",
 "Bernd Erk",
@@ -11,7 +11,7 @@ active = [
 "Adrian Moisey",
 "Ken Mugrage",
 "Mike Rosado",
-"Yvo van Doorn",
+"Matty Stratton",
 "Jason Yee"
 ]
 


### PR DESCRIPTION
Moves Matty Stratton from co-chair to active, reinstate Yvo as co-chair
