### PR TITLE
[LDN-2023] Tweak wording on the CfP and Welcome pages

### DIFF
--- a/content/events/2023-london/propose.md
+++ b/content/events/2023-london/propose.md
@@ -9,8 +9,6 @@ Description = "Propose a talk for devopsdays London 2023"
 
 <center><h2><a href="https://forms.gle/iBjCTD5N3abLAcNP8">Our CFP is now open</a></h2></center>
 
-Due to the COVID-19 situation we are only looking for speakers who are normally a resident of the UK.
-
 <hr>
 
 There are three ways to propose a topic at devopsdays:

--- a/content/events/2023-london/propose.md
+++ b/content/events/2023-london/propose.md
@@ -7,7 +7,7 @@ Description = "Propose a talk for devopsdays London 2023"
 
 <hr>
 
-<center><h2><a href="https://forms.gle/iBjCTD5N3abLAcNP8">Our CFP is now open</a></h2></center>
+<center><h2>Our CFP is now open! Use <a href="https://forms.gle/iBjCTD5N3abLAcNP8">this form</a> to propose a talk.</h2></center>
 
 <hr>
 

--- a/content/events/2023-london/propose.md
+++ b/content/events/2023-london/propose.md
@@ -39,6 +39,7 @@ As a speaker we will provide you with:
 in addition, if you are personally funding your attendance we have some budget to cover reasonable travel and accommodation costs.
 
 <hr>
+
 ### Help with your talk
 
 If you are a first time speaker and/or from an under represented group in technology

--- a/content/events/2023-london/welcome.md
+++ b/content/events/2023-london/welcome.md
@@ -16,10 +16,10 @@ Description = "DevOpsDays London 2023"
         <div class="p-2">
           <a class="btn btn-secondary btn-block" href="/events/2023-london/sponsor"> <i class="fa fa-money fa-lg"></i>&nbsp;&nbsp;&nbsp;Sponsor the Conference</a>
         </div>
-        <!-- <div class="p-2">
-          <a class="btn btn-secondary btn-block" href="https://forms.gle/tbc"> <i class="fa fa-microphone fa-lg"></i>&nbsp;&nbsp;
+        <div class="p-2">
+          <a class="btn btn-secondary btn-block" href="https://forms.gle/iBjCTD5N3abLAcNP8"> <i class="fa fa-microphone fa-lg"></i>&nbsp;&nbsp;
             &nbsp; Propose a talk</a>
-        </div>  -->
+        </div>
         <!-- <div class="p-2">
           <a class="btn btn-secondary btn-block" href="https://ti.to/devopsdays-london/2023"> <i class="fa fa-ticket fa-lg"></i>&nbsp;&nbsp;&nbsp;Get a ticket</a>
         </div> -->

--- a/content/events/2023-london/welcome.md
+++ b/content/events/2023-london/welcome.md
@@ -45,7 +45,6 @@ Description = "DevOpsDays London 2023"
       We are not a commercial conference and we believe that our focus on serving the community creates a truly unique experience for both delegates and sponsors.
     </p>
     <p>We expect 350 people (depending on COVID-19 guidance) this year and will be holding the event on September 21st-22nd at the QEII Centre in London..</p>
-    <p>For the first time this year we will offer interactive online tickets as well.</p>
     <p>The format of DevOpsDays London includes a single track of 30 minute talks in the morning of each event, followed by Ignite talks (5 minute, auto forwarding). We spend the rest of the afternoon in Open Spaces, which are considered a key portion of the event.
     </p>
     {{< event_twitter >}}


### PR DESCRIPTION
- Remove old words about COVID speaker restrictions since they weren't listened to last year and we had a great event.
- Make the CfP proposals form more obvious, since as an organizer it took me a while to realise that was where to click to submit, so I'm assuming it's not obvious to others either.
- Fix rendering of the "Help with your talk" heading which was showing up as raw `### Help with your talk` text on the rendered page.
- The homepage needed some tweaks as well, see the later commits.
