### PR TITLE
[ATX-2025] Open registration, fix proposal link

### DIFF
--- a/content/events/2025-austin/welcome.md
+++ b/content/events/2025-austin/welcome.md
@@ -29,14 +29,14 @@ Description = "devopsdays Austin 2025"
             {{< event_location >}}
           </div>
         </div>
-<!--        <div class = "row">
+        <div class = "row">
           <div class = "col-md-2">
             <strong>Register</strong>
           </div>
           <div class = "col-md-8">
             <a href="https://tickets.devopsdays.org/devopsdays-austin/2025/">Register to attend the conference!</a>
           </div>
-        </div> -->
+        </div>
         <div class = "row">
           <div class = "col-md-2">
             <strong>Propose</strong>

--- a/data/events/2025/austin/main.yml
+++ b/data/events/2025/austin/main.yml
@@ -21,7 +21,7 @@ cfp_date_announce: 2025-03-15T00:00:00-05:00 # inform proposers of status
 
 cfp_link: "https://talks.devopsdays.org/devopsdays-austin-2025/cfp" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
-registration_date_start: 2024-10-20T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
+registration_date_start: 2024-10-22T00:00:00-05:00 # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
 registration_date_end: 2025-04-30T11:59:59-05:00 # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.
 
 registration_closed: "" #set this to true if you need to manually close registration before your registration end date
@@ -36,9 +36,10 @@ location: "TCEA Conference Center" # Defaults to city, but you can make it the v
 location_address: "3100 Alvin Devane Blvd Building B, Austin, TX 78741" #Optional - use the street address of your venue. This will show up on the welcome page if set. Also used by the event_map shortcode!
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
- # - name: propose
+  - name: propose
   - name: location
- # - name: register
+  - name: register
+    url: https://tickets.devopsdays.org/devopsdays-austin/2025/
  # - name: program
  # - name: speakers
   - name: sponsor


### PR DESCRIPTION
Adds the registration link to the site and turns on the proposal link in the top nav
