### PR TITLE
[DC-2024] Add new sponsorship types

### DIFF
--- a/content/events/2024-washington-dc/sponsor.md
+++ b/content/events/2024-washington-dc/sponsor.md
@@ -20,9 +20,9 @@ We expect over 300 attendees based on venue capacity and past participation, and
 
 DevOpsDays DC does not share registration information directly with sponsors, but feel free to ask attendees for their contact details.
 
-## Kubernetes Days DC 2024 Co-Sponsorship Opportunities
+### Kubernetes Days DC 2024 Co-Sponsorship Opportunities
 
-Kubernetes Days DC (site launching March 2024) is a one-day event on Tuesday, September 23, also at the American Red Cross headquarters.
+Kubernetes Days DC (site launching March 2024) is a one-day event on Tuesday, September 24, also at the American Red Cross headquarters.
 
 Sponsor both events and:
 
@@ -96,7 +96,7 @@ KDC expects about 150 attendees for their event.
     <tr>
     <td>Available sponsorships</td>
       <td class="yes"><strong>6</strong></td>
-      <td class="yes"><strong>4</strong></td>
+      <td class="yes"><strong>3</strong></td>
       <td class="yes"><strong>6</strong></td>
   </tr>
   <tr>
@@ -207,7 +207,7 @@ Refunds: Full sponsor refunds are available until 6/1/2024. Sponsor refunds betw
 * Dedicated room and 60-minute time slot for up to 30 participants
 * Available only to Platinum-level sponsors
 
-### Happy Hour sponsorship
+### Social Hour sponsorship
 
 The American Red Cross is an alcohol-free facility. If you would like to sponsor
 (or co-sponsor) a social event at a local venue after the event Social Hour, we
@@ -216,14 +216,32 @@ are ready to help you. Please contact {{< email_organizers >}}.
 ### Closed Captioning Sponsor - Price $4,500 USD (1 spot)
 
 * Your logo by the screen where talks are transcribed
-  * 1 included ticket
-  * Event MC pitch and introduction
+* 1 included ticket
+* Event MC pitch and introduction
 
-### Lanyard Sponsor - Price $4,500 USD (1 spot)
+### ~~Lanyard Sponsor - Price $4,500 USD (1 spot)~~
 
 * Your logo and colors around every attendee's credential
-  * 1 included ticket
-  * Event MC pitch and introduction
+* 1 included ticket
+* Event MC pitch and introduction
+
+### Breakfast Sponsor - Price $2,000 USD (1 spot)
+
+* Signage with your logo by the breakfast tables during breakfast both days
+* 1 included ticket
+* Event MC pitch and introduction
+
+### Lunch Sponsor - Price $6,000 USD (1 spot)
+
+* Signage with your logo by the lunch tables during lunch both days
+* 2 included tickets
+* Event MC pitch and introduction
+
+### Break Sponsor - Price $3,000 USD (1 spot)
+
+* Signage with your logo by the break tables during morning and afternoon breaks both days
+* 1 included ticket
+* Event MC pitch and introduction
 
 ### Community Sponsorship (3 spots)
 

--- a/content/events/2024-washington-dc/welcome.md
+++ b/content/events/2024-washington-dc/welcome.md
@@ -81,6 +81,12 @@ Description = "devopsdays washington dc 2024"
   </div>
 
 <hr>
+<div>
+  <h2 class="speaker-page" style="color: #17a2b8; display: inline-block;">{{< event_link page="sponsor" text="Sponsor the conference!" >}}</h2>
+  <div style="text-align: left;">We greatly value sponsors for this open event. If you are interested in sponsoring, please drop us an email at {{< email_organizers >}}.</div>
+  <div style="text-align: left"><a href="https://bit.ly/doddc24-sponsor" style="font-size: 20px;">➡️ View Our Sponsor Prospectus ⬅️</a></div>
+</div>
+<hr>
 <h2 class="speaker-page" style="color: #17a2b8; display: inline-block;">Featured Keynote Speaker!!</h2>
 <div class="speaker-bio">
   <img class="organizer-image" src="/events/2024-washington-dc/speakers/tapabrata-pal.png" alt="Dr. Tapabrata 'Topo' Pal" class="speaker-image">

--- a/data/events/2024/washington-dc/main.yml
+++ b/data/events/2024/washington-dc/main.yml
@@ -204,7 +204,6 @@ sponsors:
     #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
 
   
-
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.
@@ -225,6 +224,18 @@ sponsor_levels:
     label: Silver
     max: 6
     #max: 0 # This is the same as omitting the max limit.
+  - id: breakfast
+    label: Breakfast
+    max: 1
+  - id: lunch
+    label: Lunch
+    max: 1
+  - id: break
+    label: Break
+    max: 1
+  - id: closedcaptioning
+    label: Closed Captioning
+    max: 1
   - id: community
     label: Community
     max: 3


### PR DESCRIPTION
- Added new sponsorship types for breakfast, lunch, and breaks
- Marked the lanyard sponsorship sold (strikethrough)
- Updated available gold sponsorships from 4 to 3
- Added call for sponsorships on Welcome page