### PR TITLE
[BER-2024] Add Cloudsmith as platinum sponsor

### DIFF
--- a/data/events/2024-berlin.yml
+++ b/data/events/2024-berlin.yml
@@ -95,6 +95,8 @@ organizer_email: "berlin@devopsdays.org" # Put your organizer email address here
 sponsors:
   - id: netways
     level: partner
+  - id: cloudsmith
+    level: platinum
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
We received confirmation that Cloudsmith payed the sponsorship fee and are now officially a sponsor for the Berlin 2024 event.