### PR TITLE
[DEN-2024] Update livestream link to 2024

### DIFF
--- a/content/events/2024-denver/welcome.md
+++ b/content/events/2024-denver/welcome.md
@@ -91,7 +91,7 @@ Description = "devopsdays Denver 2024"
     <strong>📺 Livestream: </strong>
   </div>
   <div class="col-md-4">
-    <a href="https://www.youtube.com/watch?v=TPzrdHNsvGE">Youtube</a>
+    <a href="https://www.youtube.com/watch?v=uV8KLBwLy5c">Youtube</a>
   </div>
 </div>
 


### PR DESCRIPTION
The livestream link on the welcome page is currently pointing at the 2023 recording. This PR updates it to the current live stream underway for 2024.
