### PR TITLE
ci: Ensure sponsors are alphabetical (at the same tier)

### DIFF
--- a/.github/workflows/alphabetical-sponsors.yml
+++ b/.github/workflows/alphabetical-sponsors.yml
@@ -1,0 +1,61 @@
+name: Check Sponsors are Alphabetical
+
+on:
+  pull_request:
+    paths:
+      - 'data/events/*.yml'
+jobs:
+  check-sorting:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install yq
+      run: sudo apt-get install -y yq
+
+    - name: Check if sponsors are sorted
+      run: |
+        #!/bin/bash
+
+        for file in $(git diff --name-only | grep -E 'data/events/*/.*\.yml'); do
+          sponsors=$(yq '.sponsors' $file)
+
+          platinum=$(echo $sponsors | yq '.[] | select(.level == "platinum")')
+          gold=$(echo $sponsors | yq '.[] | select(.level == "gold")')
+          silver=$(echo $sponsors | yq '.[] | select(.level == "silver")')
+          bronze=$(echo $sponsors | yq '.[] | select(.level == "bronze")')
+          community=$(echo $sponsors | yq '.[] | select(.level == "community")')
+
+          platinum_sorted=$(echo $platinum | jq 'sort_by(.id)' 2>/dev/null)
+          gold_sorted=$(echo $gold | jq 'sort_by(.id)' 2>/dev/null)
+          silver_sorted=$(echo $silver | jq 'sort_by(.id)' 2>/dev/null)
+          bronze_sorted=$(echo $bronze | jq 'sort_by(.id)' 2>/dev/null)
+          community_sorted=$(echo $community | jq 'sort_by(.id)' 2>/dev/null)
+
+          if [ "$platinum" != "$platinum_sorted" ]; then
+            echo "Platinum sponsors in $file are not sorted alphabetically by ID."
+            exit 1
+          fi
+
+          if [ "$gold" != "$gold_sorted" ]; then
+            echo "Gold sponsors in $file are not sorted alphabetically by ID."
+            exit 1
+          fi
+
+          if [ "$silver" != "$silver_sorted" ]; then
+            echo "Silver sponsors in $file are not sorted alphabetically by ID."
+            exit 1
+          fi
+
+          if [ "$bronze" != "$bronze_sorted" ]; then
+            echo "Bronze sponsors in $file are not sorted alphabetically by ID."
+            exit 1
+          fi
+
+          if [ "$community" != "$community_sorted" ]; then
+            echo "Community sponsors in $file are not sorted alphabetically by ID."
+            exit 1
+          fi
+        done

--- a/.github/workflows/alphabetical-sponsors.yml
+++ b/.github/workflows/alphabetical-sponsors.yml
@@ -3,7 +3,7 @@ name: Check Sponsors are Alphabetical
 on:
   pull_request:
     paths:
-      - 'data/events/*.yml'
+      - 'data/events/*/*.yml'
 jobs:
   check-sorting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- I got bored of manually fixing the 2024 London sponsors data when I noticed it was non-alphabetical and had already been on the website for a bit with the logos not in order ([one](https://github.com/devopsdays/devopsdays-web/pull/14372), [two](https://github.com/devopsdays/devopsdays-web/pull/14434)).
- So here's a minimum viable CI check that runs whenever someone edits an event YAML file.
- It checks that the sponsors are sorted alphabetically by ID at each tier.

Example (events/2024/test/main.yml):

```yaml
sponsors:
  - id: Elephant
    level: platinum
  - id: Aardvark
    level: gold
  - id: Zebra
    level: gold
  - id: Fish
    level: gold
  - id: Cat
    level: silver
  - id: Dog
    level: silver
```

would output:

```text
Gold sponsors in events/2024/test/main.yml are not sorted alphabetically by ID.
```

and so the user would change the "gold" sponsors ordering to the following, to fix the error:

```yaml
  - id: Aardvark
    level: gold
  - id: Fish
    level: gold
  - id: Zebra
    level: gold
```

I considered fixing the ordering in-place and pushing a commit to the user's PR, but fork PRs don't have a lot of permissions and I'm too tired to think about it seriously on top of organizing an actual conference, so that can maybe be a stretch goal for later.