### PR TITLE
[2025-AMS] Remove Platinum sponsorship tier

### DIFF
--- a/data/events/2025/amsterdam/main.yml
+++ b/data/events/2025/amsterdam/main.yml
@@ -155,9 +155,6 @@ sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 # unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
 # sponsorship for a specific level, it is best to remove the level.
 sponsor_levels:
-  - id: platinum
-    label: Platinum
-    max: 1
   - id: beer
     label: Beverage
     max: 1
@@ -165,7 +162,7 @@ sponsor_levels:
     label: Coffee
     max: 1
   - id: captioning
-    label: Captioning
+    label: Accessibility
     max: 1
   - id: gold
     label: Gold


### PR DESCRIPTION
- This matches the prospectus.
- Also, to match the prospectus, rename "Captioning" to "Accessibility".
