### PR TITLE
[DC-2024] Link to Kubernetes Community Day DC

### DIFF
--- a/content/events/2024-washington-dc/sponsor.md
+++ b/content/events/2024-washington-dc/sponsor.md
@@ -22,7 +22,7 @@ DevOpsDays DC does not share registration information directly with sponsors, bu
 
 ### Kubernetes Days DC 2024 Co-Sponsorship Opportunities
 
-Kubernetes Days DC (site launching March 2024) is a one-day event on Tuesday, September 24, also at the American Red Cross headquarters.
+[Kubernetes Days DC](https://community.cncf.io/events/details/cncf-kcd-washington-dc-presents-kcd-washington-dc-2024/) is a one-day event on Tuesday, September 24, also at the American Red Cross headquarters.
 
 Sponsor both events and:
 

--- a/content/events/2024-washington-dc/welcome.md
+++ b/content/events/2024-washington-dc/welcome.md
@@ -105,7 +105,7 @@ Description = "devopsdays washington dc 2024"
 
   <p>We'll be back at the {{< event_link page="location" text="American Red Cross Headquarters" >}} in Washington, DC. It's an amazing venue with a lot of history.</p>
 
-  We're also excited to be teaming up again with Kubernetes Community Day DC who will be hosting their [event on September 24, 2024](https://community.cncf.io/kcd-washington-dc/)! Whether you are a developer, ops pro, system engineer, or any other IT professional excited about cloud native technologies, Kubernetes Community Days DC (KCD DC) will have something for you. Supported by the Cloud Native Computing Foundation, their 2024 event will also be hosted at the historic national headquarters of the American Red Cross. This full-day conference will focus on knowledge sharing, best practices, and new developments in and around Kubernetes.
+  We're also excited to be teaming up again with [Kubernetes Community Day DC](https://community.cncf.io/events/details/cncf-kcd-washington-dc-presents-kcd-washington-dc-2024/) who will be hosting their event on September 24, 2024! Whether you are a developer, ops pro, system engineer, or any other IT professional excited about cloud native technologies, Kubernetes Community Days DC (KCD DC) will have something for you. Supported by the Cloud Native Computing Foundation, their 2024 event will also be hosted at the historic national headquarters of the American Red Cross. This full-day conference will focus on knowledge sharing, best practices, and new developments in and around Kubernetes.
 
   Follow us on [Twitter](https://twitter.com/DevOpsDaysDC) or [LinkedIn](https://www.linkedin.com/company/devopsdays-dc/) to get all the latest updates and announcements.
   <br>


### PR DESCRIPTION
* DevOpsDays DC and Kubernetes Community Day DC (KCD) team up. 
* The KCD website is now live.
* This links to the KCD site from the home and sponsor pages

Preview links:
* [home page](https://deploy-preview-14188--devopsdays-web.netlify.app/events/2024-washington-dc/welcome/)
* [sponsor page](https://deploy-preview-14188--devopsdays-web.netlify.app/events/2024-washington-dc/sponsor)
