### PR TITLE
fix: vertical alignment of event sidebar

### DIFF
--- a/themes/devopsdays-theme/assets/scss/custom.scss
+++ b/themes/devopsdays-theme/assets/scss/custom.scss
@@ -118,7 +118,9 @@ b, strong {
   font-size: 9pt;
   text-transform: uppercase;
   color: #000000;
+  margin-top: 1.5rem;
 }
+
 /* set the current month style */
 .left-nav-months.current {
   font-weight: 900;
@@ -131,11 +133,18 @@ b, strong {
   font-size: 18pt;
   color: #000000;
 }
+
+.left-nav-year + .left-nav-months {
+  margin-top: 0;
+}
+
 .left-nav-event {
+  display: block;
   font-family: 'Roboto', sans-serif;
   font-weight: 100;
   font-size: 9pt;
   text-transform: capitalize;
+  margin-bottom: .35rem;
 }
 
 /* Footer */

--- a/themes/devopsdays-theme/layouts/partials/future.html
+++ b/themes/devopsdays-theme/layouts/partials/future.html
@@ -12,10 +12,10 @@
   {{- if ne ($.Scratch.Get "month") (dateFormat "January" .startdate ) -}}
     {{- $.Scratch.Set "month" (dateFormat "January" .startdate ) -}}
     {{- $.Scratch.Set "month-displayed" "false" -}}
-<br />
+
   {{- end -}}
   {{- if ne ($.Scratch.Get "year-displayed") "true" -}}
-    <h3 class="left-nav-year">{{ dateFormat "2006" .startdate }}</h3>
+    <h3 class="left-nav-year mt-4">{{ dateFormat "2006" .startdate }}</h3>
     {{- $.Scratch.Set "year-displayed" "true" -}}
   {{- end -}}
   {{- if ne ($.Scratch.Get "month-displayed") "true" -}}
@@ -27,21 +27,21 @@
       <a href = "{{ (printf "/events/%s" .name ) }}" class = "left-nav-event">
     {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2" .enddate }}:
     {{ .city }}
-      </a><br />
+      </a>
     {{- else -}}
-  <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">
-    {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2" .enddate }}:
-    {{ .city }}
-  </a><br />
+      <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">
+        {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2" .enddate }}:
+        {{ .city }}
+      </a>
     {{- end -}}
   {{- else -}}
-  <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">
-    {{ dateFormat "Jan 2" .startdate }}:
-    {{ .city }}
-  </a><br />
+    <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">
+      {{ dateFormat "Jan 2" .startdate }}:
+      {{ .city }}
+    </a>
   {{- end -}}
 {{- end -}}
-<h3 class="left-nav-year">TBD</h3>
+<h3 class="left-nav-year mt-3">TBD</h3>
 {{- range sort $tbd "city" -}}
-    <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">{{ .city }}</a><br />
+  <a href = "{{ (printf "/events/%s" .name) }}" class = "left-nav-event">{{ .city }}</a>
 {{- end -}}


### PR DESCRIPTION
Fixing an issue with the vertical spacing above the `TBD` title. The first image shows the current appearance, which can be verified at: https://devopsdays.org/about

<img width="196" height="225" alt="Screenshot 2025-09-26 at 14 22 31" src="https://github.com/user-attachments/assets/d46ce77e-7a6c-4a23-b0be-8c69e4e80a4c" />

The second image shows the result of the changes, with a unit of vertical spacing introduced above the TBD heading. 

<img width="171" height="246" alt="Screenshot 2025-09-26 at 14 23 01" src="https://github.com/user-attachments/assets/9e6ca917-5b99-440a-949c-1dc0fdfef8ad" />

The primary changes in this PR are:
- Removing the use of `<br/>` element for vertical spacing
- Use CSS to manage the vertical space, through a mixture of custom CSS and bootstrap utility classes.