### PR TITLE
[LDN-2023] Add GitHub as a bronze sponsor

### DIFF
--- a/data/events/2023-london.yml
+++ b/data/events/2023-london.yml
@@ -102,6 +102,8 @@ sponsors:
   # bronze sponsors
   - id: dxw
     level: bronze
+  - id: github
+    level: bronze
   - id: gitlab
     level: bronze
   - id: helloself


### PR DESCRIPTION
- The usual "employers of organizers get a free bronze slot" thingy.