### PR TITLE
[LIMA-2026] Add new sponsor community

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -149,7 +149,10 @@ sponsors:
    - id: orexe
      level: bronze
      url: https://orexe.pe/
-#Community Sponsors 
+#Community Sponsors
+   - id: hackemate
+     level: community
+     url: https://www.youtube.com/@hackemate
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
This pull request adds a new community sponsor to the Lima 2026 event configuration.

- Event sponsorship:
  * Added `hackemate` as a community-level sponsor with a link to their YouTube channel in the `main.yml` configuration file.