### PR TITLE
[LIMA-2026] Add sponsor platinum

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -137,12 +137,16 @@ sponsors:
    - id: port
      level: platinum
      url: https://www.port.io/
-   - id: orexe
-     level: bronze
-     url: https://orexe.pe/
+   - id: thoughtworks
+     level: platinum
+     url: https://www.thoughtworks.com/
+
 #Gold Sponsors
 #Silver Sponsors
 #Bronze Sponsors
+   - id: orexe
+     level: bronze
+     url: https://orexe.pe/
 #Community Sponsors 
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link


### PR DESCRIPTION
This pull request updates the sponsor listings for the Lima 2026 event. The main changes involve adjusting the placement and level of certain sponsors to ensure they are correctly categorized.

**Sponsor updates:**

* Moved `orexe` from the platinum section to the bronze section and ensured it appears under Bronze Sponsors.
* Added `thoughtworks` as a platinum sponsor with the appropriate URL.