### PR TITLE
[2024-Ghent] Changing the email address to belgium@devopsdays.org

### DIFF
--- a/data/events/2024-ghent.yml
+++ b/data/events/2024-ghent.yml
@@ -95,7 +95,7 @@ team_members: # Name is the only required field for team members.
     twitter: "TrilandsBV"
     github: "MonaShivdasani"
 
-organizer_email: "ghent@devopsdays.org" # Put your organizer email address here
+organizer_email: "belgium@devopsdays.org" # Put your organizer email address here
 
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.


### PR DESCRIPTION
Changing the email address to belgium@devopsdays.org