### PR TITLE
[Halifax-2024] Open CfP for Halifax-2024

### DIFF
--- a/content/events/2024-halifax/propose.md
+++ b/content/events/2024-halifax/propose.md
@@ -4,35 +4,38 @@ Type = "event"
 Description = "Propose a talk for devopsdays Halifax 2024"
 +++
 
-**The CfP page is still under construction. Please check back later.**
+The CfP for DevOpsDays Halifax 2024 is now OPEN! 
 
-  {{< cfp_dates >}}
+<strong>Visit [this website](https://talks.devopsdays.org/devopsdays-halifax-2024/cfp) to submit your talk.</strong>
 
-<hr>
-
-There are three ways to propose a topic at devopsdays:
-<ol>
-  <li><strong><em>A 30-minute talk</em></strong> presented during the conference, usually in the mornings.</li>
-  <li><strong><em>An Ignite talk</em></strong> presented during the <a href="/pages/ignite-talks-format">Ignite sessions</a> (scheduling varies). These are 5 minutes slots with slides changing every 15 seconds (20 slides total).</li>
-  <li><strong><em>Open Space</em></strong>: If you'd like to lead a group discussion during the attendee-suggested <a href="/pages/open-space-format">Open Space</a> breakout sessions, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference. If you'd like to demo your product or service, you should <a href="../sponsor">sponsor the event</a> and demo it at your table.
-</ol>
+Important: The CfP closes on 2024-03-31 23:59 (America/Halifax time).
 
 <hr>
 
-Choosing talks is part art, part science; here are some factors we consider when trying to assemble the best possible program for our local audience:
+We're looking for speakers for the first DevOpsDays Conference in Halifax. Want to present your thoughts, ideas, and strategies around DevOps to your peers from Atlantic Canada? Submit your talk proposal here for review by the DevOpsDays Halifax organizing committee.
 
-- _broad appeal_: How will your talk play out in a room of people with a variety of backgrounds? Technical deep dives need more levels to provide value for the whole room, some of whom might not use your specific tool.
-- _new local presenters_: You are the only one who can tell your story. We are very interested in the challenges and successes being experienced in our local area. We are happy to provide guidance/coaching for new speakers upon request.
-- _under-represented voices_: We want to hear all voices, including those that may speak less frequently at similar events. Whether you're in a field not typically thought of as a technology field, you're in a large, traditional organization, or you're the only person at your organization with your background, we are interested in your unique experience.
-- _original content_: We will consider talks that have already been presented elsewhere, but we prefer talks that the local area isn't likely to have already seen.
-- _no third-party submissions_: This is a small community-driven event, and speakers need to be directly engaged with the organizers and attendees. If a PR firm or your marketing department is proposing the talk, you've already shown that as a speaker you're distant from the process.
-- _no vendor pitches_: As much as we value vendors and sponsors, we are not going to accept a talk that appears to be a pitch for your product.
+This is a single track event, with 30 minute slots. We're expecting between 150-200 attendees at the conference.
 
-<hr>
+Some topic ideas include but are not limited to:
 
-<strong>How to submit a proposal:</strong> Send an email to [{{< email_organizers >}}] with the following information
-<ol>
-	<li>Type (presentation, panel discussion, ignite)</li>
-	<li>Proposal Title (can be changed later)</li>
-	<li>Description (several sentences explaining what attendees will learn)</li>
-</ol>
+- Automation: Infrastructure as code (IaC), CI/CD pipelines, configuration management, containerization, and orchestration.
+- Cloud Native: Building and deploying applications for the cloud, microservices architecture, serverless computing, and cloud-native security.
+- Security: DevSecOps, vulnerability management, secrets management, and compliance.
+- Monitoring and Observability: Metrics, logging, tracing, and alerting for performance and incident response.
+- Testing: Continuous testing, automated testing frameworks, and chaos engineering.
+- Collaboration: Communication, teamwork, and cultural change between development and operations teams.
+- Artificial intelligence (AI) and Machine Learning (ML): Applications in DevOps, automation, and anomaly detection.
+- Edge computing: Building and deploying applications at the edge of the network.
+- Serverless computing: Building applications without managing infrastructure.
+- Quantum computing: Potential applications for DevOps and IT.
+- Open source tools and technologies: Latest advancements and best practices.
+
+You can find more information about the conference, including our code of conduct, [here](https://devopsdays.org/events/2024-halifax/conduct).
+
+First-time speaking? Come on board! We're navigating this journey for the first time too!
+
+Do you require funding for travel or accommodation? Please send an email to [{{< email_organizers >}}] with some details. We have a limited budget for speaker travel and accommodation assistance, and we'll allocate this based on need and on a first-come-first-serve basis.
+
+All submissions will be reviewed blindly, meaning that the program committee is unable to see the submitter’s personal details. Only the title of the talk and the describing abstract will be visible to the reviewers in order to reduce unconscious bias. After all talks are rated, we will inform you about the status of your submission. Talks can either be accepted, rejected or waitlisted. In case your talk is waitlisted, we will message you if a speaking slot opens up before the conference.<strong>How to submit a proposal:</strong> Visit [this website](https://talks.devopsdays.org/devopsdays-halifax-2024/cfp) to submit your talk. 
+
+If you have any question regarding the CfP, you can send an email to [{{< email_organizers >}}].

--- a/data/events/2024-halifax.yml
+++ b/data/events/2024-halifax.yml
@@ -10,11 +10,11 @@ startdate:  2024-08-21
 enddate:  2024-08-22
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:  # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_start: 2024-01-15 # start accepting talk proposals.
+cfp_date_end: 2024-03-31 # close your call for proposals.
+cfp_date_announce: 2024-04-30 # inform proposers of status
 
-cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_link: "https://talks.devopsdays.org/devopsdays-halifax-2024/cfp" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
 registration_date_end: # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
@@ -33,7 +33,7 @@ location: "Marion McCain Arts and Social Sciences Building, Dalhousie University
 location_address: "6135 University Ave, Halifax, NS B3H 4P9, Canada" #Optional - use the street address of your venue. This will show up on the welcome page if set.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- # - name: propose
+  - name: propose
   - name: location
  # - name: registration
  # - name: program


### PR DESCRIPTION
This PR makes the necessary changes for the CfP page of DevOpsDays Halifax 2024 as we make the CfP live.
