### PR TITLE
[MSP 2024] LA 2024 had the old solarwinds logo

### DIFF
--- a/data/events/2024/los-angeles/main.yml
+++ b/data/events/2024/los-angeles/main.yml
@@ -145,7 +145,7 @@ sponsors:
     level: gold
   - id: siglens
     level: gold
-  - id: solarwinds
+  - id: solarwinds-before-20240613
     level: gold
   - id: couchbase
     level: silver


### PR DESCRIPTION
Followup to https://github.com/devopsdays/devopsdays-web/pull/14198 to ensure the old logo appears in the one place needed.