### PR TITLE
[KRK-2023] Updated schedule/speakers URLs + replaced contact email addresses

### DIFF
--- a/content/events/2023-krakow/program.md
+++ b/content/events/2023-krakow/program.md
@@ -5,4 +5,4 @@ Description = "Program information for devopsdays Kraków 2023"
 +++
 Schedule will be updated and edited after receiving confirmation from other speakers. Exact lectures and schedule is subject to change.
 
-<a href="https://dodkrakow.pl/schedule/">Schedule</a>
+<a href="https://dodkrakow.pl/schedule-2023/">Schedule</a>

--- a/content/events/2023-krakow/welcome.md
+++ b/content/events/2023-krakow/welcome.md
@@ -51,7 +51,7 @@ Description = "devopsdays Kraków 2023"
   <div class="text">
     <a href="https://eventory.cc/event/devopsdays-krakow-2023" type="button" class="btn btn-danger btn-lg btn-block">REGISTRATION</a>
     <a href="https://dodkrakow.pl/call-for-papers-2023/" type="button" class="btn btn-danger btn-lg btn-block">PROPOSE</a>
-    <a href="mailto:olga.michaliszyn@proidea.pl " type="button" class="btn btn-danger btn-lg btn-block">SPONSOR</a>
+    <a href="mailto:krakow@devopsdays.org " type="button" class="btn btn-danger btn-lg btn-block">SPONSOR</a>
     <a href="/events/2023-krakow/contact" type="button" class="btn btn-danger btn-lg btn-block">CONTACT</a>
   </div>
 </div>

--- a/content/events/2023-krakow/welcome.md
+++ b/content/events/2023-krakow/welcome.md
@@ -50,7 +50,6 @@ Description = "devopsdays Kraków 2023"
   </div>
   <div class="text">
     <a href="https://eventory.cc/event/devopsdays-krakow-2023" type="button" class="btn btn-danger btn-lg btn-block">REGISTRATION</a>
-    <a href="https://dodkrakow.pl/call-for-papers-2023/" type="button" class="btn btn-danger btn-lg btn-block">PROPOSE</a>
     <a href="mailto:krakow@devopsdays.org " type="button" class="btn btn-danger btn-lg btn-block">SPONSOR</a>
     <a href="/events/2023-krakow/contact" type="button" class="btn btn-danger btn-lg btn-block">CONTACT</a>
   </div>

--- a/data/events/2023-krakow.yml
+++ b/data/events/2023-krakow.yml
@@ -36,15 +36,13 @@ location_address: "Nadwiślańska 6, 30-527 Kraków"
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: registration
     url: "https://eventory.cc/event/devopsdays-krakow-2023"
-  - name: propose
-    url: "https://dodkrakow.pl/call-for-papers-2023/"
   - name: sponsor
-    url: "mailto:olga.michaliszyn@proidea.pl"
+    url: "mailto:krakow@devopsdays.org"
   - name: location
   - name: program
-    url: https://dodkrakow.pl/schedule/
+    url: https://dodkrakow.pl/schedule-2023/
   - name: speakers
-    url: https://dodkrakow.pl/speakers/
+    url: https://dodkrakow.pl/#speakers
   - name: contact
 # - name: example
 #   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/


### PR DESCRIPTION
- Replaced email addresses with the official one for the whole organizing group
- Added schedule and speaker links for the final schedule
- Removed links to the CFP page
