### PR TITLE
[LDN-2025] Adding Google Logo Sponsor

### DIFF
--- a/data/events/2025/london/main.yml
+++ b/data/events/2025/london/main.yml
@@ -129,6 +129,8 @@ sponsors:
   - id: chainguard
     level: standard
   # Logo sponsors
+  - id: "google"
+    level: logo
   - id: cyberark
     level: logo
 


### PR DESCRIPTION
This add's Google's Sponsorship Logo for the London 2025 event
