### PR TITLE
[HOU-2024] Adding CFP announce date

### DIFF
--- a/data/events/2024-houston.yml
+++ b/data/events/2024-houston.yml
@@ -16,7 +16,7 @@ enddate: 2024-06-05T00:00:00-06:00 # The end date of your event. Leave blank if 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2024-02-01T00:00:00-06:00  # start accepting talk proposals.
 cfp_date_end: 2024-03-31T23:59:59-06:00 # close your call for proposals.
-cfp_date_announce: # inform proposers of status
+cfp_date_announce: 2024-04-15T00:00:00-06:00 # inform proposers of status
 
 cfp_link: "https://talks.devopsdays.org/devopsdays-houston-2024/cfp" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 


### PR DESCRIPTION
Adding CFP announce date so that CFP shows up on the devopsdays.org site.
