### PR TITLE
[LIMA-2025] Add new sponsor

### DIFF
--- a/data/events/2025/lima/main.yml
+++ b/data/events/2025/lima/main.yml
@@ -155,6 +155,10 @@ sponsors:
    - id: datascienceresearchperu
      level: community
      url: https://www.datascience.pe/
+   - id: kubeevents
+     level: community
+   - id: kubecareers
+     level: community
    
   
 


### PR DESCRIPTION
This pull request updates the sponsors list for the Lima 2025 event by adding new community sponsors.

Event sponsorship updates:

* [`data/events/2025/lima/main.yml`](diffhunk://#diff-419afd7be7a3132ef252b3ac5397061f53ec3ffb0f9d6a37482c9f677880a63dR158-R161): Added `kubeevents` and `kubecareers` as community-level sponsors.