### PR TITLE
[HAL-2024] Add Preconference Workshop Page

### DIFF
--- a/content/events/2024-halifax/welcome.md
+++ b/content/events/2024-halifax/welcome.md
@@ -93,6 +93,7 @@ Description = "DevOpsDays Halifax 2024"
     <a href="https://talks.devopsdays.org/devopsdays-halifax-2024/schedule/"><button>Event Schedule</button></a>
     <a href="../location/"><button>Get Venue Info</button></a>
     <a href="https://talks.devopsdays.org/devopsdays-halifax-2024/speaker/"><button>Check Out Our Speakers</button></a>
+    <a href="../workshop/"><button>Preconference Workshop</button></a> 
     <a href="../sponsor/"><button>Become a Sponsor</button></a>
     <a href="../contact/"><button>Contact Us</button></a>
   </div>

--- a/content/events/2024-halifax/workshop.md
+++ b/content/events/2024-halifax/workshop.md
@@ -4,7 +4,7 @@ Type = "workshop"
 Description = "Join the hands-on Cloud Workshop hosted by GDG Halifax and learn Generative AI on Google Cloud."
 +++
 
-## Preconference Workshop - Explore Generative AI with the Vertex AI Gemini API
+## Explore Generative AI with the Vertex AI Gemini API
 
 <img src="https://res.cloudinary.com/startup-grind/image/upload/c_scale,w_2560/c_crop,h_640,w_2560,y_0.38_mul_h_sub_0.38_mul_640/c_crop,h_640,w_2560/c_fill,dpr_2.0,f_auto,g_center,q_auto:good/v1/gcs/platform-data-goog/event_banners/Copy%20of%20Horizontal%20Lockup%20-%20Color_MmVOLmC.jpeg" alt="Workshop Logo" style="width:100%; max-width:600px; margin: 0 auto; display: block;">
 

--- a/content/events/2024-halifax/workshop.md
+++ b/content/events/2024-halifax/workshop.md
@@ -1,0 +1,25 @@
++++
+Title = "Preconference Workshop - DevOpsDays Halifax 2024"
+Type = "workshop"
+Description = "Join the hands-on Cloud Workshop hosted by GDG Halifax and learn Generative AI on Google Cloud."
++++
+
+## Preconference Workshop - Explore Generative AI with the Vertex AI Gemini API
+
+<img src="https://res.cloudinary.com/startup-grind/image/upload/c_scale,w_2560/c_crop,h_640,w_2560,y_0.38_mul_h_sub_0.38_mul_640/c_crop,h_640,w_2560/c_fill,dpr_2.0,f_auto,g_center,q_auto:good/v1/gcs/platform-data-goog/event_banners/Copy%20of%20Horizontal%20Lockup%20-%20Color_MmVOLmC.jpeg" alt="Workshop Logo" style="width:100%; max-width:600px; margin: 0 auto; display: block;">
+
+Join us for a hands-on Cloud Workshop hosted by Google Developers Group (GDG) Halifax as part of DevOpsDays Halifax 2024. This exclusive workshop focuses on Generative AI technologies on Google Cloud, providing participants with practical skills and a unique learning experience.
+
+### What You'll Learn:
+- **Text Generation:** Enhance content creation with advanced text generation techniques.
+- **Image and Video Analysis:** Utilize cutting-edge tools for analyzing and generating multimedia content.
+- **Function Calling with Gemini API:** Apply advanced function calling techniques to your AI projects.
+
+Upon completion, participants will receive a skill badge from Google Cloud, showcasing their proficiency in using the Vertex AI Gemini API. This digital badge is a testament to your skills and can be shared with your network to boost your cloud career.
+
+### How to Attend:
+This workshop is complimentary for registered attendees of DevOpsDays Halifax 2024. Once you register for the conference, you will receive a special invitation link to register for the workshop. Space is limited, so we encourage early registration to secure your spot.
+
+Don't miss this opportunity to gain hands-on experience and expand your AI capabilities!
+
+{{< event_twitter >}}

--- a/data/events/2024/halifax/main.yml
+++ b/data/events/2024/halifax/main.yml
@@ -34,6 +34,7 @@ location_address: "6135 University Ave, Halifax, NS B3H 4P9, Canada" #Optional -
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
  # - name: propose
+  - name: workshop
   - name: location
   - name: registration
   - name: Schedule


### PR DESCRIPTION
This PR introduces a new page for the Preconference Workshop at DevOpsDays Halifax 2024.
Changes include:
- Added `workshop.md` under `content/events/2024-halifax/` detailing the workshop.
- Updated `data/events/2024/halifax/main.yml` to include the workshop page in the navigation.
- Add button for Preconference Workshop to welcome page