### PR TITLE
[AMS-2024] Add (empty) info pages for sponsors and speakers

### DIFF
--- a/content/events/2024-amsterdam/speaker-info.md
+++ b/content/events/2024-amsterdam/speaker-info.md
@@ -1,0 +1,6 @@
++++
+date = "2016-10-17T08:26:34-05:00"
+title = "Speaker Information"
+type = "event"
+description = "Speaker information for DevOpsDays Amsterdam 2024"
++++

--- a/content/events/2024-amsterdam/sponsor-info.md
+++ b/content/events/2024-amsterdam/sponsor-info.md
@@ -1,0 +1,6 @@
++++
+date = "2016-10-17T08:26:34-05:00"
+title = "Sponsor Information"
+type = "event"
+description = "Sponsor information for devopsdays Amsterdam 2024!"
++++


### PR DESCRIPTION
These pages are placeholders for the sponsor and speaker info so the team can fill it in with the GitHub editor. 