### PR TITLE
Fix Nashville redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -70,7 +70,7 @@
 /montreal/*		/events/2022-montreal/:splat		302
 /moscow/*		/events/2020-moscow/:splat		302
 /nairobi/*		/events/2014-nairobi/:splat		302
-/nashville/*		/events/2022-nashville/:splat		302
+/nashville/*		/events/2023-nashville/:splat		302
 /natal/*		/events/2020-natal/:splat		302
 /new-york-city/*	/events/2021-new-york-city/:splat	302
 /new-zealand/*		/events/2019-auckland/:splat		302


### PR DESCRIPTION
The redirect for devopsdays.org/nashville still points at the 2022 site. This fixes that.

