### PR TITLE
[HAL-2024] Add SUSE as a Gold Sponsor

### DIFF
--- a/data/events/2024/halifax/main.yml
+++ b/data/events/2024/halifax/main.yml
@@ -91,6 +91,8 @@ organizer_email: "halifax@devopsdays.org" # Put your organizer email address her
 sponsors:
   - id: dns
     level: gold
+  - id: suse
+    level: gold
  #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
   - id: arresteddevops
     level: community


### PR DESCRIPTION
This PR adds SUSE as a gold sponsor for the DevOpsDays Halifax 2024 event.