### PR TITLE
[CHATTANOOGA-2024] Update sponsors and CFP

### DIFF
--- a/content/events/2024-chattanooga/sponsor.md
+++ b/content/events/2024-chattanooga/sponsor.md
@@ -4,7 +4,7 @@ Type = "event"
 Description = "Sponsor devopsdays Chattanooga 2024"
 +++
 
-We greatly value sponsors for this open event. If you are interested in sponsoring, see our <a href="https://www.canva.com/design/DAGJEfff434/naOfOEopxUPZvaHtJWg89g/edit?utm_content=DAGJEfff434&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton">prospectus</a> for sponsorship levels and details. To lock in your sponsorship or if you have additional questions, please email us at [{{< email_organizers >}}].
+We greatly value sponsors for this open event. If you are interested in sponsoring, see our <a href="https://www.canva.com/design/DAGJEfff434/ibQY8USDKtwKoD_2fdvL-A/view?utm_content=DAGJEfff434&utm_campaign=designshare&utm_medium=link&utm_source=editor">prospectus</a> for sponsorship levels and details. To lock in your sponsorship or if you have additional questions, please email us at [{{< email_organizers >}}].
 
 <hr>
 

--- a/data/events/2024/chattanooga/main.yml
+++ b/data/events/2024/chattanooga/main.yml
@@ -15,7 +15,7 @@ enddate: 2024-11-15T23:59:59-05:00 # The end date of your event. Leave blank if 
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2024-06-28 # start accepting talk proposals.
-cfp_date_end: 2024-08-01 # close your call for proposals.
+cfp_date_end: 2024-08-07 # close your call for proposals.
 cfp_date_announce: 2024-08-15 # inform proposers of status
 
 cfp_link: "https://sessionize.com/chattanooga-devopsdays-2024/" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.


### PR DESCRIPTION
- Use canva view link instead of edit link for sponsors.
- Bump CFP close out by one week.