### PR TITLE
[LIMA-2025] update url sponsors

### DIFF
--- a/data/events/2025/lima/main.yml
+++ b/data/events/2025/lima/main.yml
@@ -133,6 +133,7 @@ sponsors:
    - id: interbank
      level: gold
    - id: manage-engine
+     url: https://www.manageengine.com/latam/
      level: gold
    - id: esan
      level: gold


### PR DESCRIPTION
This pull request includes a small change to the `data/events/2025/lima/main.yml` file. It adds a `url` field for the `manage-engine` sponsor entry, providing a link to their website.