### PR TITLE
[LDN-2024] Ignites are still "talk" types

### DIFF
--- a/content/events/2024-london/program/hannah-foxwell.md
+++ b/content/events/2024-london/program/hannah-foxwell.md
@@ -3,7 +3,7 @@ Talk_date = ""
 Talk_start_time = ""
 Talk_end_time = ""
 Title = "The Next Transformation?"
-Type = "ignite"
+Type = "talk"
 Speakers = ["hannah-foxwell"]
 +++
 


### PR DESCRIPTION
- I got this wrong in #14480, whoops, I thought an ignite was a thing by itself but nope, it's still a "talk". I hope this will make the speaker info and the talk abstract link together, because right now Hannah's photo and bio don't show up?