### PR TITLE
Add sponsors to program page template 

### DIFF
--- a/themes/devopsdays-theme/layouts/program/single.html
+++ b/themes/devopsdays-theme/layouts/program/single.html
@@ -222,5 +222,5 @@
 </div>
 </div>
 {{- end -}}
-
+{{ partial "sponsors.html" . }}
 {{ end }}


### PR DESCRIPTION
Fixes #14359 

Sponsors have been left off the program page template as an oversight. This brings the program template in line with every other event page template. 