### PR TITLE
[MSP-2024] Add improving-confluent as a sponsor and close sponsorship

### DIFF
--- a/data/events/2024/minneapolis/main.yml
+++ b/data/events/2024/minneapolis/main.yml
@@ -131,7 +131,7 @@ sponsors:
   - id: improving-confluent
     level: gold
 
-sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
+sponsors_accepted : "no" # Whether you want "Become a XXX Sponsor!" link
 
 # In this section, list the level of sponsorships and the label to use.
 # You may optionally include a "max" attribute to limit the number of sponsors per level. For

--- a/data/events/2024/minneapolis/main.yml
+++ b/data/events/2024/minneapolis/main.yml
@@ -128,6 +128,8 @@ sponsors:
     level: silver
   - id: cirrusnorth
     level: alacarte
+  - id: improving-confluent
+    level: gold
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
Sponsorships are now closed with the event around the corner. 
Improving/Confluent should be the last one :+1: 