### PR TITLE
[TPA-2024] Added DNSimple as Platinum Sponsor

### DIFF
--- a/data/events/2024/tampa/main.yml
+++ b/data/events/2024/tampa/main.yml
@@ -104,6 +104,8 @@ sponsors:
     level: community
   - id: tampagai
     level: community
+  - id: dnsimple
+    level: platinum
 
  
 #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.


### PR DESCRIPTION
We are thrilled to announce that DNSimple is joining us as a valued sponsor for DevOpsDays Tampa Bay 2024! Their support and commitment to the DevOps community help make events like ours possible, fostering innovation, collaboration, and growth.

Want to be a sponsor for our event? Please visit our website: [DevOpsDays Tampa Bay 2024 Sponsorship](https://devopsdays.org/events/2024-tampa/sponsor).

Stay tuned for more updates as we gear up for an amazing DevOpsDays Tampa Bay 2024!