### PR TITLE
[VAN-2024] Extend CFP by a bit to get more lightning talks

### DIFF
--- a/data/events/2024-vancouver.yml
+++ b/data/events/2024-vancouver.yml
@@ -15,7 +15,7 @@ enddate: 2024-05-18T23:59:59-08:00 # The end date of your event. Leave blank if 
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2024-01-15T00:00:00-08:00 # start accepting talk proposals.
-cfp_date_end: 2024-02-15T00:00:00-08:00 # close your call for proposals.
+cfp_date_end: 2024-02-21T00:00:00-08:00 # close your call for proposals.
 cfp_date_announce: 2024-03-15T00:00:00-08:00 # inform proposers of status
 
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.

--- a/data/events/2024-vancouver.yml
+++ b/data/events/2024-vancouver.yml
@@ -15,7 +15,7 @@ enddate: 2024-05-18T23:59:59-08:00 # The end date of your event. Leave blank if 
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2024-01-15T00:00:00-08:00 # start accepting talk proposals.
-cfp_date_end: 2024-02-21T00:00:00-08:00 # close your call for proposals.
+cfp_date_end: 2024-02-26T00:00:00-08:00 # close your call for proposals.
 cfp_date_announce: 2024-03-15T00:00:00-08:00 # inform proposers of status
 
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.


### PR DESCRIPTION
We are hoping to get a few more lightning talks, so we've modified our submission form to only allow lightning talks and we will extend the CFP by about a week.