### PR TITLE
[BER-2024] Adding JFrog as Gold sponsor

### DIFF
--- a/data/events/2024/berlin/main.yml
+++ b/data/events/2024/berlin/main.yml
@@ -105,6 +105,8 @@ sponsors:
     level: platinum
   - id: osism-tech
     level: platinum
+  - id: jfrog
+    level: gold
   - id: kubeevents
     level: partner
 


### PR DESCRIPTION
Just settled the agreement with JFrog on a Gold sponsorship for the Berlin event