### PR TITLE
[AMS-2025] Add Google as Bronze sponsor

### DIFF
--- a/data/events/2025/amsterdam/main.yml
+++ b/data/events/2025/amsterdam/main.yml
@@ -151,6 +151,8 @@ sponsors:
     level: bronze
   - id: servicenow
     level: bronze
+  - id: google
+    level: bronze
 #   - id: samplesponsorname
 #     level: gold
 #  #  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.


### PR DESCRIPTION
Adding Google as a Bronze sponsor for the 2025 Amsterdam event.