### PR TITLE
[ATL-2025] Add link to Nathen's slides

### DIFF
--- a/content/events/2025-atlanta/program/nathen-harvey.md
+++ b/content/events/2025-atlanta/program/nathen-harvey.md
@@ -12,3 +12,5 @@ Artificial intelligence is rapidly changing the landscape of software developmen
 Drawing on the latest findings from DORA's research, we will reveal the complex reality of AI's impact on developer experience. We'll explore both the significant advantages and the unexpected pitfalls that teams are encountering. More importantly, you'll learn actionable strategies to integrate AI effectively, avoid common pitfalls, and create a culture of continuous improvement.
 
 Join us to discover how your team can get better at getting better and unlock the true power of AI to transform your development workflow.
+
+[Slides](https://drive.google.com/file/d/1NQwsblD3XtaAdhDZCczz7-w8HCunaPQG/view?usp=sharing)


### PR DESCRIPTION
The slides from Nathen's talk are available, link to them.

Preview - https://deploy-preview-15135--devopsdays-web.netlify.app/events/2025-atlanta/program/nathen-harvey

cc: @ecology-chris 