### PR TITLE
[site] add a null check for PR descriptions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,12 @@ jobs:
             echo "PR description does not have default text removed"
             exit 1
           fi
+
+          # Check to make sure the description isn't empty
+          if [[ $PR_DESCRIPTION = "null" ]]; then
+            echo "PR description is empty"
+            exit 1
+          fi
       - name: Comment on PR
         id: comment
         if: failure() && steps.prcheck.outcome == 'failure'
@@ -34,5 +40,3 @@ jobs:
           message: |
             `en_US`: Hi @${{ github.event.pull_request.user.login }}! It looks like you've left the default text in the pull request description. Please replace that text with something meaningful. Thanks!
             `pt_BR`: Olá @${{ github.event.pull_request.user.login }}! Parece que você deixou o texto predefinido na descrição da PR. Por favor, substitua esse texto por algo mais relevante. Obrigado!
-
-            


### PR DESCRIPTION
This extends the PR description check to make sure the description isn't empty.