### PR TITLE
[DFW-2024] added sponsors: datadog gold and capitalone silver

### DIFF
--- a/data/events/2024/dallas/main.yml
+++ b/data/events/2024/dallas/main.yml
@@ -186,7 +186,11 @@ sponsors:
     level: gold
   - id: rackn
     level: gold
+  - id: datadog
+    level: gold
   - id: bmc
+    level: silver
+  - id: capitalone
     level: silver
   # - id: devopslive
   #   level: community


### PR DESCRIPTION
Added the following sponsors:

- Datadog - Gold
- Capital One - Silver