### PR TITLE
[Raleigh-2024] Remove Mel Cone from Organizers

### DIFF
--- a/data/events/2024/raleigh/main.yml
+++ b/data/events/2024/raleigh/main.yml
@@ -90,11 +90,6 @@ team_members: # Name is the only required field for team members.
   - name: Felipe Fernandez
     linkedin: "https://www.linkedin.com/in/felipe-fernandes-21901b5a/"
     image: "felipe-fernandez.jpg"
-  - name: Mel Cone
-    linkedin: "https://www.linkedin.com/in/melmaliacone/"
-    image: "mel-cone.jpg"
-    github: "melmaliacone"
-    twitter: "melmaliacone"
   - name: Jason Hibbets
     linkedin: "https://www.linkedin.com/in/jasonhibbets/"
     image: "jason-hibbets.jpg"


### PR DESCRIPTION
Removed Mel's info from raleigh.yml

She resigned from our group. After this is merged, an email will be sent to remove from the distros.

Thanks!