### PR TITLE
Fix mac sed issue

### DIFF
--- a/utilities/common_code
+++ b/utilities/common_code
@@ -32,8 +32,7 @@ string_replace() {
   file=$3
 
   if [[ -w "${file}" ]] ; then
-    # sed -i'' should work for macos and linux equally.
-    sed -i'' "s/${escaped_lhs}/${escaped_rhs}/" "${file}"
+    sedcmd "s/${escaped_lhs}/${escaped_rhs}/" "${file}"
   else
     echo "WARNING: ${file} not writeable"
     return 1


### PR DESCRIPTION
When I tried to use the [add_speakers script](https://github.com/devopsdays/devopsdays-web/blob/main/utilities/add_speakers.sh) on my mac, I ran into the issue in https://github.com/devopsdays/devopsdays-web/issues/13876. This patch allows adding speakers (conference speakers, not audio devices) on a mac to work.

Fixes https://github.com/devopsdays/devopsdays-web/issues/13876