### PR TITLE
[LDN-2023] Fix misspellings of new organizer names

### DIFF
--- a/data/events/2023-london.yml
+++ b/data/events/2023-london.yml
@@ -77,8 +77,11 @@ team_members: # Name is the only required field for team members.
     twitter: "devops_rob"
   - name: "Jessica Cregg"
     twitter: "JessicaCregg"
-  - name: "Issa Long"
-  - name: "Ethan Summer"
+  - name: "Issy Long"
+    twitter: "issyl0"
+    github: "issyl0"
+    website: "https://issylong.com"
+  - name: "Ethan Sumner"
 
 organizer_email: "london@devopsdays.org" # Put your organizer email address here
 


### PR DESCRIPTION
These were misspelled in #12367. But also, thank you for having me. And I took the liberty of adding my social media handles too. (I'll let Ethan do their own ones.)