### PR TITLE
[RDU-2024] Changed Jit from Gold to Happy Hour

### DIFF
--- a/data/events/2024/raleigh/main.yml
+++ b/data/events/2024/raleigh/main.yml
@@ -116,7 +116,7 @@ sponsors:
   - id: observeinc
     level: gold
   - id: jit
-    level: gold
+    level: happyhour
   - id: nadog
     level: community
   - id: portworx


### PR DESCRIPTION
Change Jit.io from Gold Sponsor to Happy Hour Sponsor. 