### PR TITLE
[BER-2024] Add Snyk as platinum sponsor

### DIFF
--- a/data/events/2024-berlin.yml
+++ b/data/events/2024-berlin.yml
@@ -97,6 +97,8 @@ sponsors:
     level: partner
   - id: cloudsmith
     level: platinum
+  - id: snyk
+    level: platinum
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION


We received confirmation that Cloudsmith payed the sponsorship fee and are now officially a sponsor for the Berlin 2024 event.
