### PR TITLE
[ZRH-2023] Fixed the video headline from 2022 to 2023

### DIFF
--- a/content/events/2023-zurich/welcome.md
+++ b/content/events/2023-zurich/welcome.md
@@ -11,7 +11,7 @@ Description = "DevOpsDays Zurich 2023"
   </div>
   <div class = "col-md-3">
     <iframe src="https://player.vimeo.com/video/831240524?h=935e4fa3fe?autoplay=1&muted=1" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen  style="float:bottom"></iframe>
-    Impressions from 2022
+    Impressions from 2023
   </div>  
 </div>
 <div class = "row">

--- a/content/events/2024-zurich/welcome.md
+++ b/content/events/2024-zurich/welcome.md
@@ -11,7 +11,7 @@ Description = "DevOpsDays Zurich 2024"
   </div>
   <div class = "col-md-3">
     <iframe src="https://player.vimeo.com/video/831240524?h=935e4fa3fe?autoplay=1&muted=1" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen  style="float:bottom"></iframe>
-    Impressions from 2022
+    Impressions from 2023
   </div>  
 </div>
 <div class = "row">


### PR DESCRIPTION
*Please title your pull request in this format: The event name and year in the title of the PR, along with a description of what is being changed, i.e., `[CHI-2019] Add Bluth Company as a sponsor`*

If you are adding or removing organisers, please email info@devopsdays.org with the details of who is being added and removed, along with the full names and email addresses of the new team, so we can update Slack and the mailing list.
