### PR TITLE
[AMS-2023] Add ws facilitator Stephan, update interview sched

### DIFF
--- a/content/events/2023-amsterdam/program/ws-mark-heistek.md
+++ b/content/events/2023-amsterdam/program/ws-mark-heistek.md
@@ -4,7 +4,7 @@ Talk_start_time = ""
 Talk_end_time = ""
 Title = "Come and play! Learn how to deal with resistance!"
 Type = "talk"
-Speakers = ["mark-heistek"]
+Speakers = ["mark-heistek", "stephan-heistek"]
 +++
 Resistance is everywhere. It's within your team, it's with your manager, it's within your relationship, and everywhere you look, there's always some kind of resistance.
 Now, this isn't perse a bad thing, resistance is just one phase of change. Insecurity, resistance, anger, joy, and happiness are all part of the change. 

--- a/content/events/2023-amsterdam/speakers/stephan-heistek.md
+++ b/content/events/2023-amsterdam/speakers/stephan-heistek.md
@@ -1,0 +1,12 @@
++++
+Title = "Stephan Heistek"
+Linkedin = ""
+Website = ""
+Twitter = ""
+image = ""
+type = "speaker"
+linktitle = "mark-heistek"
++++
+Stephan Heistek, a former renovation professional, has transitioned to focus on hypnotherapy. With a background in renovation and a passion for helping others, Stephan combines his skills to facilitate positive change. Through extensive training, he specializes in using hypnosis techniques to help individuals overcome challenges and achieve personal growth. Stephan's compassionate approach creates a safe and supportive environment for clients, guiding them towards lasting transformation. 
+
+Beyond hypnotherapy, he remains connected to his roots in renovation, finding innovative ways to blend design principles with the power of suggestion. Stephan's journey showcases his versatility and unwavering commitment to empowering others.

--- a/data/events/2023-amsterdam.yml
+++ b/data/events/2023-amsterdam.yml
@@ -620,7 +620,7 @@ program:
     date: 2023-06-23T00:00:00+02:00
     start_time: "14:10"
     end_time: "14:55"
-  - title: "Online: Interview with Lesley Cordero, Thiago de Faria, and Andrew Zigler"
+  - title: "Online: Interview with Lesley Cordero, Lou Creemers and Andrew Zigler"
     type: open-space
     date: 2023-06-23T00:00:00+02:00
     start_time: "14:10"


### PR DESCRIPTION
Adds workshop facilitator Stephan Heistek (for Mark Heistek), update interview schedule (add Lou Cremers, move Thiago to recording slot). 
