### PR TITLE
[CAC-2023] DevOpsDays Caceres 2023 - apr 2023 update 2

### DIFF
--- a/data/events/2023-caceres.yml
+++ b/data/events/2023-caceres.yml
@@ -137,6 +137,8 @@ sponsors:
     level: collaborators
   - id: azuanet
     level: collaborators
+  - id: tego
+    level: collaborators
   - id: voicemod
     level: coffee
   - id: aws-user-groups-spain


### PR DESCRIPTION
This PR adds a new collaborator to the event.

Closes [#20](https://github.com/neovasili/devopsdays-web/issues/20)