### PR TITLE
[ARG-2025] Add DevOpsDays Buenos Aires 2026 event structure

### DIFF
--- a/content/events/2026-buenosaires/conduct.md
+++ b/content/events/2026-buenosaires/conduct.md
@@ -1,0 +1,29 @@
++++
+Title = "Conduct"
+Type = "event"
+Description = "Code of conduct for DevOpsDays Buenos Aires 2026"
++++
+
+All attendees, speakers, sponsors, and volunteers at DevOpsDays Buenos Aires 2026 are required to agree with the following code of conduct. Organizers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensure a safe environment for everybody.
+
+### The Quick Version
+
+Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter, and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers.
+
+### The Less Quick Version
+
+Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+
+If a participant engages in harassing behavior, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately.
+
+Conference staff can be identified by distinct staff badges. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+We expect participants to follow these rules at conference and workshop venues and conference-related social events.
+
+_The DevOpsDays Buenos Aires 2026 Code of Conduct is based on [confcodeofconduct.com](https://confcodeofconduct.com)._ 
+
+### Contact of Conduct Committee: [conduct@devopsdays.org](mailto:conduct@devopsdays.org)

--- a/content/events/2026-buenosaires/event.md
+++ b/content/events/2026-buenosaires/event.md
@@ -1,0 +1,21 @@
+---
+# DevOpsDays Buenos Aires 2026  
+city: "Buenos Aires"
+year: "2026"
+
+event_twitter: "DevOpsDaysBA"  # si ya tienen cuenta de X/Twitter
+email: "buenosaires@devopsdays.org"
+tentative_event_start_date: "2026-04-09"
+tentative_event_end_date: "2026-04-10"
+cfp_date_start: TBD
+cfp_date_end: TBD
+cfp_date_announce: TBD
+
+registration_date_start: TBD
+registration_date_end: TBD
+
+location: "Ciudad Autónoma de Buenos Aires, Argentina"
+title: "DevOpsDays Buenos Aires 2026"
+description: "¡Bienvenidos al primer DevOpsDays Buenos Aires! Será un evento lleno de aprendizajes, comunidad, diversidad y tecnología en el corazón de Argentina. Pronto compartiremos más detalles sobre el lugar, la agenda y cómo participar."
+event_type: "in-person"
+

--- a/content/events/2026-buenosaires/location.md
+++ b/content/events/2026-buenosaires/location.md
@@ -1,0 +1,27 @@
++++
+Title = "Venue"
++++
+
+**Lugar:** A confirmar  
+Estamos evaluando diferentes opciones para realizar DevOpsDays Buenos Aires 2026.
+Será en la Ciudad Autónoma de Buenos Aires, Argentina, y queremos que sea un espacio accesible y cómodo para todos los asistentes.
+Pronto anunciaremos el lugar exacto, pero queremos que sepas que estamos trabajando para ofrecerte una experiencia inolvidable.
+Algunas de las opciones que estamos considerando son:
+- Espacios de coworking 
+- Centro de Convenciones
+- Universidades locales (UADE, Di Tella, UCA, etc.)
+- KONEX
+- Salón de eventos en Palermo o Microcentro, como Jano's Corporativo, Espacio Darwin, o el Centro Cultural Recoleta. 
+¡Será en el corazón de la ciudad, de fácil acceso y con mucha onda DevOps!
+
+**Venue:** To be confirmed  
+We are evaluating different options to host DevOpsDays Buenos Aires 2026.
+It will take place in the Autonomous City of Buenos Aires, Argentina, and we want it to be an accessible and comfortable space for all attendees.
+We will announce the exact venue soon, but we want you to know that we are working to offer you an unforgettable experience.
+Some of the options we are considering are:
+- Coworking spaces
+- Convention Center
+- Local universities (UADE, Di Tella, UCA, etc.)
+- KONEX
+- Event halls in Palermo or Microcentro, such as Jano's Corporativo, Espacio Darwin, or the Centro Cultural Recoleta.  
+It will be in the heart of the city, easily accessible, and with a great DevOps vibe!

--- a/content/events/2026-buenosaires/organizers.yml
+++ b/content/events/2026-buenosaires/organizers.yml
@@ -1,0 +1,29 @@
+- name: Axel Labrua
+  linkedin: TBD
+  email: axel.labruna@live.com.ar
+  bio: TBD
+  role: lead organizer
+
+- name: Matias Armandola
+  linkedin: TBD
+  email: matiarman@gmail.com
+  bio: TBD
+  role: organizer
+
+- name: Martin Calderon
+  linkedin: TBD
+  email: martin@kaizen.la
+  bio: TBD
+  role: organizer
+
+- name: Maika Esteves
+  linkedin: TBD
+  email: contactomaikaesteves@gmail.com
+  bio: TBD
+  role: organizer
+
+- name: Rossana Suarez
+  linkedin: TBD
+  email: ingrossanasuarez@gmail.com
+  bio: TBD
+  role: organizer

--- a/content/events/2026-buenosaires/program.yml
+++ b/content/events/2026-buenosaires/program.yml
@@ -1,0 +1,17 @@
+# A definir más adelante
+# - title: "Opening Keynote"
+#   type: "talk"
+#   date: 2026-04-09
+#   start_time: "09:00"
+#   end_time: "09:45"
+#   speakers:
+#     - Organizers 
+#   description: "Opening remarks and welcome to the event."
+# - title: "Closing Keynote"
+#   type: "talk"
+#   date: 2026-04-09
+#   start_time: "16:00"
+#   end_time: "16:45"
+#   speakers:
+#     - Organizers
+#   description: "Closing remarks and wrap-up of the event."

--- a/content/events/2026-buenosaires/sponsors.yml
+++ b/content/events/2026-buenosaires/sponsors.yml
@@ -1,0 +1,12 @@
+# Sponsors se agregarán una vez confirmados.
+# Ejemplo de formato:
+# - id: microsoft
+#   level: platinum
+#   url: https://microsoft.com
+
+[]
+# Sponsors will be added once confirmed.
+# Example format: 
+# - id: microsoft
+#   level: platinum
+#   url: https://microsoft.com

--- a/content/events/2026-buenosaires/welcome.md
+++ b/content/events/2026-buenosaires/welcome.md
@@ -1,0 +1,11 @@
++++
+Title = "DevOpsDays Buenos Aires 2026"
+Tentative Start Date = "2026-04-09"
+Tentative End Date = "2026-04-10"
+Location = "Buenos Aires, Argentina"
++++
+
+¡Bienvenidos al primer DevOpsDays Buenos Aires!  
+Será un evento lleno de aprendizajes, comunidad, diversidad y tecnología en el corazón de Argentina.
+
+Pronto compartiremos más detalles sobre el lugar, la agenda y cómo participar.


### PR DESCRIPTION
This PR adds the initial structure and metadata for DevOpsDays Buenos Aires 2026.

Includes:
- event.yml
- welcome.md
- organizers.yml
- sponsors.yml (placeholder)
- location.md
- program.yml (placeholder)
- conduct.md

Looking forward to bringing DevOpsDays to Argentina 🇦🇷!

