### PR TITLE
[LONDON-2024] Add CAST and Honeycomb as sponsors; alphabetize

### DIFF
--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -109,13 +109,17 @@ organizer_email: "london@devopsdays.org" # Put your organizer email address here
 sponsors:
   # platinum sponsors
   # gold sponsors
-  - id: cloudsmith
+  - id: castai
     level: gold
-  - id: elastic
+  - id: cloudsmith
     level: gold
   - id: contrast_security
     level: gold
+  - id: elastic
+    level: gold
   # silver sponsors
+  - id: honeycomb
+    level: silver
   - id: macstadium
     level: silver
   # bronze sponsors


### PR DESCRIPTION
Probably useful to review this discarding whitespace (`?w=1`) because I added the sponsors in alphabetical order.