### PR TITLE
[RIO-2026]Update CFP link for Rio de Janeiro event

### DIFF
--- a/data/events/2026/rio-de-janeiro/main.yml
+++ b/data/events/2026/rio-de-janeiro/main.yml
@@ -20,7 +20,7 @@ cfp_date_start:  2026-02-18T00:00:00-03:00
 cfp_date_end:  2026-05-18T00:00:00-03:00
 cfp_date_announce:  2026-06-13T09:00:00-03:00
 cfp_open: "true"
-cfp_link: "https://www.papercall.io/devopsdaysrio2026"
+cfp_link: "https://docs.google.com/forms/d/e/1FAIpQLSeCMPHylPeaa2KoMvldH2kphLQJ6UIED_IJ3vZwvZEH7-N-aA/viewform"
 
 registration_date_start: 2026-03-04T09:00:00-03:00 # start accepting registration. Leave blank if registration is not open yet. This will make the "Register" button appear on your "Welcome" page.
 registration_date_end: 2026-08-15T08:00:00-03:00 # close registration. Leave blank if registration is not open yet. If you set "registration_date_start" you need a value here.


### PR DESCRIPTION
This pull request updates the CFP (Call for Proposals) submission link for the 2026 Rio de Janeiro event.

Event configuration update:

* Changed the `cfp_link` in `data/events/2026/rio-de-janeiro/main.yml` from a PaperCall URL to a Google Forms URL.