### PR TITLE
[2025-LDN] Puppet is a Logo sponsor, not Standard

### DIFF
--- a/data/events/2025/london/main.yml
+++ b/data/events/2025/london/main.yml
@@ -132,8 +132,6 @@ sponsors:
     level: standard
   - id: launch-darkly
     level: standard
-  - id: puppet-by-perforce
-    level: standard
   # Accessibility sponsors
   - id: ai4ru
     level: accessibility
@@ -155,6 +153,8 @@ sponsors:
   - id: mindgard
     level: logo
   - id: syntasso
+    level: logo
+  - id: puppet-by-perforce
     level: logo
 
 sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link


### PR DESCRIPTION
- Oops, I put this in the wrong place.