### PR TITLE
Update Chicago old sponsor page

### DIFF
--- a/content/events/2022-chicago/sponsor.md
+++ b/content/events/2022-chicago/sponsor.md
@@ -67,6 +67,7 @@ The best thing to do is send engineers to interact with the experts at devopsday
         SOLD OUT
       </td>
       <td>
+        <!--
         <!-- bronze Paypal button  -->
         <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
           <input type="hidden" name="cmd" value="_s-xclick">
@@ -74,6 +75,8 @@ The best thing to do is send engineers to interact with the experts at devopsday
           <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
           <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
         </form>
+        -->
+        NOT AVAILABLE
       </td>
       <td><a href="mailto:chicago-sponsors@devopsdays.org?subject=Interested%20in%20Community%20Sponsorship%20DevOpsDays%20Chicago%202022">Contact us</a>
       </td>

--- a/content/events/2022-chicago/sponsor.md
+++ b/content/events/2022-chicago/sponsor.md
@@ -4,6 +4,8 @@ Type = "event"
 Description = "Sponsor devopsdays Chicago 2022"
 +++
 
+<h2>Looking to sponsor devopsdays? Please <A href = "/chicago">check out this year's event</a>!</h2>
+
 We greatly value sponsors for this community event. If you are interested in sponsoring, please check out our <a href="https://assets.devopsdays.org/events/2022/chicago/2022-chicago-devopsdays-prospectus.pdf" target="_blank">prospectus</a> or <a href="mailto:chicago-sponsors@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Chicago%202022">send us an email</a>.
 We greatly value sponsors for this community event. If you are interested in sponsoring, please  <a href="mailto:chicago-sponsors@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Chicago%202022">send us an email</a>.
 <hr>
@@ -67,8 +69,9 @@ The best thing to do is send engineers to interact with the experts at devopsday
         SOLD OUT
       </td>
       <td>
-        <!--
+        
         <!-- bronze Paypal button  -->
+        <!--
         <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
           <input type="hidden" name="cmd" value="_s-xclick">
           <input type="hidden" name="hosted_button_id" value="DDXAP9S3324DC">

--- a/data/events/2022-chicago.yml
+++ b/data/events/2022-chicago.yml
@@ -42,7 +42,6 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: registration
   - name: program
   - name: speakers
-  - name: sponsor
   # - name: volunteer
   - name: contact
   - name: conduct


### PR DESCRIPTION
Remove sponsor nav and also paypal link from 2022 event
