### PR TITLE
[BOS-2023] Add Josh as organizer

### DIFF
--- a/data/events/2023-boston.yaml
+++ b/data/events/2023-boston.yaml
@@ -63,6 +63,9 @@ team_members:
     bio: "Kate works as a Site Reliability Engineer II for edx, a edtech company in the Boston area looking to expand education past the boundaries of traditional education. She has a passion for all things infrastructure and application security, and using emojis to get things done. While not at work, she’s working on a farm, playing with her dog, or biking through the streets of Massachusetts."
     image: "kateruh.jpg"
 
+  - name: "Josh"
+    bio: "Not much is known about Josh, other than he tends to show up, support the mission, not say much, and disappear into the night when no longer required."
+
 organizer_email: "boston@devopsdays.org"
 
 # Uncomment when opening for sponsorships.


### PR DESCRIPTION
Josh is joining the Boston oranizing team. I will also send a message to info@devopsdays.org.

Note that there was a [discussion in Slack](https://devopsdays.slack.com/archives/CDCDD7319/p1684255997324589) about organizing on a first-name-only / headshotless basis on the website.