### PR TITLE
[SITE] remove googlemapsapi as it preventing prod builds

### DIFF
--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -59,7 +59,6 @@ params:
   Twitter: http://www.twitter.com/devopsdays
   Linkedin: http://www.linkedin.com/groups?home=&gid=2445279
   Groups: http://groups.google.com/group/devopsdays
-  GoogleMapsAPI: AIzaSyA1WhgJirbPSYxMCWRD14IP90A4yLY4vxE
 
 minify:
   disableCSS: false


### PR DESCRIPTION
Production building has stopped, so this is quite urgent.
Removing the Google Maps API for now seems to be the quickest solution


>> SECRETS_SCAN_SMART_DETECTION_OMIT_VALUES override option set to: ****
>> Failed during stage 'building site': Build script returned non-zero exit code: 2 (https://ntl.fyi/exit-code-2)
>> ❯ Scanning complete. 80986 file(s) scanned. Secrets scanning found 0 instance(s) of secrets and 1 instance(s) of likely secrets in build output or repo code.
>> "AIza***" detected as a likely secret:
>> found value at line 48359 in public/index.xml
