### PR TITLE
[ORG-2023] Update schedule

### DIFF
--- a/data/events/2023-organizer-summit.yml
+++ b/data/events/2023-organizer-summit.yml
@@ -201,7 +201,7 @@ program:
     date: 2023-08-08T00:00:00-05:00
     start_time: "08:00"
     end_time: "09:00"
-  - title: "Opening Welcome"
+  - title: "Opening Welcome + Introduction Open Spaces process"
     type: custom
     date: 2023-08-08T00:00:00-05:00
     start_time: "09:00"
@@ -231,7 +231,7 @@ program:
     date: 2023-08-08T00:00:00-05:00
     start_time: "10:45"
     end_time: "10:50"
-  - title: "Break + Group Photo + Collection of Open Spaces topics & voting"
+  - title: "Break + Group Photo"
     type: custom
     date: 2023-08-08T00:00:00-05:00
     start_time: "11:00"
@@ -294,5 +294,5 @@ program:
   - title: "Evening Event"
     type: custom
     date: 2023-08-08T00:00:00-05:00
-    start_time: "18:30"
+    start_time: "18:00"
     end_time: "21:00"


### PR DESCRIPTION
Reflects the starting time of the social event.
Moves introduction of the Open Spaces process to the Introduction. I reviewed the time we have on the schedule to switch from session to session, which seems like enough buffer time. Might need to review this if @jjasghar has wild plans for virtual.
