### PR TITLE
[AMS-2024] New link for Google Cloud sponsorship

### DIFF
--- a/data/events/2024/amsterdam/main.yml
+++ b/data/events/2024/amsterdam/main.yml
@@ -139,6 +139,7 @@ sponsors:
     level: gold
   - id: googlecloud
     level: gold
+    url: https://cloud.google.com/developers/devopsdaysamsterdam?utm_source=events-with-google&utm_medium=et&utm_campaign=FY24-Q2-3P-devopsdaysams_join&utm_content=joininnovators&utm_term=-
   # Lanyard
   - id: schubergphilis
     level: lanyard


### PR DESCRIPTION
Updates the Google Cloud sponsorship link for 2024 Amsterdam event.