### PR TITLE
[LIMA-2025] add new sponsor

### DIFF
--- a/data/events/2025/lima/main.yml
+++ b/data/events/2025/lima/main.yml
@@ -119,6 +119,9 @@ sponsors:
    - id: dynatrace
      level: gold
      url: https://www.dynatrace.com/
+   - id: fluidattacks
+     level: gold
+     url: https://www.fluidattacks.com/
    - id: devopsinstitute
      level: community
      url: https://www.devopsinstitute.com/


### PR DESCRIPTION
This pull request updates the list of sponsors for the Lima 2025 event by adding a new gold-level sponsor.

Event sponsors update:

* [`data/events/2025/lima/main.yml`](diffhunk://#diff-419afd7be7a3132ef252b3ac5397061f53ec3ffb0f9d6a37482c9f677880a63dR122-R124): Added `fluidattacks` as a gold-level sponsor with the URL `https://www.fluidattacks.com/`.