### PR TITLE
[HAL-2024] Add Redirection to the Speakers Page

### DIFF
--- a/content/events/2024-halifax/speakers.md
+++ b/content/events/2024-halifax/speakers.md
@@ -3,3 +3,7 @@ Title = "Speakers"
 Type = "speakers"
 Description = "Speakers for devopsdays Halifax 2024"
 +++
+
+
+<meta http-equiv="refresh" content="0; url=https://talks.devopsdays.org/devopsdays-halifax-2024/speaker/" />
+<p>If you are not redirected automatically, follow this <a href="https://talks.devopsdays.org/devopsdays-halifax-2024/speaker/">link to the new speakers page</a>.</p>


### PR DESCRIPTION
This pull request adds a redirection to the speakers page for DevOpsDays Halifax 2024. Instead of listing the dynamic content of the page, it will redirect users to a new link.

- Updated `speakers.md` to include a meta refresh tag for redirection.
- Added a fallback link for users in case automatic redirection fails.

Please review the changes and let me know if there are any suggestions or further adjustments needed. Thank you!
