### PR TITLE
[NYC-2023] fix url for sponsor sym

### DIFF
--- a/data/sponsors/sym.yml
+++ b/data/sponsors/sym.yml
@@ -1,2 +1,2 @@
 name: "sym"
-url: "symops.com"
+url: "https://symops.com"


### PR DESCRIPTION
missed the `https://` initially so its treating it as a relative url