### PR TITLE
[LDN-2024] removing incorrect info for first day

### DIFF
--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -283,7 +283,7 @@ program:
   - title: "Drinks Reception in the Sponsor Hall"
     type: custom
     date: 2024-09-26T00:00:00+01:00
-    start_time: "17:10"
+    start_time: "17:00"
     end_time: "18:10"
 
   - title: "Evening event at local venue, announced during Keynote"

--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -280,12 +280,6 @@ program:
     start_time: "16:15"
     end_time: "17:00"
 
-  - title: "Day 1 Closing Remarks & Sponsor Raffle Giveaways"
-    type: custom
-    date: 2024-09-26T00:00:00+01:00
-    start_time: "17:00"
-    end_time: "17:10"
-
   - title: "Drinks Reception in the Sponsor Hall"
     type: custom
     date: 2024-09-26T00:00:00+01:00


### PR DESCRIPTION
Raffle's done on the second day, not the first as we've not got lego coming out of our ears.