### PR TITLE
[SEA-2024] Updates talk description formatting

### DIFF
--- a/content/events/2024-seattle/program/nathen-harvey.md
+++ b/content/events/2024-seattle/program/nathen-harvey.md
@@ -13,10 +13,11 @@ Let’s take a moment to reflect on how far we’ve come, celebrate the successe
 
 This session will explore some of DORA’s key findings including:
 
-Speed and stability are not tradeoffs
-A healthy culture is essential
-Improve by alleviating your team’s constraints
-Software delivery performance is good for organizational outcomes and practitioner well-being
+- Speed and stability are not tradeoffs
+- A healthy culture is essential
+- Improve by alleviating your team’s constraints
+- Software delivery performance is good for organizational outcomes and practitioner well-being
+
 We will also look at some of DORA’s neighbors, including flow metrics, the SPACE framework, and the Dimensions of DevEx.
 
 Join us for success stories, cautionary tales, and advice about how to leverage DORA to help your team get better at getting better.


### PR DESCRIPTION
There are four lines that should be bullets but were being displayed as one long sentence. This change fixes that.
