### PR TITLE
Move Mine, Ken to Advisory

### DIFF
--- a/data/core.toml
+++ b/data/core.toml
@@ -7,9 +7,7 @@ active = [
 "Bernd Erk",
 "Rafael Gomes",
 "Marco Júnior",
-"Mine Heck",
 "Adrian Moisey",
-"Ken Mugrage",
 "Mike Rosado",
 "Matty Stratton",
 "Jason Yee",
@@ -21,8 +19,10 @@ advisory = [
 "Jennifer Davis",
 "Patrick Debois (founder, 2009-2014 lead)",
 "Nathen Harvey",
+"Mine Heck",
 "Matthew Jones",
 "Bridget Kromhout (2015-2020 lead)",
+"Ken Mugrage",
 "Andrew Clay Shafer",
 "John Willis"
 ]


### PR DESCRIPTION
Per email, and with thanks for their contributions over the years, moving Mine and Ken from Active to Advisory organisers.