### PR TITLE
[GYN-2024] Update sponsor URL

### DIFF
--- a/data/events/2024/goiania/main.yml
+++ b/data/events/2024/goiania/main.yml
@@ -118,6 +118,7 @@ sponsors:
     level: gold
   - id: saveincloud
     level: gold
+    url: https://saveincloud.com/pt/solucoes-cloud/cloud-containers/cloud-kubernetes/
   - id: aws-user-group-goiania
     level: community
   - id: devopsgo


### PR DESCRIPTION
Update `SaveInCloud` URL only for Goiânia's event
