### PR TITLE
[SITE] Two small config changes

### DIFF
--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -8,7 +8,8 @@ dataDir: data
 archetypeDir: archetypes
 disableKinds: ["taxonomy"]
 enableEmoji: true
-paginatePath: blog
+pagination:
+  path: blog
 markup:
   goldmark:
     renderer:
@@ -18,7 +19,7 @@ languages:
     disabled: false
     languageCode: en-US
     languageDirection: ltr
-    languageName: Englist
+    languageName: English
     weight: 0
 
 # menus:


### PR DESCRIPTION
1. Change to a non-deprecated format for `pagination` (current version of it breaks hugo 145)
2. Fix typo in language name (we don't use this, but might as well get it right)