### PR TITLE
[BER-2024] Adds stickermule as sponsor with local URL

### DIFF
--- a/data/events/2024/berlin/main.yml
+++ b/data/events/2024/berlin/main.yml
@@ -108,6 +108,9 @@ sponsors:
     level: platinum
   - id: kubeevents
     level: partner
+  - id: stickermule
+    level: partner
+    url: https://mule.to/p68i
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Adding stickermule as partner sponsor, overriding common url for them
