### PR TITLE
[INDY-2023] Allow Indianapolis organizers to edit their site

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,5 @@ package.json    @devopsdays/build-infra
 /bin/   @devopsdays/build-infra
 /.github/   @devopsdays/build-infra
 /static/robots.txt @devopsdays/build-infra
+/data/events/2023-indianapolis.yml @ghoneycutt @apoland @napoleonjones @devopsdays/code-reviewers
+/content/events/2023-indianapolis/ @ghoneycutt @apoland @napoleonjones @devopsdays/code-reviewers


### PR DESCRIPTION
This patch allows the organizers of DoD Indy to organize pages specific to them. This is needed so that we can do immediate changes of the site for open spaces while also giving autonomy to the local team.