### PR TITLE
[CPH-2023] Updated organizer list for 2023-copenhagen / Denmark

### DIFF
--- a/data/events/2023-copenhagen.yml
+++ b/data/events/2023-copenhagen.yml
@@ -83,7 +83,10 @@ team_members: # Name is the only required field for team members.
   - name: "Søren Eriksen"
     employer: "The LEGO Group"
     image: "soeren-eriksen.jpg"
-
+  - name: "Jackie Jabson"
+    employer: "The LEGO Group"
+  - name: "Ditte Lassen"
+    employer: "Destination AARhus"
 
 organizer_email: "denmark@devopsdays.org" # Put your organizer email address here
 


### PR DESCRIPTION
Updating list of organizers in DK. Mail is also sent to info@