### PR TITLE
[LIMA-2026] Add new sponsor

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -137,11 +137,13 @@ sponsors:
    - id: port
      level: platinum
      url: https://www.port.io/
-   - id: thoughtworks
-     level: platinum
-     url: https://www.thoughtworks.com/
-
 #Gold Sponsors
+   - id: thoughtworks
+     level: gold
+     url: https://www.thoughtworks.com/
+   - id: manage-engine
+     level: gold
+     url: https://manageengine.com/latam/
 #Silver Sponsors
 #Bronze Sponsors
    - id: orexe


### PR DESCRIPTION
This pull request updates the sponsor information for the 2026 Lima event, specifically adjusting sponsor levels and adding a new gold sponsor.

Sponsor updates:

* Changed the sponsorship level of `thoughtworks` from platinum to gold in `data/events/2026/lima/main.yml`.
* Added `manage-engine` as a new gold sponsor in `data/events/2026/lima/main.yml`.