### PR TITLE
[LDN-2023] Add new organizers

### DIFF
--- a/data/events/2023-london.yml
+++ b/data/events/2023-london.yml
@@ -77,6 +77,8 @@ team_members: # Name is the only required field for team members.
     twitter: "devops_rob"
   - name: "Jessica Cregg"
     twitter: "JessicaCregg"
+  - name: "Issa Long"
+  - name: "Ethan Summer"
 
 organizer_email: "london@devopsdays.org" # Put your organizer email address here
 


### PR DESCRIPTION
We need to add two new organizers before we can request that they're added to Slack. The following adds Issa Long and Ethan Summer to our list of organizers. I've not asked them to provide any social links but if they wish to share them I will update in another Pull Request.