### PR TITLE
[REC-2024] fix redirect (oops)

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -95,8 +95,8 @@
 /poznan/*		/events/2023-poznan/:splat		302
 /prague/*		/events/2023-prague/:splat		302
 /raleigh/*		/events/2024-raleigh/:splat		302
-/recife/*		/events/2024-recife/:splat		302
 /recife/cfp     https://www.papercall.io/dodrec24    302
+/recife/*		/events/2024-recife/:splat		302
 /riga/*			/events/2018-riga/:splat		302
 /rio-de-janeiro/*	/events/2023-rio-de-janeiro/:splat	302
 /rome/*			/events/2012-italy/:splat		302


### PR DESCRIPTION
Put the explicit ref _before_ the splat so that the redirect works as expected (see #13579).