### PR TITLE
[AMS-2024] Add Bronze sponsor ATComputing

### DIFF
--- a/data/events/2024/amsterdam/main.yml
+++ b/data/events/2024/amsterdam/main.yml
@@ -160,6 +160,8 @@ sponsors:
   # Bronze
   - id: devleaps
     level: bronze
+  - id: atcomputing
+    level: bronze
 
 sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Adding ATComputing as Bronze level sponsor for Amsterdam