### PR TITLE
[LIMA-2025] add menu options

### DIFF
--- a/data/events/2025/lima/main.yml
+++ b/data/events/2025/lima/main.yml
@@ -38,8 +38,10 @@ location_address: "Jr. Alonso de Molina 1652, Santiago de Surco 15023" #Optional
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: propose
   - name: location
- # - name: registration
- # - name: program
+  - name: webperu
+    url: https://devopsdays.pe/
+  - name: registration
+    url: https://devopsdays.pe/entradas
   - name: speakers
   - name: sponsor
   - name: contact


### PR DESCRIPTION
This pull request updates the navigation elements for the DevOpsDays Lima 2025 event website. It introduces new links for "WebPeru" and "Registration" while removing commented-out entries for "Registration" and "Program."

Updated navigation elements:

* [`data/events/2025/lima/main.yml`](diffhunk://#diff-419afd7be7a3132ef252b3ac5397061f53ec3ffb0f9d6a37482c9f677880a63dL41-R44): Added "WebPeru" with a link to `https://devopsdays.pe/` and "Registration" with a link to `https://devopsdays.pe/entradas`. Removed commented-out entries for "Registration" and "Program."