### PR TITLE
[core] storing Mastodon's finger redirect inside of the netlify.toml file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,3 +23,13 @@
 [context.branch-deploy.environment]
   HUGO_VERSION = "0.102.3"
 
+# Mastodon Configuration
+[[redirects]]
+  from = "/.well-known/webfinger/*"
+  to = "https://social.devopsdays.org/:splat"
+[[headers]]
+  for = "/.well-known/webfinger/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"
+  status = 301
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,9 +27,9 @@
 [[redirects]]
   from = "/.well-known/webfinger/*"
   to = "https://social.devopsdays.org/:splat"
+  status = 301
 [[headers]]
   for = "/.well-known/webfinger/*"
     [headers.values]
     Access-Control-Allow-Origin = "*"
-  status = 301
 


### PR DESCRIPTION
* Adds necessary redirects to Netlify in order to redirect webfinger request to where Mastodon is running. 