### PR TITLE
[BOS-2024] Remove open space sponsorship

### DIFF
--- a/content/events/2024-boston/sponsor.md
+++ b/content/events/2024-boston/sponsor.md
@@ -184,15 +184,6 @@ Sponsorship Packages
 </td>
 </tr>
 <tr>
-<th scope="row">Open Spaces</th>
-<td>
-<center>1</center>
-</td>
-<td>
-<center>$2,000</center>
-</td>
-</tr>
-<tr>
 <th scope="row">Snacks</th>
 <td>
 <center>4</center>


### PR DESCRIPTION
We decided that adding an open space sponsorship was a terrible idea, and are removing it from the menu of sponsorship options now that people are asking about it.