### PR TITLE
[AMS-2024] Add stackstate as Gold sponsor

### DIFF
--- a/data/events/2024/amsterdam/main.yml
+++ b/data/events/2024/amsterdam/main.yml
@@ -129,6 +129,8 @@ sponsors:
     level: gold
   - id: exoscale
     level: gold
+  - id: stackstate
+    level: gold
   # Lanyard
   # Foodtruck
   # Recharge


### PR DESCRIPTION
Stackstate is joining Amsterdam as a Gold level sponsor!