### PR TITLE
[HALIFAX-2025] Fix redundant text under location page.

### DIFF
--- a/content/events/2025-halifax/location.md
+++ b/content/events/2025-halifax/location.md
@@ -11,19 +11,6 @@ This modern facility is centrally situated on Dalhousie's Studley Campus and off
 - [Dalhousie building directory entry](https://www.dal.ca/campus-maps/building-directory/studley-campus/rowe-management-building.html)  
 - [Google Maps location](https://maps.app.goo.gl/C9RdGqhJSqcCCyyv9)
 
-+++
-Title = "Location"
-Type = "event"
-Description = "Location for DevOpsDays Halifax 2025"
-+++
-
-DevOpsDays Halifax 2025 will be hosted at the **Kenneth C. Rowe Management Building**, located at **Dalhousie University**, 6100 University Avenue, Halifax, NS B3H 1W7.
-
-This modern facility is centrally situated on Dalhousie's Studley Campus and offers excellent spaces for keynotes, breakout sessions, and community networking.
-
-- [Dalhousie building directory entry](https://www.dal.ca/campus-maps/building-directory/studley-campus/rowe-management-building.html)  
-- [Google Maps location](https://maps.app.goo.gl/C9RdGqhJSqcCCyyv9)
-
 ## Accommodations
 For attendees requiring accommodations during the event, the following options are recommended:
 


### PR DESCRIPTION
I forgot to remove the first part of previous location text when updating. This PR removes that redundant text under location page for DevOpsDays Halifax 2025.