### PR TITLE
[AMS-2025] Updated link to new Ams sponsorship prospectus

### DIFF
--- a/content/events/2025-amsterdam/sponsor.md
+++ b/content/events/2025-amsterdam/sponsor.md
@@ -4,7 +4,7 @@ Type = "event"
 Description = "Sponsor DevOpsDays Amsterdam 2025"
 +++
 
-We greatly value sponsors for this open event.  If you are interested in sponsoring, please <a href="https://assets.devopsdays.org/events/2025/amsterdam/DevOpsDays_Amsterdam_2025_Prospectus.pdf">take a look at our prospectus</a>, then drop us an email at [{{< email_organizers >}}].
+We greatly value sponsors for this open event.  If you are interested in sponsoring, please <a href="https://assets.devopsdays.org/events/2025/amsterdam/DevOpsDays_Amsterdam_2025_Prospectus_V2.pdf">take a look at our prospectus</a>, then drop us an email at [{{< email_organizers >}}].
 
 <hr>
 


### PR DESCRIPTION
Updating the link for the Amsterdam sponsorship prospectus to a new version. Goes with the following [PR](https://github.com/devopsdays/devopsdays-assets/pull/223) in the asstes repo.