### PR TITLE
[CHI-2025] add sponsor page

### DIFF
--- a/content/events/2025-chicago/sponsor.md
+++ b/content/events/2025-chicago/sponsor.md
@@ -1,0 +1,194 @@
++++
+Title = "Sponsor"
+Type = "event"
+Description = "Sponsor DevOpsDays Chicago 2023"
++++
+
+We greatly value sponsors for this community event. If you are interested in sponsoring, please check out our <a href="https://assets.devopsdays.org/events/2025/chicago/2025-chicago-devopsdays-prospectus.pdf" target="_blank">prospectus</a> or <a href="mailto:chicago-sponsors@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Chicago%202023">send us an email</a>.
+<hr>
+
+DevOpsDays Chicago is a self organizing conference for practitioners that depends on sponsorships. We do not have vendor booths, sell product presentations, or distribute attendee contact lists. Sponsors have the opportunity to have short elevator pitches during the program and will get recognition on the website and social media before, during and after the event. Sponsors are encouraged to represent themselves by actively participating and engaging with the attendees as peers. Any attendee also has the opportunity to demo products/projects as part of an open space session.
+<p>
+Platinum and Gold sponsors get a full table in the sponsor area where they can interact with those interested to come visit during breaks. All attendees are welcome to propose any subject they want during the open spaces, but this is a community-focused conference, so heavy marketing will probably work against you when trying to make a good impression on the attendees.
+<p>
+The best thing to do is send engineers to interact with the experts at DevOpsDays Chicago on their own terms.
+
+<h2>Sponsorship Packages</h2>
+<i>All Platinum, Gold, and Bronze sponsorships paid before September 13th receive a $1000 discount</i> 
+<p>
+<p>
+
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th scope="col">THE GOODS</th>
+      <th scope="col">PLATINUM</th>
+      <th scope="col">GOLD</th>
+      <th scope="col">BRONZE</th>
+      <th scope="col">COMMUNITY</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Price</td>
+      <td><strike>$10,000</strike> $9000</td>
+      <td><strike>$6,000</strike> $5000</td>
+      <td><strike>$2,000</strike> $1000</td>
+      <td>Free</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td colspan="3"><small>
+      Note: Paypal payments include 3% service charge.
+      <br>
+      <a href="mailto:chicago-sponsors@devopsdays.org?subject=DevOpsDays%20Chicago%202022%20Sponsorship">Email us</a> if you prefer to pay by check
+      </small></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td></td>
+      <td><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=LUSEMWLZ7MKKW"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif"></a></td>
+      <td><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=S9SCLZP3USU7L"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif"></a></td>
+      <td><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=DDXAP9S3324DC"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif"></a></td>
+      <td><a href="mailto:chicago-sponsors@devopsdays.org?subject=Interested%20in%20Community%20Sponsorship%20DevOpsDays%20Chicago%202023">Contact us</a>
+      </td>
+    </tr>
+    <tr>
+      <td>Tickets Included</td>
+      <td>6</td>
+      <td>4</td>
+      <td>2</td>
+      <td>5</td>
+    </tr>
+    <tr>
+      <td>Logo on DevOpsDays Chicago website</td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+    </tr>
+    <tr>
+      <td>Logo on marketing materials</td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Logo on slides at breaks</td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Logo on participant emails</td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Shout-out from MC's at kickoff and again at breaks</td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Dedicated logo slide during breaks</td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Logo on shared slide during breaks</td>
+      <td></td>
+      <td></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+    </tr>
+    <tr>
+      <td>Dedicated table in sponsor area (with chairs)</td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Three-minute pitch between talks (includes live-stream audience)</td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>One-minute pitch between talks (includes live-stream audience)</td>
+      <td></td>
+      <td><img src = "/events/2023-chicago/yak-head.png"></td>
+      <td></td>
+      <td><a href="mailto:chicago-sponsors@devopsdays.org?subject=Interested%20in%20Community%20Sponsorship%20DevOpsDays%20Chicago%202023">Contact us</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
+<h2>Special Sponsorships</h2>
+
+All special sponsors will have their logo displayed on the DevOpsDays Chicago website and a thank you during the conference. We do have some flexibilities with these sponsorships, so just ask! Email us: <a href="mailto:chicago-sponsors@devopsdays.org">chicago-sponsors@devopsdays.org</a>.
+<br/><br/>
+
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th scope="col">Sponsorship</th>
+      <th scope="col">Price</th>
+      <th scope="col">Description</th>
+      <th scope="col">Tickets Included</th>
+      <th scope="col">Number Available</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Live Transcription</td>
+      <td>$5,000</td>
+      <td>Your logo by the screen where talks are transcribed</td>
+      <td>2</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Lanyard</td>
+      <td>$5,000</td>
+      <td>Your name and colors around every attendee's credentials</td>
+      <td>2</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Wifi</td>
+      <td>$5,000</td>
+      <td>Customize the wi-fi hotspot name</td>
+      <td>2</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Scholarships</td>
+      <td>Varies</td>
+      <td>Provide tickets for under-indexed groups to attend</td>
+      <td>5</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<div class = "row">
+<div class = "col-12">
+  <br/>
+  <br/>
+  Sponsors are responsible for providing high-res logos for use on the website and in promotional materials.  The preferred file formats are EPS or AI.
+  <br/><br/>
+  <b>All sponsors attendees must be registered to attend</b>. We offer sponsors 20% off all additional registrations.
+<br><br>
+</div>
+</div>

--- a/content/events/2025-chicago/sponsor.md
+++ b/content/events/2025-chicago/sponsor.md
@@ -166,13 +166,6 @@ All special sponsors will have their logo displayed on the DevOpsDays Chicago we
       <td>1</td>
     </tr>
     <tr>
-      <td>Wifi</td>
-      <td>$5,000</td>
-      <td>Customize the wi-fi hotspot name</td>
-      <td>2</td>
-      <td>1</td>
-    </tr>
-    <tr>
       <td>Scholarships</td>
       <td>Varies</td>
       <td>Provide tickets for under-indexed groups to attend</td>

--- a/data/events/2025/chicago/main.yml
+++ b/data/events/2025/chicago/main.yml
@@ -35,11 +35,11 @@ location_address: "" #Optional - use the street address of your venue. This will
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
  # - name: propose
- # - name: location
+#  - name: location
  # - name: registration
  # - name: program
  # - name: speakers
- # - name: sponsor
+  - name: sponsor
   - name: contact
   - name: conduct
 # - name: example
@@ -71,7 +71,7 @@ team_members: # Name is the only required field for team members.
     linkedin: "https://linkedin.com/in/dexterihorthy"
     twitter: "dexhorthy"
     github: "dexhorthy"
-    bio: "Dex has been hacking on cloud native tech at Replicated for over 5 years now. When he's not collaborating with software teams or deploying his blog on Kubernetes, he enjoys overcomplicated dinner prep and running the Chicago lakefront."
+    bio: "Dex is the CEO and co-founder of Metalytics.  Before that, he was hacking on cloud native tech at Replicated for almost 6 years. When he's not collaborating with software teams or deploying his blog on Kubernetes, he enjoys overcomplicated dinner prep and running the Chicago lakefront."
   - name: "Albert Cheung"
     image: "albert-cheung.jpg"
     linkedin: "http://www.linkedin.com/in/albcheung"
@@ -145,19 +145,19 @@ sponsors:
   - id: arresteddevops
     level: community
 
-sponsors_accepted : "no" # Whether you want "Become a XXX Sponsor!" link
+sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.
 # You may optionally include a "max" attribute to limit the number of sponsors per level. For
 # unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
 # sponsorship for a specific level, it is best to remove the level.
 sponsor_levels:
+  - id: platinum
+    label: Platinum
+    max: 2
   - id: gold
     label: Gold
 #    max: 10
-  - id: silver
-    label: Silver
-    max: 0 # This is the same as omitting the max limit.
   - id: bronze
     label: Bronze
   - id: community


### PR DESCRIPTION
Added the sponsors page, copy from 2023, added updated paypal links

<img width="1549" alt="Screenshot 2024-05-30 at 8 04 22 AM" src="https://github.com/devopsdays/devopsdays-web/assets/3730605/7df842f6-900d-46b0-b8fa-e0132ecc368f">

I'm on the fence about this ~strikethrough~ styling to show the 1k discount but open to thoughts from the chicago organizers team.

Prospectus uploaded here https://github.com/devopsdays/devopsdays-assets/pull/207
