### PR TITLE
[LIMA-2025] Add new sponsor

### DIFF
--- a/data/events/2025/lima/main.yml
+++ b/data/events/2025/lima/main.yml
@@ -140,6 +140,8 @@ sponsors:
      url: https://softtek.com/es/
    - id: devco
      level: silver
+   - id: port
+     level: silver 
    - id: idm
      level: bronze
      url: https://idmtechnology.com.pe/


### PR DESCRIPTION
This pull request updates the `sponsors` section in the `data/events/2025/lima/main.yml` file to include a new silver-level sponsor and remove an existing one.

- Added a new silver-level sponsor with `id: port`.