### PR TITLE
[LDN-2023] Link the 2023 tickets from the homepage

### DIFF
--- a/content/events/2023-london/welcome.md
+++ b/content/events/2023-london/welcome.md
@@ -20,9 +20,9 @@ Description = "DevOpsDays London 2023"
           <a class="btn btn-secondary btn-block" href="https://forms.gle/iBjCTD5N3abLAcNP8"> <i class="fa fa-microphone fa-lg"></i>&nbsp;&nbsp;
             &nbsp; Propose a talk</a>
         </div>
-        <!-- <div class="p-2">
+        <div class="p-2">
           <a class="btn btn-secondary btn-block" href="https://ti.to/devopsdays-london/2023"> <i class="fa fa-ticket fa-lg"></i>&nbsp;&nbsp;&nbsp;Get a ticket</a>
-        </div> -->
+        </div>
         <div class="p-2">
           <a class="btn btn-secondary btn-block" href="https://devopsdays.us18.list-manage.com/subscribe?u=6c07d2ff23793b0dda5929f46&id=7aba07ba8c"> <i class="fa fa-list fa-lg"></i>&nbsp;&nbsp;
             &nbsp; Get the latest announcements</a>


### PR DESCRIPTION
- ~This is draft until someone from the London organizing team gives some form of approval. But i~ It seems logical to me that we do want people to buy tickets without having to trawl the website for the "register" link (which is in the header, but quite small, and much like the "propose" link, people might miss it).