### PR TITLE
[rdu-2023] Removed duplicate sponsor

### DIFF
--- a/data/events/2023-raleigh.yml
+++ b/data/events/2023-raleigh.yml
@@ -140,10 +140,7 @@ sponsors:
     level: gold
   - id: akeyless
     level: gold
-  - id: sumologic
-    level: gold
-  
-  
+
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.


### PR DESCRIPTION
Sumo Logic is displayed twice on our sponsors page. Removed the 2nd entry from RDU yaml. 