### PR TITLE
[SITE] - Update Open Spaces Wording

### DIFF
--- a/content/page/open-space-format.md
+++ b/content/page/open-space-format.md
@@ -38,7 +38,7 @@ Since the meeting is supposed to be self-organizing, the conveners put their ene
 <strong>Opening</strong>:
 <ol>
 	<li>Show the timeline, how the event breaks down into Opening, Marketplace of ideas, Break-out sessions, Closing.</li>
-	<li>Sponsor  introduces the theme. Briefly. One or two minutes max. Long openings  drain the energy of the meeting quickly. Get participants to work ASAP.</li>
+	<li>The person who proposed the open space introduces the theme. Briefly. One or two minutes max. Long openings drain the energy of the meeting quickly. Get participants participating and discussing ASAP.</li>
 	<li>Facilitators introduce the principles and the format. Explain how the marketplace of ideas works.</li>
 </ol>
 Dan Maher has a <a href="https://github.com/phrawzty/open_spaces.deckset">slidedeck to help explain how the open spaces work.</a>


### PR DESCRIPTION
From an issue @themightymuppet raised in Slack (see #general channel).

The word "Sponsor" here is confusing and was intended to mean the person facilitating or originating the open space.
I've also changed the "to work" to clarify what's expected of participants.
