### PR TITLE
[LDN-2025] Resolving Google Sponsorship

### DIFF
--- a/data/events/2025/london/main.yml
+++ b/data/events/2025/london/main.yml
@@ -129,7 +129,7 @@ sponsors:
   # Logo sponsors
   - id: that-agile
     level: logo
-  - id: "google"
+  - id: "googlecloud"
     level: logo
   - id: cyberark
     level: logo


### PR DESCRIPTION
This resolves the miss-matching "google" sponsorship for London 2025.
