### PR TITLE
[MTL-2024] Extend CFP one more week

### DIFF
--- a/data/events/2024-montreal.yml
+++ b/data/events/2024-montreal.yml
@@ -16,7 +16,7 @@ enddate: 2024-05-28T18:00:00-04:00 # The end date of your event. Leave blank if 
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2023-12-01T00:00:00-05:00 # start accepting talk proposals.
-cfp_date_end:  2024-01-28T23:59:59-05:00 # close your call for proposals.
+cfp_date_end:  2024-02-04T23:59:59-05:00 # close your call for proposals.
 cfp_date_announce: 2024-03-01T00:00:00-05:00 # inform proposers of status
 
 cfp_link: "https://sessionize.com/devopsdays-montreal-2024/" # if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/utilities/add_speakers.sh
+++ b/utilities/add_speakers.sh
@@ -69,12 +69,6 @@ read -p "Enter speaker linkedin profile (return for none): " linkedin
 [ -z "${linkedin}" ] && linkedin=''
 string_replace "SPEAKERLINKEDIN" "${linkedin}" "${speakerfile}"
 
-#linkedin profile
-read -p "Enter speaker linkedin profile (return for none): " linkedin
-[ -z "${linkedin}" ] && linkedin=''
-sedcmd "s,SPEAKERLINKEDIN,$linkedin,g" $speakerfile
-
-
 # bio
 read -p "Enter speaker bio (return for none): " bio
 [ -z "${bio}" ] && bio=''

--- a/utilities/add_speakers.sh
+++ b/utilities/add_speakers.sh
@@ -69,6 +69,12 @@ read -p "Enter speaker linkedin profile (return for none): " linkedin
 [ -z "${linkedin}" ] && linkedin=''
 string_replace "SPEAKERLINKEDIN" "${linkedin}" "${speakerfile}"
 
+#linkedin profile
+read -p "Enter speaker linkedin profile (return for none): " linkedin
+[ -z "${linkedin}" ] && linkedin=''
+sedcmd "s,SPEAKERLINKEDIN,$linkedin,g" $speakerfile
+
+
 # bio
 read -p "Enter speaker bio (return for none): " bio
 [ -z "${bio}" ] && bio=''


### PR DESCRIPTION
I rebased and the only difference should be the `data/events/2024-montreal.yml` file but I don't know why I still see an list of commits in the PR :( 