### PR TITLE
[BOS-2024] Change Oodle's sponsorship level

### DIFF
--- a/data/events/2024/boston/main.yml
+++ b/data/events/2024/boston/main.yml
@@ -102,7 +102,7 @@ sponsors:
   - id: observe
     level: platinum
   - id: oodleai
-    level: platinum
+    level: startupalley
   - id: scaleops
     level: platinum
   - id: observe


### PR DESCRIPTION
Oodle coming in at Startup Alley instead of Platinum.