### PR TITLE
[2025-{amsterdam,eindhoven}] Show ticket shop blurb in embeds

### DIFF
--- a/content/events/2025-amsterdam/registration.md
+++ b/content/events/2025-amsterdam/registration.md
@@ -4,4 +4,4 @@ Type = "event"
 Description = "Registration for devopsdays Amsterdam 2025"
 +++
 
-{{< tix city="amsterdam" year="2025" >}}
+{{< tix city="amsterdam" year="2025" info="show" >}}

--- a/content/events/2025-eindhoven/registration.md
+++ b/content/events/2025-eindhoven/registration.md
@@ -4,4 +4,4 @@ Type = "event"
 Description = "Registration for devopsdays Eindhoven 2025"
 +++
 
-{{< tix city="eindhoven" year="2025" >}}
+{{< tix city="eindhoven" year="2025" info="show" >}}


### PR DESCRIPTION
- For some reason #14876 merged into this non-fork branch instead of `main`... maybe something is weird given I have permissions for both and my remotes were set up wrong?
- We want these changes actually live on the website, so this PR merges from the non-fork `pretix-embed-info-ams-ehv` branch into `main`.