### PR TITLE
[ZRH2023] Set DevOpsDays Zurich 2023 to sold out

### DIFF
--- a/content/events/2023-zurich/welcome.md
+++ b/content/events/2023-zurich/welcome.md
@@ -17,6 +17,7 @@ Description = "DevOpsDays Zurich 2023"
 <div class = "row">
   <div class = "col-md-12">
     <p>
+    <p>The DevOpsDays Zurich 2023 are <font color="red">SOLD OUT</font></p>
     <p>First time here? Check out our last events and get hyped!</p>
     <a href="https://www.devopsdays.org/events/2017-zurich/welcome/">DevOpsDays 2017 - Where it all started</a><br/>
     <a href="https://www.devopsdays.org/events/2018-zurich/welcome/">DevOpsDays 2018 - The Continuation</a><br/>

--- a/data/events/2023-zurich.yml
+++ b/data/events/2023-zurich.yml
@@ -25,7 +25,7 @@ cfp_link: "https://sessionize.com/devopsdays-zurich-2023/" #if you have a custom
 registration_date_start: 2022-11-08T00:00:00+02:00
 registration_date_end: 2023-05-03T00:00:00+02:00
 
-#registration_closed: "" #set this to true if you need to manually close registration before your registration end date
+registration_closed: "true" #set this to true if you need to manually close registration before your registration end date
 registration_link: "https://ti.to/dod/dodzh2023" # If you have a custom registration link, enter it here. This will control the Registration menu item as well as the "Register" button.
 
 # Location
@@ -40,7 +40,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: program
   - name: speakers
   - name: location
-  - name: registration
+#  - name: registration
   - name: sponsor
   - name: diversity
   - name: contact


### PR DESCRIPTION
*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
