### PR TITLE
DC-2025 - Sponsor Updates

### DIFF
--- a/data/events/2025/washington-dc/main.yml
+++ b/data/events/2025/washington-dc/main.yml
@@ -183,6 +183,10 @@ sponsors:
     level: community
   - id: googlecloud
     level: silver
+  - id: excella
+    level: lanyard
+  - id: groundcover
+    level: gold
  #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link


### PR DESCRIPTION
- add Excella as a Lanyard sponsor for 2025 DC event
- add Groundcover as a Gold sponsor for 2025 DC event