### PR TITLE
[SITE] add possibility to hide sponsorlevels without sponsors #14322

### DIFF
--- a/themes/devopsdays-theme/layouts/partials/sponsors.html
+++ b/themes/devopsdays-theme/layouts/partials/sponsors.html
@@ -1,9 +1,37 @@
 {{- $e := partial "functions/get-event-data" . -}}
 
+{{- $levelcount := dict "none" 0 -}}
+{{- if $e.sponsors -}}
+  {{- range $index, $level := $e.sponsor_levels -}}
+    {{- $count := 0 -}}
+    {{- range where $e.sponsors "level" $level.id -}}
+      {{- $count = add $count 1 -}}
+    {{- end -}}
+    {{- $levelcount = merge $levelcount (dict $level.id $count) -}}
+  {{- end -}}
+{{- end -}}
+
+
+
   {{- if $e.sponsor_levels -}}
     {{- range $index, $level := $e.sponsor_levels -}}
       {{- $.Scratch.Set $level.id 0 -}}
 
+        {{ $show := "yes" }}
+        {{- if (isset $e "sponsors_showempty") -}}
+          {{- if eq $e.sponsors_showempty "no" -}}
+            {{- $show = "no" -}}
+            {{- range $ln, $lc := $levelcount -}}
+              {{- if eq $level.id $ln }}
+                {{- if gt $lc 0 }}
+                  {{ $show = "yes" }}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+
+     {{- if eq $show "yes" -}}
       <div class="row cta-row">
           <!--first sponsor row-->
           <div class="col-md-12">
@@ -51,6 +79,8 @@
             {{- end -}}
           {{- end -}}
         </div>
+      {{- end -}}
+
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/themes/devopsdays-theme/reference.md
+++ b/themes/devopsdays-theme/reference.md
@@ -166,9 +166,10 @@ Each team member is an element of `sponsors`.
 | `url`      | String | No       | Will override the URL specified in the sponsor file. Useful if you have event-specific URL's for a sponsor. | http://mysponsor.com/?campaign=me |
 
 
-| Field Name          | Type   | Required | Description                                                               | Example |
-|---------------------|--------|----------|---------------------------------------------------------------------------|---------|
-| `sponsors_accepted` | String | No       | Set this to "yes" if you would like the "become a sponsor" link to appear | "yes"   |
+| Field Name           | Type   | Required | Description                                                               | Example |
+|----------------------|--------|----------|---------------------------------------------------------------------------|---------|
+| `sponsors_accepted`  | String | No       | Set this to "yes" if you would like the "become a sponsor" link to appear | "yes"   |
+| `sponsors_showempty` | String | No       | Set this to "no" to hide the sponsor levels without a sponsor             | "no"    |
 
 #### Sponsor Levels
 


### PR DESCRIPTION
The possiblitiy to add ```sponsors_showempty``` to the data yaml file
This options hides the sponsor levels with no sponsors
See #14322  for more details