### PR TITLE
[ANTWERP-2024] Enabling the program for Antwerpen 2024

### DIFF
--- a/data/events/2024/antwerp/main.yml
+++ b/data/events/2024/antwerp/main.yml
@@ -38,7 +38,7 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: location
   - name: registration
     icon: "sign-in"
- # - name: program
+  - name: program
   - name: speakers
   - name: sponsor
   - name: contact


### PR DESCRIPTION
This change  complements https://github.com/devopsdays/devopsdays-web/pull/14314 which publishes the program but doesn't enable it yet.



