### PR TITLE
.phlow: delete

### DIFF
--- a/.phlow
+++ b/.phlow
@@ -1,7 +1,0 @@
-[default]
-remote                 = origin
-service                = github
-integration_branch     = master
-issue_url              = https://api.github.com
-delivery_branch_prefix = ready
-


### PR DESCRIPTION
- This was added six years ago in fe6859c27b676376b65c7b449adb20e921b37cc5 with no context.
- And whatever its purpose was (someone's local development environment config?) won't work now because the branch changed to `main`.
- This doesn't seem to be used, and there are no docs about its use in this repo, so 🚮.