### PR TITLE
[LDN-2024] Add CFP for 2024

### DIFF
--- a/content/events/2024-london/location.md
+++ b/content/events/2024-london/location.md
@@ -1,0 +1,11 @@
++++
+Title = "Location"
+Type = "event"
+Description = "Location for DevOpsDays London 2024"
++++
+
+The event will be held at the <a href="https://qeiicentre.london/">QEII Centre</a> in the heart of London.
+
+{{< event_map >}}
+<br/>
+For directions, <a href="https://qeiicentre.london/about/location/">click here</a>.

--- a/content/events/2024-london/propose.md
+++ b/content/events/2024-london/propose.md
@@ -7,7 +7,7 @@ Description = "Propose a talk for devopsdays London 2024"
 
 <hr>
 
-<center><h2>Our CFP is now open! Use <a href="">this form</a> to propose a talk.</h2></center>
+<center><h2>Our CFP is now open! Use <a href="https://docs.google.com/forms/d/e/1FAIpQLSdUK4VNyhpfpqhrm8BY7KmAvSNQHIuL49YOabkYDInbnyKD1g/viewform">this form</a> to propose a talk.</h2></center>
 
 <hr>
 

--- a/content/events/2024-london/propose.md
+++ b/content/events/2024-london/propose.md
@@ -1,0 +1,49 @@
++++
+Title = "Propose"
+Type = "event"
+Description = "Propose a talk for devopsdays London 2024"
++++
+  {{< cfp_dates >}}
+
+<hr>
+
+<center><h2>Our CFP is now open! Use <a href="">this form</a> to propose a talk.</h2></center>
+
+<hr>
+
+There are three ways to propose a topic at devopsdays:
+<ol>
+  <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
+  <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
+  <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
+</ol>
+
+<hr>
+
+Choosing talks is part art, part science; here are some factors we consider when trying to assemble the best possible program for our local audience:
+
+- _broad appeal_: How will your talk play out in a room of people with a variety of backgrounds? Technical deep dives need more levels to provide value for the whole room, some of whom might not use your specific tool.
+- _new local presenters_: You are the only one who can tell your story. We are very interested in the challenges and successes being experienced in our local area. We are happy to provide guidance/coaching for new speakers upon request.
+- _under-represented voices_: We want to hear all voices, including those that may speak less frequently at similar events. Whether you're in a field not typically thought of as a technology field, you're in a large, traditional organization, or you're the only person at your organization with your background, we are interested in your unique experience.
+- _original content_: We will consider talks that have already been presented elsewhere, but we prefer talks that the local area isn't likely to have already seen.
+- _no third-party submissions_: This is a small community-driven event, and speakers need to be directly engaged with the organizers and attendees. If a PR firm or your marketing department is proposing the talk, you've already shown that as a speaker you're distant from the process.
+- _no vendor pitches_: As much as we value vendors and sponsors, we are not going to accept a talk that appears to be a pitch for your product.
+
+<hr>
+As a speaker we will provide you with:
+
+- a free ticket to the conference
+- free ticket for 1 other person and some discount codes
+<!-- - an invite to the speakers dinner the night before the conference starts -->
+
+in addition, if you are personally funding your attendance we have some budget to cover reasonable travel and accommodation costs.
+
+<hr>
+
+### Help with your talk
+
+If you are a first time speaker and/or from an under represented group in technology
+we would like to help you with your talk.
+
+Several of the committee are veteran speakers and can provide help and suggestions
+to make your talk better should it be selected.

--- a/content/events/2024-london/welcome.md
+++ b/content/events/2024-london/welcome.md
@@ -17,6 +17,10 @@ Description = "DevOpsDays London 2024"
           <a class="btn btn-secondary btn-block" href="/events/2024-london/sponsor"> <i class="fa fa-money fa-lg"></i>&nbsp;&nbsp;&nbsp;Sponsor the Conference</a>
         </div>
         <div class="p-2">
+          <a class="btn btn-secondary btn-block" href="https://docs.google.com/forms/d/e/1FAIpQLSdUK4VNyhpfpqhrm8BY7KmAvSNQHIuL49YOabkYDInbnyKD1g/viewform"> <i class="fa fa-microphone fa-lg"></i>&nbsp;&nbsp;
+            &nbsp; Propose a talk</a>
+        </div>
+        <div class="p-2">
           <a class="btn btn-secondary btn-block" href="https://ti.to/devopsdays-london/2024"> <i class="fa fa-ticket fa-lg"></i>&nbsp;&nbsp;&nbsp;Get a ticket</a>
         </div>
         <div class="p-2">

--- a/data/events/2024-london.yml
+++ b/data/events/2024-london.yml
@@ -16,11 +16,11 @@ startdate: 2024-09-26T00:00:00+01:00 # The start date of your event. Leave blank
 enddate: 2024-09-27T00:00:00+01:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-# cfp_date_start: 2023-01-31T00:00:00+01:00 # start accepting talk proposals.
-# cfp_date_end: 2023-05-20T23:59:59+01:00 # close your call for proposals.
-# cfp_date_announce: 2023-06-20T23:59:59+01:00 # inform proposers of status
+cfp_date_start: 2023-09-22T00:00:00+01:00 # start accepting talk proposals.
+cfp_date_end: 2024-05-24T23:59:59+01:00 # close your call for proposals.
+cfp_date_announce: 2024-06-26T23:59:59+01:00 # inform proposers of status
 
-# cfp_link: "https://forms.gle/iBjCTD5N3abLAcNP8"
+cfp_link: ""
 
 # registration_date_start: 2023-01-31T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
 # registration_date_end: 2023-09-15T23:59:59+01:00 # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
@@ -30,18 +30,18 @@ enddate: 2024-09-27T00:00:00+01:00 # The end date of your event. Leave blank if 
 
 # Location
 #
-# coordinates: "51.4999205, -0.1284255" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+coordinates: "51.4999205, -0.1284255" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "London" # Defaults to city, but you can make it the venue name.
 
-# location_address: "QEII Centre, Broad Sanctuary, Westminster"
+location_address: "QEII Centre, Broad Sanctuary, Westminster"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
   # - name: registration
 # - name: propose
   # - name: program
   # - name: speakers
-  # - name: location
-#  - name: accessibility
+  - name: location
+  - name: accessibility
   - name: sponsor
   - name: contact
   - name: conduct

--- a/data/events/2024-london.yml
+++ b/data/events/2024-london.yml
@@ -20,7 +20,7 @@ cfp_date_start: 2023-09-22T00:00:00+01:00 # start accepting talk proposals.
 cfp_date_end: 2024-05-24T23:59:59+01:00 # close your call for proposals.
 cfp_date_announce: 2024-06-26T23:59:59+01:00 # inform proposers of status
 
-cfp_link: ""
+cfp_link: "https://docs.google.com/forms/d/e/1FAIpQLSdUK4VNyhpfpqhrm8BY7KmAvSNQHIuL49YOabkYDInbnyKD1g/viewform"
 
 # registration_date_start: 2023-01-31T00:00:00+01:00 # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
 # registration_date_end: 2023-09-15T23:59:59+01:00 # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
@@ -37,7 +37,7 @@ location_address: "QEII Centre, Broad Sanctuary, Westminster"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
   # - name: registration
-# - name: propose
+  - name: propose
   # - name: program
   # - name: speakers
   - name: location


### PR DESCRIPTION
We're going to shout out that there's a CFP for 2024 and start to get talks early (they'll probably age quite well lol)

- Added `content/events/2024-london/propose.md` even though it's not needed as we link with `cfp_link` but sometimes we alias to this page.
- Added location page as we know it's QEII
- Added accessibility page that was missing.