### PR TITLE
[2023-LDN] Remove Issy's website and add their Mastodon

### DIFF
--- a/data/events/2023-london.yml
+++ b/data/events/2023-london.yml
@@ -80,7 +80,7 @@ team_members: # Name is the only required field for team members.
   - name: "Issy Long"
     twitter: "issyl0"
     github: "issyl0"
-    website: "https://issylong.com"
+    mastodon: "https://hachyderm.io/@issyl0"
   - name: "Ethan Sumner"
 
 organizer_email: "london@devopsdays.org" # Put your organizer email address here


### PR DESCRIPTION
- My website is failing with an SSL error and I don't care to fix it at the moment.
- Also I use Mastodon more than Twitter these days.
- I had a thought that it would be great to get pronouns in this list too on the organizer's page, given we show pronouns for speakers, but I'll investigate that separately.