### PR TITLE
[CHI-2025] Chore of updating event year to 2025

### DIFF
--- a/content/events/2025-chicago/sponsor.md
+++ b/content/events/2025-chicago/sponsor.md
@@ -1,7 +1,7 @@
 +++
 Title = "Sponsor"
 Type = "event"
-Description = "Sponsor DevOpsDays Chicago 2023"
+Description = "Sponsor DevOpsDays Chicago 2025"
 +++
 
 We greatly value sponsors for this community event. If you are interested in sponsoring, please check out our <a href="https://assets.devopsdays.org/events/2025/chicago/2025-chicago-devopsdays-prospectus.pdf" target="_blank">prospectus</a> or <a href="mailto:chicago-sponsors@devopsdays.org?subject=Interested%20in%20Sponsoring%20DevOpsDays%20Chicago%202023">send us an email</a>.

--- a/content/events/2025-chicago/welcome.md
+++ b/content/events/2025-chicago/welcome.md
@@ -17,7 +17,7 @@ Description = "DevOpsDays Chicago is coming back in 2025! The group that brought
       The format of DevOpsDays Chicago includes a single track of 30 minute talks in the morning, followed by Ignite talks (5 minute lightning talks). We spend the rest of the afternoon in Open Spaces, which are considered a key portion of the event.
     </p>
     <p>
-      The organizers of DevOpsDays Chicago believe that the community is stronger when all can participate, therefore we are dedicated to making the 2024 event as accessible as possible, including captioning for the morning talks. <a href = "../location">Our venue</a> is accessible as well.  If you have any questions about any specific accommodation you may need in order to attend, please email chicago@devopsdays.org.
+      The organizers of DevOpsDays Chicago believe that the community is stronger when all can participate, therefore we are dedicated to making the 2025 event as accessible as possible, including captioning for the morning talks. <a href = "../location">Our venue</a> is accessible as well.  If you have any questions about any specific accommodation you may need in order to attend, please email chicago@devopsdays.org.
     </p>
     <div class = "row" id = "cta-row"> 
       <div class = "col-md-12">


### PR DESCRIPTION
This pull request includes updates to the event details for DevOpsDays Chicago, changing the event year from 2023/2024 to 2025 in the `sponsor.md` and `welcome.md` files. 

* [`content/events/2025-chicago/sponsor.md`](diffhunk://#diff-6611d2e6b4b2ae4ec618a42d03ad00742cf1321145aa035add8e4d1b6ce2ad79L4-R4): Updated the description to reflect the new event year, changing "Sponsor DevOpsDays Chicago 2023" to "Sponsor DevOpsDays Chicago 2025".
* [`content/events/2025-chicago/welcome.md`](diffhunk://#diff-32f78196245b96bf94b0fc0ca8af7c47e0e9110d4a058847269824e160165432L20-R20): Updated the event year in the paragraph about accessibility, changing "we are dedicated to making the 2024 event as accessible as possible" to "we are dedicated to making the 2025 event as accessible as possible".
