### PR TITLE
[SITE] add logo rendering

### DIFF
--- a/themes/devopsdays-theme/reference.md
+++ b/themes/devopsdays-theme/reference.md
@@ -420,3 +420,12 @@ or
 ```
 {{< event_map width = "600" height="500" >}}
 ```
+
+### tix
+Embeds the DevOpsDays Pretix ticket and registration system
+This shortcode requires two parameters, city and year, where the city is typically the organiser city and the year the event year.
+Please note this may be differ, please check with in your Pretix for the two names.
+
+```
+{{< tix city="belgium" year="antwerp-2024" >}}
+```


### PR DESCRIPTION
Add logo rendering

- use logo.png to generate logo.webp on listing page
- use logo.png to generate logo.webp on welcome page

**This adds the asset folder for hugo rendering and requires hugo-extended**
To avoid any breakage, the old style remains supported and this adds rendering if the file exists