### PR TITLE
[CHI-2023] Update 2023 covid policy

### DIFF
--- a/content/events/2023-chicago/covid-19-policy.md
+++ b/content/events/2023-chicago/covid-19-policy.md
@@ -1,16 +1,30 @@
 +++
-Title = "COVID-19 Policy"
+Title = "Health & Safety / COVID-19 Policy"
 Type = "event"
-Description = "COVID-19 Policy for DevOpsDays Chicago 2023"
+Description = "Health & Safety Policy for DevOpsDays Chicago 2023"
 aliases = ["/events/2023-chicago/covid"]
 +++
 
-In order to ensure the health and safety of all our attendees, staff, speakers, sponsors, and venue partners, DevOpsDays Chicago is instituting the following COVID-19 policy for our 2023 event:
+In order to ensure the health and safety of all our attendees, staff, speakers, sponsors, and venue partners, DevOpsDays Chicago is instituting the following COVID-19 policy for our 2023 event
 
-* We are requiring vaccination for in-person attendance. If you are not able to show proof of vaccination, you are invited to participate online. Specifically, all in-person participants - including sponsors, speakers, staff, and attendees - must have completed a full COVID-19 vaccination (full defined as both shots of Pfizer/Moderna or one shot of Johnson & Johnson) at least two (2) weeks prior to this event, by July 18, 2023. We will require proof of vaccination -- original card, legible photo of card (front and back), or app -- plus matching ID for badge pickup. A negative COVID test will not be accepted as a substitute for proof of vaccination. We welcome travelers from outside of the US, but do not necessarily have expertise in validating non-CDC-issued vaccine cards. Please reach out to us at chicago@devopsdays.org ahead of the conference, so that we can ensure that we’re prepared to validate your vaccine card.
+### Vaccination
+* We are requiring vaccination or a negative test within the last 24 hours for in-person attendance. If you are not able to show proof of vaccination or a negative test, you are invited to participate online. Specifically, all in-person participants - including sponsors, speakers, staff, and attendees - must have completed a full COVID-19 vaccination at least two (2) weeks prior to this event, by **July 26, 2023**. 
+* We will require proof of vaccination – original card, legible photo of card (front and back), or app government-compliant digital vaccination verification app (such as Clear or VaxYes) – plus matching ID for badge pickup. A negative COVID test (PCR or ACG) from within the last 24 hours will not be accepted as a substitute for proof of vaccination. 
+* We welcome travelers from outside of the US, but do not necessarily have expertise in validating non-CDC-issued vaccine cards. Please reach out to us at chicago@devopsdays.org ahead of the conference, so that we can ensure that we’re prepared to validate your vaccine card.
 
-* While local mask mandates have been lifted, at this time well-fitted masks (i.e. KN95/N95/KF94) will still be required to be worn at our event; 'makeshift' masks (such as neck gaiters or bandanas) or masks with exhalation vents will not be accepted. We are paying close attention to the [Illinois Department of Health](https://dph.illinois.gov/covid19/community-guidance.html) recommendations and the [City of Chicago Community Transmission and Risk](https://www.chicago.gov/city/en/sites/covid-19/home/community-transmission-and-risk.html) pages for further guidance. Masks will be available on-site for anyone who requires one.
+### Masks
+* As of February 2022, Illinois has lifted the mask mandate for most venues.  However, we will still recommend the wearing of approved masks (KN95/N95/KF94) in all indoor spaces. 
+* Please respect everyone’s decision to mask up or not; any disrespect or harrassment to other attendees will be in violation of not only our Health & Safety policy but our [Code of Conduct](https://devopsdays.org/events/2023-chicago/conduct) and you will be asked to leave.
+* We are paying close attention to the [Illinois Department of Health](https://dph.illinois.gov/covid19/community-guidance.html) recommendations and the [City of Chicago Community Transmission and Risk](https://www.chicago.gov/city/en/sites/covid-19/home/community-transmission-and-risk.html) pages for further guidance. 
+* Masks will be available on-site for anyone who requires one.
 
-* If you are feeling sick on either day of the event, we strongly encourage you to stay home and not try to attend. Refunds are available for any ticketholder who cannot attend due to illness.
+### Symptoms
+* If you are feeling sick on either day of the event, we strongly encourage you to stay home and not try to attend. Refunds are available for any ticketholder who cannot attend due to illness. 
+* We reserve the right to temperature check any individual presenting symptoms and refuse entry based on a ‘positive’ fever result
 
-* If you cannot comply with these requirements, we ask that you request a ticket refund by emailing chicago@devopsdays.org and participate virtually by watching our livestream and interacting online.
+**If you cannot comply with these requirements, we ask that you request a ticket refund by emailing chicago@devopsdays.org and participate virtually by watching our livestream and interacting online.**
+
+### Note on Changes To Policy
+We reserve the right to change our Health & Safety policy and will be constantly reevaluating this policy between now and the event.  However, the Health & Safety policy will not be made any **less** restrictive 60 days prior to the event. If you have any questions or concerns about your ticket purchase based on our policy, please email chicago@devopsdays.org
+
+Please note our policies are also subject to change depending on federal, state, and local requirements/guidelines/mandates.

--- a/content/events/2023-chicago/covid-19-policy.md
+++ b/content/events/2023-chicago/covid-19-policy.md
@@ -7,20 +7,20 @@ aliases = ["/events/2023-chicago/covid"]
 
 In order to ensure the health and safety of all our attendees, staff, speakers, sponsors, and venue partners, DevOpsDays Chicago is instituting the following COVID-19 policy for our 2023 event
 
-### Vaccination
-* We are requiring vaccination or a negative test within the last 24 hours for in-person attendance. If you are not able to show proof of vaccination or a negative test, you are invited to participate online. Specifically, all in-person participants - including sponsors, speakers, staff, and attendees - must have completed a full COVID-19 vaccination at least two (2) weeks prior to this event, by **July 26, 2023**. 
-* We will require proof of vaccination – original card, legible photo of card (front and back), or app government-compliant digital vaccination verification app (such as Clear or VaxYes) – plus matching ID for badge pickup. A negative COVID test (PCR or ACG) from within the last 24 hours will not be accepted as a substitute for proof of vaccination. 
-* We welcome travelers from outside of the US, but do not necessarily have expertise in validating non-CDC-issued vaccine cards. Please reach out to us at chicago@devopsdays.org ahead of the conference, so that we can ensure that we’re prepared to validate your vaccine card.
+### Vaccination / Testing
+* We are requiring vaccination or a negative test (PCR or antigen) within the last 24 hours for in-person attendance. If you are not able to show proof of vaccination or a negative test, you are invited to participate online. Specifically, all in-person participants - including sponsors, speakers, staff, and attendees - must have completed a full COVID-19 vaccination at least two (2) weeks prior to this event, by **July 26, 2023**. 
+* We will require proof of vaccination – original card, legible photo of card (front and back), or government-compliant digital vaccination verification app (such as Clear or VaxYes) – plus matching ID for badge pickup.
+* We will require proof of a negative COVID test within the last 24 hours if proof of vaccination is not available. Acceptable proof of testing includes the original PCR test printout or email, a negative antigen test result or a photo of a negative antigen test result with something reflecting the date in it. A **limited** number of antigen tests will be available on-site.
 
 ### Masks
-* As of February 2022, Illinois has lifted the mask mandate for most venues.  However, we will still recommend the wearing of approved masks (KN95/N95/KF94) in all indoor spaces. 
+* As of February 2022, Illinois has lifted the mask mandate for most venues.  However, we will still recommend the wearing of approved masks (KN95/N95/KF94) that fully cover the nose and mouth in all indoor spaces. 
 * Please respect everyone’s decision to mask up or not; any disrespect or harrassment to other attendees will be in violation of not only our Health & Safety policy but our [Code of Conduct](https://devopsdays.org/events/2023-chicago/conduct) and you will be asked to leave.
 * We are paying close attention to the [Illinois Department of Health](https://dph.illinois.gov/covid19/community-guidance.html) recommendations and the [City of Chicago Community Transmission and Risk](https://www.chicago.gov/city/en/sites/covid-19/home/community-transmission-and-risk.html) pages for further guidance. 
 * Masks will be available on-site for anyone who requires one.
 
 ### Symptoms
 * If you are feeling sick on either day of the event, we strongly encourage you to stay home and not try to attend. Refunds are available for any ticketholder who cannot attend due to illness. 
-* We reserve the right to temperature check any individual presenting symptoms and refuse entry based on a ‘positive’ fever result
+* We reserve the right to temperature check any individual presenting symptoms and refuse entry based on a ‘positive’ fever result.
 
 **If you cannot comply with these requirements, we ask that you request a ticket refund by emailing chicago@devopsdays.org and participate virtually by watching our livestream and interacting online.**
 
@@ -28,3 +28,8 @@ In order to ensure the health and safety of all our attendees, staff, speakers, 
 We reserve the right to change our Health & Safety policy and will be constantly reevaluating this policy between now and the event.  However, the Health & Safety policy will not be made any **less** restrictive 60 days prior to the event. If you have any questions or concerns about your ticket purchase based on our policy, please email chicago@devopsdays.org
 
 Please note our policies are also subject to change depending on federal, state, and local requirements/guidelines/mandates.
+
+### International Travelers
+* Non citizens may be required to show proof of vaccination at ports of entry into the United States.  Please visit the Department of Homeland Security website [here](https://www.dhs.gov/news/2021/10/29/frequently-asked-questions-guidance-travelers-enter-us) or the CDC website [here](https://www.cdc.gov/coronavirus/2019-ncov/travelers/proof-of-vaccination.html) for additional guidance. 
+* Additionally you can also check with your flight carrier as they may have updated information.
+* We welcome travelers from outside of the US, but do not necessarily have expertise in validating non-CDC-issued vaccine cards. Please reach out to us at chicago@devopsdays.org ahead of the conference, so that we can ensure that we’re prepared to validate your vaccine card.

--- a/content/events/2023-chicago/welcome.md
+++ b/content/events/2023-chicago/welcome.md
@@ -9,7 +9,7 @@ Description = "DevOpsDays Chicago is coming back in 2023! The group that brought
    <div class="row">
     <div class="alert alert-info" role="alert">
        <h2>COVID-19</h2>
-       <p>While we are making every attempt to hold an in-person event in 2023, we recognize that the ongoing pandemic may affect this plan. The health and well-being of our attendees is of paramount importance, so we reserve the right to apply reasonable attendance requirements in accordance with local or federal guidance. We also reserve the right to cancel completely, or change to a virtual event, if the in-person event cannot be held safely.</p>
+       <p>While we are making every attempt to hold an in-person event in 2023, we recognize that the ongoing pandemic may affect this plan. The health and well-being of our attendees is of paramount importance, so we reserve the right to apply reasonable attendance requirements in accordance with local or federal guidance. {{< event_link page="covid-19-policy" text="You can read our 2023 COVID-19 policy here" >}}. We also reserve the right to cancel completely, or change to a virtual event, if the in-person event cannot be held safely.</p>
               <!-- <p>While we are making every attempt to hold an in-person event in 2023, we recognize that the ongoing pandemic may affect this plan. The health and well-being of our attendees is of paramount importance, so we reserve the right to apply reasonable attendance requirements in accordance with local or federal guidance. {{< event_link page="covid-19-policy" text="You can read our 2022 COVID-19 policy here" >}}. We also reserve the right to cancel completely, or change to a virtual event, if the in-person event cannot be held safely.</p> -->
     </div>
  </div>

--- a/data/events/2023-chicago.yml
+++ b/data/events/2023-chicago.yml
@@ -43,6 +43,8 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: sponsor
   - name: contact
   - name: conduct
+  - name: Health and Safety Policy
+    url: /events/2023-chicago/covid
 # - name: example
 #   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/
 #   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site


### PR DESCRIPTION
This PR:
* Updates the 2023 Covid/Health & Safety policy with our decisions for the 2023 event.
* Adds a link to the 2023 Health & Safety policy to the main welcome page