### PR TITLE
[BER-2024] Add Splunk as Platinum sponsor

### DIFF
--- a/data/events/2024/berlin/main.yml
+++ b/data/events/2024/berlin/main.yml
@@ -108,6 +108,8 @@ sponsors:
     level: platinum
   - id: tigera
     level: platinum
+  - id: splunk
+    level: platinum
   - id: doit
     level: silver
   - id: kubeevents


### PR DESCRIPTION
Adding Splunk as Sponsor for the Berlin event.
