### PR TITLE
[2023-LDN] Add actual details about the evening events

### DIFF
--- a/content/events/2023-london/program/ten-years-of-dodl.md
+++ b/content/events/2023-london/program/ten-years-of-dodl.md
@@ -4,7 +4,7 @@ Talk_start_time = ""
 Talk_end_time = ""
 Title = "10 Years of DevOpsDays London - Discussion"
 Type = "talk"
-Speakers = []
+Speakers = ["dodl-organisers"]
 +++
 
 We're celebrating 10 years of DevOpsDays London! Join organisers of past and present for a discussion about the good, the bad, and the future of this conference and the DevOps movement in general.

--- a/content/events/2023-london/program/ten-years-of-dodl.md
+++ b/content/events/2023-london/program/ten-years-of-dodl.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "10 Years of DevOpsDays London - Discussion"
+Type = "talk"
+Speakers = []
++++
+
+We're celebrating 10 years of DevOpsDays London! Join organisers of past and present for a discussion about the good, the bad, and the future of this conference and the DevOps movement in general.

--- a/content/events/2023-london/speakers/dodl-organisers.md
+++ b/content/events/2023-london/speakers/dodl-organisers.md
@@ -1,0 +1,8 @@
++++
+Title = "DODL Organisers"
+type = "speaker"
+linktitle = "ten-years-of-dodl"
+
++++
+
+DevOpsDays London organisers of past and present.

--- a/data/events/2023-london.yml
+++ b/data/events/2023-london.yml
@@ -236,8 +236,8 @@ program:
     date: 2023-09-21T00:00:00+01:00
     start_time: 16:00
     end_time: 16:15
-  - title: "10 Years of DevOpsDays London - Discussion"
-    type: custom
+  - title: "ten-years-of-dodl"
+    type: talk
     date: 2023-09-21T00:00:00+01:00
     start_time: "16:15"
     end_time: "17:00"
@@ -246,10 +246,13 @@ program:
     date: 2023-09-21T00:00:00+01:00
     start_time: "17:00"
     end_time: "17:10"
-  - title: "Evening Reception - TBC"
+  - title: "Drinks Reception in the Sponsor Hall"
     type: custom
-    date: 2023-09-21T00:00:00+01:00
     start_time: "17:10"
+    end_time: "18:10"
+  - title: "Evening event hosted by DOXLON, Adaptavist and GitLab!"
+    type: custom
+    start_time: "18:30"
     end_time: "Onwards"
   - title: "Breakfast"
     type: custom

--- a/data/events/2023-london.yml
+++ b/data/events/2023-london.yml
@@ -248,10 +248,12 @@ program:
     end_time: "17:10"
   - title: "Drinks Reception in the Sponsor Hall"
     type: custom
+    date: 2023-09-21T00:00:00+01:00
     start_time: "17:10"
     end_time: "18:10"
   - title: "Evening event hosted by DOXLON, Adaptavist and GitLab!"
     type: custom
+    date: 2023-09-21T00:00:00+01:00
     start_time: "18:30"
     end_time: "Onwards"
   - title: "Breakfast"


### PR DESCRIPTION
- We've finally got confirmation of our drinks reception and the evening event being hosted for us by a community sponsor.
- Also convert the "10 years of DevOpsDays London" item into a talk and add some blurb.
