### PR TITLE
[ATL-2023] Remove rescheduling message on welcome page

### DIFF
--- a/content/events/2023-atlanta/welcome.md
+++ b/content/events/2023-atlanta/welcome.md
@@ -9,8 +9,6 @@ Description = "devopsdays Atlanta 2023"
   {{< event_logo >}}
 </div> -->
 
-**We are rescheduling Devopsdays Atlanta to September, 2023. Exact dates will be available soon. We apologize for any inconvenience and hope to see you at the event!**
-
 <!-- <div class = "row">
   <div class = "col-md-2">
     <strong>Dates</strong>


### PR DESCRIPTION
I completely missed the rescheduling message on the welcome page. This removes that message.