### PR TITLE
[LIMA-2025] Add new sponsor

### DIFF
--- a/data/events/2025/lima/main.yml
+++ b/data/events/2025/lima/main.yml
@@ -125,9 +125,17 @@ sponsors:
    - id: nttdata
      level: gold
      url: https://pe.nttdata.com/
+   - id: dynatrace
+     level: gold
+     url: https://www.dynatrace.com/es-la/
    - id: linearb
      level: silver
      url: https://linearb.io/
+   - id: softtek
+     level: silver
+     url: https://softtek.com/es/
+   - id: devco
+     level: silver
    - id: idm
      level: bronze
      url: https://idmtechnology.com.pe/


### PR DESCRIPTION
This pull request updates the list of sponsors for the 2025 Lima event in the `main.yml` file. The changes include the addition of new sponsors across gold and silver levels.

### Sponsor updates:
* Added `dynatrace` as a gold-level sponsor with the URL `https://www.dynatrace.com/es-la/`.
* Added `softtek` and `devco` as silver-level sponsors with URLs `https://softtek.com/es/` and `https://www.devco.com.co/`, respectively.