### PR TITLE
[LDN-2024] Add Elastic 🥇 and GitHub 🥉 as sponsors

### DIFF
--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -108,9 +108,13 @@ sponsors:
   # gold sponsors
   - id: cloudsmith
     level: gold
+  - id: elastic
+    level: gold
   # silver sponsors
   # bronze sponsors
   - id: commify
+    level: bronze
+  - id: github
     level: bronze
   # community sponsors
 


### PR DESCRIPTION
- We have more sponsors.
- Elastic are Gold sponsors.
- GitHub are my employer, so get a free Bronze sponsorship as a perk of letting me do conference things on work time.