### PR TITLE
[BER-2024] Add DoIt as Silver sponsor

### DIFF
--- a/data/events/2024/berlin/main.yml
+++ b/data/events/2024/berlin/main.yml
@@ -108,6 +108,8 @@ sponsors:
     level: platinum
   - id: tigera
     level: platinum
+  - id: doit
+    level: silver
   - id: kubeevents
     level: partner
   - id: stickermule


### PR DESCRIPTION
Adding DoIt as Silver sponsor for the Berlin event.