### PR TITLE
[2024-LDN] Add MacStadium as 🥉 sponsor

### DIFF
--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -111,6 +111,8 @@ sponsors:
   - id: elastic
     level: gold
   # silver sponsors
+  - id: macstadium
+    level: silver
   # bronze sponsors
   - id: commify
     level: bronze


### PR DESCRIPTION
MacStadium have decided to sponsor the London event at Silver. Hurray!