### PR TITLE
[CHI-2024] Add redirect to CFP

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -25,6 +25,7 @@
 /cape-town/*		/events/2020-cape-town/:splat		302
 /charlotte/*		/events/2022-charlotte/:splat		302
 /chattanooga/*		/events/2023-chattanooga/:splat		302
+/chicago/cfp    https://talks.devopsdays.org/devopsdays-chicago-2024/cfp 302
 /chicago/*		/events/2024-chicago/:splat		302
 /columbus/*		/events/2020-columbus/:splat		302
 /copenhagen/*		/events/2023-copenhagen/:splat		302


### PR DESCRIPTION
This makes devopsday.org/chicago/cfp redirect to the NOT YET PUBLISHED cfp page for the event; just setting this up to not have to do it later!