### PR TITLE
[AMS-2025] update sponsorship tiers

### DIFF
--- a/data/events/2025/amsterdam/main.yml
+++ b/data/events/2025/amsterdam/main.yml
@@ -177,18 +177,12 @@ sponsor_levels:
   - id: coffee
     label: Coffee
     max: 1
-  - id: captioning
-    label: Accessibility
-    max: 1
   - id: gold
     label: Gold
     max: 8
   - id: lanyard
     label: Lanyard
     max: 1
-  - id: foodtruck
-    label: "Food Truck"
-    max: 4
   - id: silver
     label: Silver
     max: 8


### PR DESCRIPTION
Removed food trucks and captioning sponsors as options due to deadline constraint.