### PR TITLE
Make sponsor logo script compatible with new directory structure

### DIFF
--- a/utilities/change_sponsor_logo.sh
+++ b/utilities/change_sponsor_logo.sh
@@ -50,7 +50,7 @@ cp "$SPONSOR_FILE" "$OLD_SPONSOR_FILE"
 # Find all events with this sponsor in years other than this year, excluding existing renames
 SPONSOR_REGEX="id:[ ]+$SPONSOR_NAME[ $]*"
 pushd "$(gitroot)/data/events" > /dev/null
-EVENTS_TO_MODIFY=($(grep -E "$SPONSOR_REGEX" * | grep -v 'before' | grep -v "^$(date +%Y)" | cut -d ':' -f 1))
+EVENTS_TO_MODIFY=($(git ls-tree -r --name-only HEAD | xargs grep -E "$SPONSOR_REGEX" | grep -v 'before' | grep -v "^$(date +%Y)" | cut -d ':' -f 1))
 
 # Modify the events.
 for event_file in "${EVENTS_TO_MODIFY[@]}"; do


### PR DESCRIPTION
The sponsor logo script can no longer find sponsor logo usages under the `data` directory, as of #13686. Running it will produce output like:
```
grep: 2009: Is a directory
grep: 2010: Is a directory
grep: 2011: Is a directory
grep: 2012: Is a directory
grep: 2013: Is a directory
grep: 2014: Is a directory
grep: 2015: Is a directory
grep: 2016: Is a directory
grep: 2017: Is a directory
grep: 2018: Is a directory
grep: 2019: Is a directory
grep: 2020: Is a directory
grep: 2021: Is a directory
grep: 2022: Is a directory
grep: 2023: Is a directory
grep: 2024: Is a directory
grep: 2025: Is a directory
```

It is now looking for all files underneath `data/events` recursively, instead of just directly underneath it.