### PR TITLE
[BHM-AL-2024] Adding Fetch as Host sponsor

### DIFF
--- a/data/events/2024/birmingham-al/main.yml
+++ b/data/events/2024/birmingham-al/main.yml
@@ -88,6 +88,8 @@ sharing_image: "sharing_logo.png"
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
+  - id: fetch
+    level: host
   - id: digital-motion
     level: bronze
   - id: birmingham-area-software-enthusiasts


### PR DESCRIPTION
* Adding Fetch as a Host sponsor for the Birmingham, AL 2024 event