### PR TITLE
[AMS-2024] remove cfp url

### DIFF
--- a/data/events/2024-amsterdam.yml
+++ b/data/events/2024-amsterdam.yml
@@ -40,7 +40,7 @@ masthead_background: "backdrop.png"
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: location
   - name: registration
-  - name: propose
+  # - name: propose
   # - name: program
   # - name: speakers
   - name: sponsor


### PR DESCRIPTION
CfP closed. Remove the url on the event page.
