### PR TITLE
[AMS-2024] Added speaker links and fixed year typo

### DIFF
--- a/content/events/2024-amsterdam/speakers.md
+++ b/content/events/2024-amsterdam/speakers.md
@@ -1,5 +1,5 @@
 +++
 Title = "Speakers"
 Type = "speakers"
-Description = "Speakers for devopsdays amsterdam 2023"
+Description = "Speakers for devopsdays Amsterdam 2024"
 +++

--- a/content/events/2024-amsterdam/speakers/matteo-bianchi.md
+++ b/content/events/2024-amsterdam/speakers/matteo-bianchi.md
@@ -1,8 +1,8 @@
 +++
 Title = "Matteo Bianchi"
-Linkedin = ""
-Website = ""
-Twitter = ""
+Linkedin = "https://www.linkedin.com/in/mbianchidev/"
+Website = "https://github.com/mbianchidev"
+Twitter = "https://twitter.com/mbianchidev"
 image = "matteo-bianchi.jpg"
 type = "speaker"
 linktitle = "matteo-bianchi"


### PR DESCRIPTION
Adding my links and fixing two small typos related to year and city name (capital letter)
