### PR TITLE
[London-2024] Add dxw and syntasso as bronze sponsors

### DIFF
--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -118,6 +118,10 @@ sponsors:
     level: bronze
   - id: github
     level: bronze
+  - id: dxw
+    level: bronze
+  - id: syntasso
+    level: bronze
   # community sponsors
 
 sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link


### PR DESCRIPTION
Update to add a couple of sponsors for London. Images exist from previous years.