### PR TITLE
[LDN-2024] Adjusting Evening avent wording

### DIFF
--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -278,7 +278,7 @@ program:
     start_time: "17:10"
     end_time: "18:10"
 
-  - title: "Evening event to be announced"
+  - title: "Evening event at local venue, announced during Keynote"
     type: custom
     date: 2024-09-26T00:00:00+01:00
     start_time: "18:30"


### PR DESCRIPTION
We wanted to update the wording as it could be interpretated that we're still to announce/arrange one - when we infact do, but will be announcing during keynotes
