### PR TITLE
[HAL-2024] Remove outdated sponsorship prospectus link

### DIFF
--- a/content/events/2024-halifax/sponsor.md
+++ b/content/events/2024-halifax/sponsor.md
@@ -13,8 +13,6 @@ Platinum and Gold sponsors get a full table in the sponsor area where they can i
 <p>
 The best thing to do is send engineers to interact with the experts at DevOpsDays Halifax on their own terms.
 
-## [Download Our Prospectus Here!](https://drive.google.com/file/d/1lOO12QTfEGpOEBWOg7oiQnVvzrfLuxSN/view?usp=sharing)
-
 <h2>Sponsorship Packages</h2>
 
 <table class="table table-bordered table-hover">


### PR DESCRIPTION
This pull request removes the outdated sponsorship prospectus link from the SPONSOR.md file for DevOpsDays Halifax 2024. 