### PR TITLE
[AMS-2024] update sponsorships

### DIFF
--- a/data/events/2024/amsterdam/main.yml
+++ b/data/events/2024/amsterdam/main.yml
@@ -151,7 +151,6 @@ sponsors:
   # Foodtruck
   - id: flyio
     level: foodtruck
-  # Recharge
   # Silver
   - id: sysdig
     level: silver
@@ -199,9 +198,6 @@ sponsor_levels:
   - id: foodtruck
     label: "Food Truck"
     max: 4
-  - id: recharge
-    label: "Recharge Station"
-    max: 1
   - id: silver
     label: Silver
     max: 8


### PR DESCRIPTION
Removed the recharge station sponsor option because of purchasing deadlines.