### PR TITLE
[Krakow-2024] redirect krakow splat to 2024

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -60,7 +60,7 @@
 /kansas-city/*		/events/2024-kansas-city/:splat		302
 /kazan/*		/events/2018-kazan/:splat		302
 /kiel/*			/events/2018-kiel/:splat		302
-/krakow/*		/events/2023-krakow/:splat		302
+/krakow/*		/events/2024-krakow/:splat		302
 /kiev/*			/events/2024-kyiv/:splat		302
 /kyiv/*			/events/2024-kyiv/:splat		302
 /ljubljana/*		/events/2023-ljubljana/:splat		302


### PR DESCRIPTION
The Krakow redirect still points to the 2023 event. This points it at the 2024 event.