### PR TITLE
[EHV-2023] Update organizers

### DIFF
--- a/data/events/2023-eindhoven.yml
+++ b/data/events/2023-eindhoven.yml
@@ -110,14 +110,9 @@ team_members: # Name is the only required field for team members.
     twitter: "KrisBuytaert"
     github: "KrisBuytaert"
     linkedin: "https://www.linkedin.com/in/krisbuytaert"
-    image: "kris-buytaert.jpeg"
+    image: "kris-buytaert.jpg"
 
   # not-local to Eindhoven but also helping Eindhoven.
-  - name: "Harm Boertien"
-    twitter: "Harm_Ops"
-    github: "HarmB"
-    linkedin: "https://www.linkedin.com/in/harmboertien"
-    image: harm.jpeg
 
   - name: "Daniel Paulus"
     pronouns: "he/him"


### PR DESCRIPTION
Remove Harm from active orgs list (and update Kris' picture).
The distribution list has been updated (and I sent an email about the change).