### PR TITLE
Allow content reviewers to review common changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,3 +20,6 @@ package.json    @devopsdays/build-infra
 .gitpod.yml @devopsdays/build-infra
 /.github/workflow/ @devopsdays/build-infra
 .nvmrc  @devopsdays/build-infra
+/data/events/ @devopsdays/content-reviewers
+/data/sponsors/ @devopsdays/content-reviewers
+/content/events/ @devopsdays/content-reviewers

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -7,3 +7,5 @@
 Large files should go in https://github.com/devopsdays/devopsdays-assets/ . *If _this_ PR is related to an _assets_ PR*, please include a link to the latter.
 
 Up to date guidelines for pull requests can be found in the [contributing guide](https://github.com/devopsdays/devopsdays-web/blob/main/CONTRIBUTING.md#guidelines).
+
+If you are changing sponsor information, be sure you are [following the guidelines](https://github.com/devopsdays/devopsdays-web/blob/main/utilities/README.md#updating-a-sponsor-image-or-data).


### PR DESCRIPTION
Create a new group by which we can add people who have done this before
and know what content is OK and what needs core to approve.
