### PR TITLE
[BOS-2024] Schedule updates

### DIFF
--- a/data/events/2024/boston/main.yml
+++ b/data/events/2024/boston/main.yml
@@ -146,8 +146,8 @@ program:
     date: 2024-10-21
     start_time: "9:15"
     end_time: "9:30"
-  - title: "Coming soon!"
-    type: custom
+  - title: "sara-gerion"
+    type: talk
     date: 2024-10-21
     start_time: "9:30"
     end_time: "10:00"
@@ -233,12 +233,12 @@ program:
     date: 2024-10-22
     start_time: "9:15"
     end_time: "9:30"
-  - title: "sara-gerion"
+  - title: "sanjita-gupta"
     type: talk
     date: 2024-10-22
     start_time: "9:30"
     end_time: "10:00"
-  - title: "sanjita-gupta"
+  - title: "kanish-sharma"
     type: talk
     date: 2024-10-22
     start_time: "10:05"
@@ -263,8 +263,8 @@ program:
     date: 2024-10-22
     start_time: "12:00"
     end_time: "13:30"
-  - title: "kanish-sharma"
-    type: talk
+  - title: "Lightning Talks"
+    type: custom
     date: 2024-10-22
     start_time: "13:30"
     end_time: "14:00"


### PR DESCRIPTION
Day two keynote speaker has been moved up to day one; day two schedule has been reorganized to include lightning talks in the missing slot.