### PR TITLE
[NYC-2023] Remove CFP

### DIFF
--- a/content/events/2023-new-york-city/welcome.md
+++ b/content/events/2023-new-york-city/welcome.md
@@ -68,14 +68,14 @@ Description = "devopsdays New York City 2023"
         <h4 class="my-3"><small>{{< event_link page="registration" text="Tickets are on sale now!" >}}</small></h4>
       </div>
     </div>
-    <div class = "row">
+    <!-- <div class = "row">
       <div class = "col-md-1 mx-5 px-0">
         <h4 class="my-3"><strong>Propose</strong></h4>
       </div>
       <div class = "col-md-9">
         <h4 class="my-3"><small><a href="https://sessionize.com/devopsdays-new-york-city-2023" target="_blank">Submit a talk proposal</a></small></h4>
       </div>
-    </div>
+    </div> -->
     <div class = "row">
       <div class = "col-md-1 mx-5 px-0">
         <h4 class="my-3"><strong>Sponsors</strong></h4>

--- a/data/events/2023-new-york-city.yml
+++ b/data/events/2023-new-york-city.yml
@@ -37,7 +37,7 @@ location_address: "524 West 59th Street, New York, NY 10019" #Optional - use the
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: location
-  - name: propose
+  # - name: propose
   - name: registration
   # - name: program
   # - name: speakers


### PR DESCRIPTION
CFP ended a week ago, remove references from the event page.