### PR TITLE
[WAW-2023] Updated CFP end date

### DIFF
--- a/data/events/2023-warsaw.yml
+++ b/data/events/2023-warsaw.yml
@@ -18,8 +18,8 @@ enddate: 2023-11-08T23:59:59+02:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2023-06-01T00:00:00+02:00
-cfp_date_end: 2023-09-05T23:59:59+02:00
-cfp_date_announce: 2023-09-15T00:00:00+02:00
+cfp_date_end: 2023-09-15T23:59:59+02:00
+cfp_date_announce: 2023-09-22T00:00:00+02:00
 
 cfp_link: "https://devopsdays.pl/call-for-papers-2023/"
 


### PR DESCRIPTION
We are extending CFP time by one week to give people more time to send proposals after summer vacation time.
