### PR TITLE
[CAC-2024] DevopsDays Caceres - broken sponsor link

### DIFF
--- a/data/sponsors/seventhlab.yml
+++ b/data/sponsors/seventhlab.yml
@@ -1,2 +1,2 @@
 name: "Seventhlab"
-url: "https://sevnethlab.es"
+url: "https://seventhlab.es"

--- a/static/events/2024-caceres/main.css
+++ b/static/events/2024-caceres/main.css
@@ -115,6 +115,3 @@ h3 {
 .card-block > a {
   padding: 2%;
 }
-.hard-hidden {
-  display: none !important;
-}

--- a/static/events/2024-caceres/main.js
+++ b/static/events/2024-caceres/main.js
@@ -23,17 +23,4 @@ $(document).ready(function () {
       element.style.minWidth = '200px';
     });
   }
-
-  // Prevent showing call for papers custom links before the opening date
-  const callForPapersOpen = new Date('2024-05-01');
-  const callForPaperDivs = document.querySelectorAll('.call-for-papers');
-  const callForPaperNavBar = document.querySelectorAll('ul.navbar-nav > li:first-child.nav-item.active');
-  if (new Date() < callForPapersOpen) {
-    callForPaperDivs.forEach((element) => {
-      element.classList.add('hard-hidden');
-    });
-    callForPaperNavBar.forEach((element) => {
-      element.classList.add('hard-hidden');
-    });
-  }
 });


### PR DESCRIPTION
This PR essentially fixes one sponsor link typo. It also removes some no longer used code for hiding C4P buttons before it started.
