### PR TITLE
[AMS-2024] Fly.io Food truck sponsor

### DIFF
--- a/data/events/2024/amsterdam/main.yml
+++ b/data/events/2024/amsterdam/main.yml
@@ -139,6 +139,8 @@ sponsors:
   - id: schubergphilis
     level: lanyard
   # Foodtruck
+  - id: flyio
+    level: foodtruck
   # Recharge
   # Silver
   - id: sysdig


### PR DESCRIPTION
Adds Fly.io as a food truck sponsor for Devopsdays Amsterdam.
