### PR TITLE
[SEA-2024] map and keynote updates

### DIFF
--- a/content/events/2024-seattle/location.md
+++ b/content/events/2024-seattle/location.md
@@ -4,7 +4,15 @@ Type = "event"
 Description = "Location for devopsdays seattle 2024"
 +++
 
-Seattle Convention Center | Arch at 800 Pike Building
-800 Pike St, Seattle, WA 98101
+Seattle Convention Center | Arch at 705 Pike Building
+705 Pike St, Seattle, WA 98101
 <!-- Uncomment this only if you have set the coordinates for your location in the config yaml. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html -->
 {{< event_map >}}
+
+## Conference floor
+
+We are located on the 6th for of the Seattle Convention Center Arch at 750 Building.
+After enter the building from Pike St. Take one of the Elevators, not the Office Tower elevators, or the Esclator past the fountian to the top floor.
+
+<a href="https://assets.devopsdays.org/events/2024/seattle/venue.png">
+<img src="https://assets.devopsdays.org/events/2024/seattle/venue.png" alt="SSC Level 6 map" style="width:500px;height:750px;"></a>

--- a/content/events/2024-seattle/program/nathen-harvey.md
+++ b/content/events/2024-seattle/program/nathen-harvey.md
@@ -2,7 +2,21 @@
 Talk_date = ""
 Talk_start_time = ""
 Talk_end_time = ""
-Title = "TBD"
+Title = "A Decade with DORA"
 Type = "talk"
 Speakers = ["nathen-harvey"]
 +++
+
+DORA will publish its tenth report on software delivery performance this year, marking more than a decade of research into what it takes to build and scale high-performing technology teams.
+
+Let’s take a moment to reflect on how far we’ve come, celebrate the successes of today’s DORA community, and make some predictions about the future.
+
+This session will explore some of DORA’s key findings including:
+
+Speed and stability are not tradeoffs
+A healthy culture is essential
+Improve by alleviating your team’s constraints
+Software delivery performance is good for organizational outcomes and practitioner well-being
+We will also look at some of DORA’s neighbors, including flow metrics, the SPACE framework, and the Dimensions of DevEx.
+
+Join us for success stories, cautionary tales, and advice about how to leverage DORA to help your team get better at getting better.

--- a/data/events/2024/seattle/main.yml
+++ b/data/events/2024/seattle/main.yml
@@ -96,7 +96,7 @@ sponsors:
     level: silver
 # Community
   - id: arresteddevops
-    level: community  
+    level: community
   - id: seattle-coffeeops
     level: community
   - id: seagl


### PR DESCRIPTION
- Add Nathen Harvey Talk info
- Add link to venue map in assets https://github.com/devopsdays/devopsdays-assets/pull/204
