### PR TITLE
[BOS-2023] Sponsorship info

### DIFF
--- a/content/events/2023-boston/sponsor.md
+++ b/content/events/2023-boston/sponsor.md
@@ -1,0 +1,211 @@
++++
+Title = "Sponsor"
+Type = "event"
+Description = "Sponsor DevOpsDays Boston 2023"
++++
+
+### Download our [sponsor prospectus](https://assets.devopsdays.org/events/2023/boston/DevOpsDays_Boston_2023_Sponsor_Prospectus.pdf)
+Our sponsor prospectus is available below, and as a downloadable PDF for easy distribution within your organization.
+
+To sponsor the conference, please send us an e-mail at [boston@devopsdays.org](mailto:boston@devopsdays.org).
+
+---
+
+### Join the community
+
+**DevOpsDays Boston** is a two-day
+technology community conference that will
+return this year on October 16 – 17 to the
+Cyclorama of Boston Center for the Arts
+(BCA) and Calderwood Pavilion theaters in
+Boston’s historic South End. The
+conference will also be streamed online.
+
+DevOpsDays is a grassroots event
+organized and operated by technology
+professionals to promote the sharing of
+ideas, challenges, and solutions related to
+DevOps, IT management, and technology
+in general. It is organized by peers who
+care about and believe in improving the
+culture of technology work, process
+automation, and the creation of sustained
+value delivery in an environment of
+inclusion.
+
+### Why Sponsor DevOpsDays Boston?
+
+**DevOpsDays Boston** is part of a global
+phenomenon that is reshaping the
+technology industry. DevOpsDays
+conferences around the world bring
+together the highest quality speakers,
+subject matter experts, and contributors for
+two days of “Teaching and Learning.”
+
+As a DevOpsDays Boston sponsor, you
+will be branding your company as an
+ambassador to the Boston DevOps
+Community. Your company will be
+recognized as a Boston area technology
+leader, exposing your brand, products, and
+services to our region’s top tech talent.
+
+---
+
+<div class="table-responsive">
+<table class="table table-bordered table-hover table-responsive-md">
+<thead class="thead-light">
+<tr>
+<th scope="col">
+Sponsorship Packages
+</th>
+<th scope="col"></th>
+<th scope="col">
+<center>Platinum</center>
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<th scope="row">Total Number Available</th>
+<td></td>
+<td>
+<center>20</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Contribution Cost</th>
+<td></td>
+<td>
+<center>$9,500</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Table Size</th>
+<td></td>
+<td>
+<center>6' x 2.5'</center>
+</td>
+</tr>
+<tr>
+<th scope="row"># of Conference Passes</th>
+<td></td>
+<td>
+<center>4</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Company logo on DevOpsDays website</th>
+<td></td>
+<td>
+<center>Large</center>
+</td>
+</tr>
+<th scope="row">Company logo on digital signage / video loops</th>
+<td></td>
+<td>
+<center>Large</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Mentions via social media (Twitter / LinkedIn)</th>
+<td></td>
+<td>
+<center>✓</center>
+</td>
+</tr>
+<tr></tr>
+<tr>
+<th scope="row">Additional, a la carte sponsorships<br /><br /><span style="font-weight: normal;">The following may be purchased in lieu of, or in addition to, the standard Platinum sponsorship option.</span></th>
+<th>
+<center># Available</center>
+</th>
+<th>
+<center>Cost</center>
+</th>
+</tr>
+<tr>
+<th scope="row">Evening event</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$15,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Live Captioning</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$5,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Digital Graphic Recordings (Live Drawings)</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$5,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Wi-fi</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$5,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Badges and Lanyards</th>
+<td>
+<center>1</center>
+</td>
+<td>
+<center>$5,000</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Startup Alley</th>
+<td>
+<center>4</center>
+</td>
+<td>
+<center>$2,500</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Snacks</th>
+<td>
+<center>2</center>
+</td>
+<td>
+<center>$2,500</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Coffee</th>
+<td>
+<center>2</center>
+</td>
+<td>
+<center>$2,500</center>
+</td>
+</tr>
+<tr>
+<th scope="row">Donations to Community Partners</th>
+<td>
+<center>-</center>
+</td>
+<td>
+<center>$2,500</center>
+</td>
+</tr>
+</tbody>
+</table>
+</div>

--- a/content/events/2023-boston/welcome.md
+++ b/content/events/2023-boston/welcome.md
@@ -12,6 +12,10 @@ h1.welcome-page { text-transform: initial; }
 
 <div style="height:20px"></div>
 
+## Our CFP is open until May 31st! [Submit a talk on Papercall!](https://papercall.io/dodbos23)
+<div style="height:20px"></div>
+
+
 <div class="row">
   <div class="col-md-3">
     <div style="text-align:center;">{{< event_logo >}}</div>
@@ -38,12 +42,10 @@ h1.welcome-page { text-transform: initial; }
       <div class="col-md-8"><a href="https://ti.to/devopsdaysbos/2023">Register to attend the conference!</a></div>
     </div>
     -->
-    <!--
     <div class="row">
       <div class="col-md-2"><strong>Sponsors</strong></div>
       <div class="col-md-8">{{< event_link page="sponsor" text="Sponsor the conference!" >}}</div>
     </div>
-    -->
     <div class="row">
       <div class="col-md-2"><strong>Contact</strong></div>
       <div class="col-md-8">{{< event_link page="contact" text="Get in touch with the organizers" >}}</div>

--- a/data/events/2023-boston.yaml
+++ b/data/events/2023-boston.yaml
@@ -32,7 +32,7 @@ nav_elements:
 #  - name: propose
 #  - name: registration
 #  - name: speakers
-#  - name: sponsor
+  - name: sponsor
 
 team_members:
   - name: "Michael Thomas Clark"
@@ -70,17 +70,13 @@ sponsors:
 #  - id: foo
 #    level: bar
 
-sponsors_accepted : "no"
+sponsors_accepted : "yes"
 
 sponsor_levels:
   - id: platinum
     label: Platinum
-  - id: lanyard
-    label: Lanyard
-    max: 1
-  - id: coffee
-    label: Coffee
-    max: 1
+  - id: alacarte
+    label: A la Carte
   - id: startupalley
     label: Startup Alley
 


### PR DESCRIPTION
Publishing sponsorship info for 2023. This depends on devopsdays/devopsdays-assets#158.