### PR TITLE
[AMS-2023] Add Elastic as Gold sponsor

### DIFF
--- a/data/events/2023-amsterdam.yml
+++ b/data/events/2023-amsterdam.yml
@@ -140,6 +140,8 @@ sponsors:
 # Gold
   - id: github
     level: gold
+  - id: elastic
+    level: gold
 # Silver
   - id: wiz
     level: silver


### PR DESCRIPTION
* Add Elastic as gold sponsor for Amsterdam