### PR TITLE
[LDN-2024] Add john willis to speakers/program

### DIFF
--- a/content/events/2024-london/program/john-willis.md
+++ b/content/events/2024-london/program/john-willis.md
@@ -1,0 +1,10 @@
++++
+Talk_date = ""
+Talk_start_time = ""
+Talk_end_time = ""
+Title = "Deming to DevOps (Revisited 2024)"
+Type = "talk"
+Speakers = ["john-willis"]
++++
+
+Dr. W. Edwards Deming, a pioneer in quality management and continuous improvement, introduced the System of Profound Knowledge, which revolutionized manufacturing and management practices in the 20th century. This presentation revisits Deming's influential work and examines its relevance from the past to the present and into the future. We explore how Deming's principles of systems thinking, variation, knowledge theory, and psychology continue to shape modern methodologies, particularly DevOps. As we look toward 2024 and beyond, we will discuss how Deming's ideas can be further integrated with emerging technologies, such as Generative AI, to drive innovation, foster collaboration, and achieve organizational excellence in an increasingly complex world.

--- a/content/events/2024-london/speakers/john-willis.md
+++ b/content/events/2024-london/speakers/john-willis.md
@@ -1,0 +1,11 @@
++++
+Title = "John Willis"
+LinkedIn = ""
+pronouns = ""
+image = ""
+type = "speaker"
+linktitle = "john-willis"
+
++++
+
+John Willis has worked in IT management for almost 45 years and is a prolific author, including "Deming's Journey to Profound Knowledge" and "The DevOps Handbook." He is researching DevOps, DevSecOps, IT risk, modern governance, audit compliance, and the history of Generative AI. Previously, he was an Evangelist at Docker Inc., VP of Solutions for Socketplane (sold to Docker) and Enstratius (sold to Dell), and a VP at Ch. Willis also founded Gulf Breeze Software, an award-winning IBM business partner specializing in deploying Tivoli technology to the enterprise. Willis has authored six IBM Redbooks for IBM on enterprise systems management and was the founder and chief architect at Chain Bridge Systems.

--- a/content/events/2024-london/speakers/john-willis.md
+++ b/content/events/2024-london/speakers/john-willis.md
@@ -1,7 +1,7 @@
 +++
 Title = "John Willis"
-LinkedIn = ""
-pronouns = ""
+LinkedIn = "https://www.linkedin.com/in/johnwillisatlanta"
+pronouns = "he/him"
 image = ""
 type = "speaker"
 linktitle = "john-willis"

--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -402,3 +402,6 @@ ignites:
     date: 2024-09-27T23:59:59+01:00
   - title: "anais-urlichs"
     date: 2024-09-27T23:59:59+01:00
+  - title: "john-willis"
+    date: 2024-09-27T23:59:59+01:00
+


### PR DESCRIPTION
Add John Willis as speaker to 2024 London's program and speaker page. Added to ignite last slot second day.

We don't currently have an image yet for this speaker.