### PR TITLE
[BOS-2024] Health and safety statement

### DIFF
--- a/content/events/2024-boston/health-and-safety.md
+++ b/content/events/2024-boston/health-and-safety.md
@@ -1,0 +1,19 @@
++++
+Title = "Health and Safety"
+Type = "event"
+Description = "Health and safety information for devopsdays Boston 2024"
++++
+
+DevOpsDays Boston is excited to welcome attendees back in 2024! Unlike 2022 and 2023's events, we will not require proof of vaccination, a recent negative COVID test, or mask wearing, to attend the conference in 2024.
+
+That said, we strongly encourage you to stay home and not try to attend if either of the following are true - in line with the [CDC's Respiratory Virus Guidance](https://www.cdc.gov/respiratory-viruses/guidance/respiratory-virus-guidance.html):
+1. You are feeling sick on either day of the event.
+2. You had a known respiratory infection within five days of the conference, and are still taking medication (fever reducers, antibiotics / antivirals, etc.) to manage the symptoms.
+
+If in doubt, consider wearing a mask. We'll additionally have a small supply of complementary masks available for those who would like one.
+
+In the event that you are not able to attend, please contact us for a full refund for both days, or a partial refund for either/or day.
+
+DevOpsDays Boston may be required to change this policy prior to the conference to align with updated guidance. Updates to this guidance will be e-mailed to all registered attendees. If you are unable to attend or choose not to attend due to a change to this policy, we'd be more than happy to refund your full purchase price.
+
+We're looking forward to seeing you in October!

--- a/data/events/2024/boston/main.yml
+++ b/data/events/2024/boston/main.yml
@@ -42,6 +42,8 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: contact
   - name: location
   - name: sponsor
+  - name: "Health and Safety"
+    url: "/events/2024-boston/health-and-safety"
 
 # These are the same people you have on the mailing list and Slack channel.
 team_members:


### PR DESCRIPTION
Add a health and safety statement for Boston 2024.

I used an awkward workaround to get the title of this page to render as "Health and Safety", rather than "Health-and-Safety". Let me know if there's a better way to do this.