### PR TITLE
[AMS 2023] sponsors update

### DIFF
--- a/data/events/2023-amsterdam.yml
+++ b/data/events/2023-amsterdam.yml
@@ -195,6 +195,12 @@ sponsors:
   # Bronze
   - id: raftech
     level: bronze
+  - id: itility
+    level: bronze
+  - id: inuits
+    level: bronze
+  - id: kabisa
+    level: bronze
 
 sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 

--- a/data/events/2023-amsterdam.yml
+++ b/data/events/2023-amsterdam.yml
@@ -138,6 +138,9 @@ organizer_email: "amsterdam@devopsdays.org" # Put your organizer email address h
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
+  # Platinum
+  - id: portworx
+    level: platinum
   # Beer
   - id: contrast_security
     level: beer

--- a/data/events/2023-amsterdam.yml
+++ b/data/events/2023-amsterdam.yml
@@ -221,9 +221,6 @@ sponsor_levels:
   - id: lanyard
     label: Lanyard
     max: 1
-  - id: recharge
-    label: "Power recharge"
-    max: 1
   - id: foodtruck
     label: "Food Trucks"
     max: 4


### PR DESCRIPTION
- Add Portworx as Platinum
- Add itility, inuits and kabisa as bronze
- Remove recharge sponsor option