### PR TITLE
[RDU-2024]: add Clickhouse as community sponsor

### DIFF
--- a/data/events/2024/raleigh/main.yml
+++ b/data/events/2024/raleigh/main.yml
@@ -130,6 +130,8 @@ sponsors:
     level: community
   - id: learnk8s
     level: community
+  - id: clickhouse
+    level: community
   - id: cyclelabs
     level: community
   - id: guiding-eyes-for-the-blind


### PR DESCRIPTION
![5d0a613e-7ee7-48b4-993e-967f1d99c67c](https://github.com/devopsdays/devopsdays-web/assets/1649081/9a6da39f-769c-48e0-8eef-8db994ad804a)

Adds [Clickhouse](https://clickhouse.com/) as a community sponsor for RDU2024