### PR TITLE
[AMS-2025] Add Redgate as Silver sponsor

### DIFF
--- a/data/events/2025/amsterdam/main.yml
+++ b/data/events/2025/amsterdam/main.yml
@@ -144,6 +144,8 @@ sponsors:
     level: silver
   - id: edb
     level: silver
+  - id: redgate
+    level: silver
   # Bronze
   - id: devleaps
     level: bronze


### PR DESCRIPTION
Adding Redgate as a Silver level sponsor for Amsterdam. 
