### PR TITLE
[LIMA-2026] Add Platinium Sponsor

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -134,6 +134,9 @@ sponsors:
    - id: nttdata
      level: platinum
      url: https://pe.nttdata.com/
+   - id: port
+     level: platinum
+     url: https://www.port.io/
    - id: orexe
      level: bronze
      url: https://orexe.pe/


### PR DESCRIPTION
This pull request adds a new platinum-level sponsor, Port, to the event's main sponsor list for Lima 2026.

- Event sponsor update:
  * Added a new platinum sponsor, `port`, with the URL `https://www.port.io/` to `data/events/2026/lima/main.yml`.