### PR TITLE
[HAL-2024] Add agenda link to navigation menu

### DIFF
--- a/data/events/2024/halifax/main.yml
+++ b/data/events/2024/halifax/main.yml
@@ -37,7 +37,6 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: location
   - name: registration
   - name: agenda
-    icon:"calendar-days"
     url: "https://talks.devopsdays.org/devopsdays-halifax-2024/schedule/"
  # - name: program
   - name: speakers

--- a/data/events/2024/halifax/main.yml
+++ b/data/events/2024/halifax/main.yml
@@ -36,6 +36,9 @@ nav_elements: # List of pages you want to show up in the navigation of your page
  # - name: propose
   - name: location
   - name: registration
+  - name: agenda
+    icon:"calendar-days"
+    url: "https://talks.devopsdays.org/devopsdays-halifax-2024/schedule/"
  # - name: program
   - name: speakers
     url: "https://talks.devopsdays.org/devopsdays-halifax-2024/speaker/"

--- a/data/events/2024/halifax/main.yml
+++ b/data/events/2024/halifax/main.yml
@@ -36,7 +36,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
  # - name: propose
   - name: location
   - name: registration
-  - name: agenda
+  - name: Schedule
     url: "https://talks.devopsdays.org/devopsdays-halifax-2024/schedule/"
  # - name: program
   - name: speakers


### PR DESCRIPTION
This pull request adds a new link to the top navigation menu of the DevOpsDays Halifax 2024 event page. The new link directs users to the external event agenda page.
