### PR TITLE
[LDN-2023] Close down London 2022

### DIFF
--- a/content/events/2022-london/welcome.md
+++ b/content/events/2022-london/welcome.md
@@ -11,53 +11,26 @@ Description = "DevOpsDays London 2022"
 <div class="row">
   <div class="col-md-4">
     <img alt="DevOpsDays London 2022" src="/events/2022-london/logo.png" class="img-fluid">
-    <div class="d-flex flex-row">
-      <div class="col-md-12">
-        <div class="p-2">
-          <a class="btn btn-secondary btn-block" href="/events/2022-london/sponsor"> <i class="fa fa-money fa-lg"></i>&nbsp;&nbsp;&nbsp;Sponsor the Conference</a>
-        </div>
-        <div class="p-2">
-          <a class="btn btn-secondary btn-block" href="https://forms.gle/CpCsWWH5pT9NgZma7"> <i class="fa fa-microphone fa-lg"></i>&nbsp;&nbsp;
-            &nbsp; Propose a talk</a>
-        </div>
-        <div class="p-2">
-          <a class="btn btn-secondary btn-block" href="https://ti.to/devopsdays-london/2022"> <i class="fa fa-ticket fa-lg"></i>&nbsp;&nbsp;&nbsp;Get a ticket</a>
-        </div>
-        <div class="p-2">
-          <a class="btn btn-secondary btn-block" href="https://devopsdays.us18.list-manage.com/subscribe?u=6c07d2ff23793b0dda5929f46&id=7aba07ba8c"> <i class="fa fa-list fa-lg"></i>&nbsp;&nbsp;
-            &nbsp; Get the latest announcements</a>
-        </div>
-        <div class="p-2">
-          <a class="btn btn-secondary btn-block" href="/events/2022-london/contact"> <i class="fa fa-envelope-o fa-lg"></i>&nbsp;&nbsp;
-            &nbsp; Contact the Organizers</a>
-        </div>
-      </div>
-    </div>
   </div>
 
   <div class="col-md-7">
-    <div class="alert alert-secondary" role="alert">
-      <h4 class="alert-heading">Coronavirus (COVID-19) policy.</h4>
-      <p>We are committed to provide a COVID-safe environment for all our attendees, including but not limited to Attendees, Sponsor Delegates, Volunteers, and Organising staff. We therefore ask you to comply with these measures outlined below, which may be greater than mandated in the UK at the time of the event.</p>
-      <ul>
-        <li><b>Masks should be worn at all times</b>, unless eating, drinking, or presenting a talk.</li>
-        <li>All attendees must have had a <b>negative lateral flow test</b> result each morning before arriving at the conference venue.</li>
-        <li>We encourage you to be fully vaccinated, as well as wearing a mask while travelling to the conference.</li>
-        <li>Please note that the risk profile of other attendees may be different to yours. Please respect their wishes around social distancing and physical contact.</li>
-        <li>To accommodate this policy, we will be providing you with <b>a pack of lateral flow tests</b>, and <b>two FFP2</b> masks to replace any you use while attending the conference, <b>free of charge</b>.</li>
-        <li>If you <b>test positive</b> or <b>feel ill, please do not attend</b>. We will provide you with details of our live stream and virtual event and refund you the difference between the in-person and virtual ticket prices. If you choose not to participate virtually we offer you a full refund.</li>
-      </ul>
+    <div class="d-flex flex-row">
+      <div class="col-md-12">
+        <div class="p-2">
+            <p><b>Catch up on the event below!</b></p>
+        </div>
+      </div>
     </div>
-    <p>The first DevOpsDays was held in Ghent, Belgium in 2009. Since then, DevOpsDays events have multiplied and expanded globally with over 55 events in for 2018.</p>
-    <p>DevOpsDays is a worldwide series of community run technical conferences covering topics of software development, IT infrastructure operations, and the intersection between them. It is run by volunteers from community, for the benefit of the community.
-      We are not a commercial conference and we believe that our focus on serving the community creates a truly unique experience for both delegates and sponsors.
-    </p>
-    <p>We expect 350 people (depending on COVID-19 guidance) this year and will be holding the event on September 29-30th at the
-      Kia Oval, Kennington, London.</p>
-    <p>For the first time this year we will offer interactive online tickets as well.</p>
-    <p>The format of DevOpsDays London includes a single track of 30 minute talks in the morning of each event, followed by Ignite talks (5 minute, auto forwarding). We spend the rest of the afternoon in Open Spaces, which are considered a key portion
-      of the event.
-    </p>
-    {{< event_twitter >}}
+    <div class="col-md-12">
+      <div class="p-2">
+        <a class="btn btn-secondary btn-block" href="https://youtube.com/playlist?list=PLuEbc43fHqLhunccTG6rbFNZP6Dw93I3X"> <i class="fa fa-video-camera fa-lg"></i>&nbsp;&nbsp;&nbsp; Watch the Recordings</a>
+      </div>
+      <div class="p-2">
+        <a class="btn btn-secondary btn-block" href="https://www.flickr.com/photos/160959951@N05/albums/72177720304917837"> <i class="fa fa-camera fa-lg"></i>&nbsp;&nbsp;&nbsp; Photography</a>
+      </div>
+      <div class="p-2">
+        <a class="btn btn-secondary btn-block" href="/events/2022-london/contact"> <i class="fa fa-envelope-o fa-lg"></i>&nbsp;&nbsp;&nbsp; Contact the Organizers</a>
+      </div>
+    </div>
   </div>
 </div>

--- a/data/events/2020-london.yml
+++ b/data/events/2020-london.yml
@@ -47,8 +47,6 @@ nav_elements: # List of pages you want to show up in the navigation of your page
 #   icon: "map-o" # This is a font-awesome icon that will display on small screens. Choose at http://fontawesome.io/icons/
 #   url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site
 
-masthead_background: "background.png"
-
 # These are the same people you have on the mailing list and Slack channel.
 team_members: # Name is the only required field for team members.
   - name: "Andy Burgin"

--- a/data/events/2022-london.yml
+++ b/data/events/2022-london.yml
@@ -37,12 +37,12 @@ location_address: "Kia Oval, Kennington, London SE11 5SS"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
   # - name: propose
-  - name: registration
+  # - name: registration
   - name: program
   - name: speakers
   - name: location
   - name: accessibility
-  - name: sponsor
+  # - name: sponsor
   - name: contact
   - name: conduct
   - name: subscribe
@@ -150,7 +150,7 @@ sponsors:
   - id: syntasso
     level: bronze
 
-sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
+sponsors_accepted: "no" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.
 # You may optionally include a "max" attribute to limit the number of sponsors per level. For


### PR DESCRIPTION
I'd forgotten to close down the previous year and provide links to the videos and photography.

This PR should suffice in correcting that mistake.

Further to this I also noticed a duplicate key in 2019: `masthead_background` which I've also corrected (though this'll make very little difference to anything other than suppressed warnings).