### PR TITLE
[AMS-2024] add gold sponsor

### DIFF
--- a/data/events/2024/amsterdam/main.yml
+++ b/data/events/2024/amsterdam/main.yml
@@ -137,6 +137,8 @@ sponsors:
     level: gold
   - id: stackstate
     level: gold
+  - id: googlecloud
+    level: gold
   # Lanyard
   - id: schubergphilis
     level: lanyard


### PR DESCRIPTION
Adding Google Cloud as a gold sponsor.