### PR TITLE
[ATX-2025] Adds prospectus and final sponsor tier updates

### DIFF
--- a/content/events/2025-austin/sponsor.md
+++ b/content/events/2025-austin/sponsor.md
@@ -4,8 +4,24 @@ Type = "event"
 Description = "Sponsor DevOpsDays Austin 2025"
 +++
 
-We greatly value sponsors for this event. If you are interested in sponsoring, please drop us an email at [{{< email_organizers >}}].
+DevOpsDays Austin is now in its THIRTEENTH year, consistently one of the best attended and reviewed DevOpsDays events on the planet. Sponsor the conference and connect with leaders in the most vibrant tech community in the region. These are the people influencing decisions about security, monitoring, operations, engineering, quality, and product development at leading companies in Central Texas and beyond.
 
-The sponsorship prospectus will be published here shortly.
+DevOpsDays Austin 2025 will be held at the Texas Computer Education Association (TCEA) from May 1-2, 2025, and will accommodate a cap of 320 attendees. Our theme this year will be “The DevOps Journey”—it’s about the journey, not the destination.
+
+<a href="mailto:austin@devopsdays.org" class="btn btn-primary"><i class="fa fa-envelope fa-lg"></i>   Email us to become a sponsor</a>
+
+### Sponsor Benefits
+
+* Large audience of technical decision-makers from top companies, many of which will be previous year speakers
+* Conversations with DevOps experts
+* Branding and promotion on the DevOpsDays website and other social media
+
+### Prospectus
+
+<a href="https://assets.devopsdays.org/events/2025/austin/devopsdays-austin-2025-sponsor-prospectus.pdf" class="btn btn-primary"><i class="fa fa-folder fa-lg"></i>   View the DevOpsDays Austin 2025 Sponsor Prospectus</a>
+
+### Ready to sponsor?
+
+We can take payment directly through PayPal, or we can set up an invoice for you. To get an invoice, email us at {{< email_organizers >}}. Otherwise, use the links in the prospectus to pay directly, or feel free to email us to get links sent directly to you!
 
 <hr>

--- a/data/events/2025/austin/main.yml
+++ b/data/events/2025/austin/main.yml
@@ -158,6 +158,12 @@ sponsor_levels:
   - id: quiet
     label: Quiet Room
     max: 1
+  - id: food
+    label: Food
+    max: 6
+  - id: swag
+    label: Swag Bag (Add-On)
+    max: 20
   - id: community
     label: Local Community Groups
     max: 2


### PR DESCRIPTION
Adding a link to the prospectus, cleaning up the sponsor us page, and adding a couple of sponsor tiers.

Depends on https://github.com/devopsdays/devopsdays-assets/pull/220