### PR TITLE
[AMS-2023] Fix some sponsor url's

### DIFF
--- a/data/events/2023-amsterdam.yml
+++ b/data/events/2023-amsterdam.yml
@@ -200,6 +200,7 @@ sponsors:
   - id: inuits
     level: bronze
   - id: kabisa
+    url: https://cloudlegends.nl/
     level: bronze
   - id: atcomputing
     level: bronze

--- a/data/sponsors/atcomputing.yml
+++ b/data/sponsors/atcomputing.yml
@@ -1,2 +1,2 @@
 name: "AT Computing"
-url: "https://atcomputing.com/"
+url: "https://atcomputing.nl/"


### PR DESCRIPTION
Made an typo with the AT computing url. This fixes that ( com -> nl ).

Using an custom url for Kabisa as they have a diferent brand that they want to point to.