### PR TITLE
Fix event map shortcode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -54,3 +54,4 @@ enableEmoji = true
   Twitter = "http://www.twitter.com/devopsdays"
   Linkedin = "http://www.linkedin.com/groups?home=&gid=2445279"
   Groups = "http://groups.google.com/group/devopsdays"
+  GoogleMapsAPI = "AIzaSyA1WhgJirbPSYxMCWRD14IP90A4yLY4vxE"

--- a/themes/devopsdays-theme/layouts/shortcodes/event_map.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/event_map.html
@@ -3,7 +3,20 @@
 {{- $lat := index $coords 0 -}}
 {{- $lng := index $coords 1 -}}
 
+{{- with $e.location_address -}}
+<iframe
+  width="450"
+  height="250"
+  frameborder="0" style="border:0"
+  referrerpolicy="no-referrer-when-downgrade"
+  src='https://www.google.com/maps/embed/v1/place?key={{ $.Site.Params.GoogleMapsAPI }}&q={{ replace $e.location_address " " "+"}}' allowfullscreen>
+</iframe>
+{{- end -}}
+
+
+<!--
 <div id="map_canvas" style="width: 550px; height: 265px"></div>
+
 
 <script type="text/javascript" language="javascript">
   function initMap() {
@@ -29,3 +42,4 @@
 </script>
 
 <script type="text/javascript" src="https://maps-api-ssl.google.com/maps/api/js?key=AIzaSyC1bvNK9qFJGEhoWNbQuojmJJ1Tg0DoOew"></script>
+-->

--- a/themes/devopsdays-theme/layouts/shortcodes/event_map.html
+++ b/themes/devopsdays-theme/layouts/shortcodes/event_map.html
@@ -12,34 +12,3 @@
   src='https://www.google.com/maps/embed/v1/place?key={{ $.Site.Params.GoogleMapsAPI }}&q={{ replace $e.location_address " " "+"}}' allowfullscreen>
 </iframe>
 {{- end -}}
-
-
-<!--
-<div id="map_canvas" style="width: 550px; height: 265px"></div>
-
-
-<script type="text/javascript" language="javascript">
-  function initMap() {
-    var mapDiv = document.getElementById("map_canvas");
-    var position = new google.maps.LatLng({{ $lat }}, {{ $lng }});
-
-    var map = new google.maps.Map(mapDiv, {
-      center: position,
-      zoom: 14,
-      mapTypeID: google.maps.MapTypeId.ROADMAP
-    });
-
-    var marker = new google.maps.Marker({
-      position: position,
-      map: map,
-      title: "{{ $e.location }}",
-    });
-  }
-
-  window.onload = function() {
-    initMap();
-  };
-</script>
-
-<script type="text/javascript" src="https://maps-api-ssl.google.com/maps/api/js?key=AIzaSyC1bvNK9qFJGEhoWNbQuojmJJ1Tg0DoOew"></script>
--->

--- a/themes/devopsdays-theme/reference.md
+++ b/themes/devopsdays-theme/reference.md
@@ -410,3 +410,8 @@ Returns the end date of registration for your event
 ```
 {{< registration_end >}}
 ```
+### event_map
+If you have `location_address` set in your datafile, this will return a Google Map of that address
+```
+{{< event_map >}}
+```

--- a/utilities/examples/data/events/main.yml
+++ b/utilities/examples/data/events/main.yml
@@ -28,10 +28,11 @@ registration_link: "" # If you have a custom registration link, enter it here. T
 
 # Location
 #
-coordinates: "" # The coordinates of your city. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
+# coordinates: "" # No longer used
+
 location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
-location_address: "" #Optional - use the street address of your venue. This will show up on the welcome page if set.
+location_address: "" #Optional - use the street address of your venue. This will show up on the welcome page if set. Also used by the event_map shortcode!
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
  # - name: propose


### PR DESCRIPTION
This has been broken for a long time apparently...and yet it's in use :)

You can compare https://deploy-preview-13701--devopsdays-web.netlify.app/events/2024-singapore/location to https://devopsdays.org/events/2024-singapore/location to test :)

Fixes #8458
Fixes #13115