### PR TITLE
[DOCUMENTATION] Fix typo in Hugo server command for local setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ or
 
 ```
 # Run with your local Hugo installation
-hugo server -w --baseUrl="http://localhost:1313"
+hugo server -w --baseURL="http://localhost:1313"
 ```
 
 Now open `http://localhost:1313` in a browser and navigate to the content that you're editing - voilà! Note: hugo's `watch` is not going to catch every change, so if you're making structural/file or date changes, consider Control-C and restart of the `watch` command.


### PR DESCRIPTION
This pull request addresses a typo in the documentation for setting up the local Hugo server. The `--baseUrl` parameter has been corrected to `--baseURL` to align with Hugo's required syntax. This change ensures that users following the setup instructions can successfully start the local server without encountering errors.