### PR TITLE
[ATL-2025] Nathen no longer uses Twitter

### DIFF
--- a/content/events/2025-atlanta/speakers/nathen-harvey.md
+++ b/content/events/2025-atlanta/speakers/nathen-harvey.md
@@ -2,7 +2,6 @@
 Title = "Nathen Harvey"
 Linkedin = "https://www.linkedin.com/in/nathen/"
 Website = "https://linktr.ee/nathenharvey"
-Twitter = "nathenharvey"
 image = "nathen-harvey.png"
 type = "speaker"
 linktitle = "nathen-harvey"


### PR DESCRIPTION
Nathen no longer uses Twitter. This change removes it from his speaker bio for the 2025 DevOpsDays Atlanta event.

Preview - https://deploy-preview-15089--devopsdays-web.netlify.app/events/2025-atlanta/speakers/nathen-harvey/

There should not be a twitter link.