### PR TITLE
[MTL-2025] Remove the join as from the sponsor banner

### DIFF
--- a/data/events/2025/montreal/main.yml
+++ b/data/events/2025/montreal/main.yml
@@ -155,7 +155,7 @@ sponsor_levels:
   #   max: 11
   - id: bronze
     label: Bronze
-    max: 9
+    max: 1
   - id: venue
     label: Venue
     max: 1
@@ -176,3 +176,4 @@ sponsor_levels:
   #   max: 5
   - id: community
     label: Community
+    max: 1 # to prevent "join as" string from appearing


### PR DESCRIPTION
max=1 added so we remove the "Join as" legened