### PR TITLE
[LIMA-2026] Add new sponsor platinum

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -137,6 +137,9 @@ sponsors:
    - id: port
      level: platinum
      url: https://www.port.io/
+   - id: ibm
+     level: platinum
+     url: https://www.ibm.com
 #Gold Sponsors
    - id: thoughtworks
      level: gold


### PR DESCRIPTION
This pull request adds a new platinum-level sponsor to the Lima 2026 event.

* Event sponsorship updates:
  * Added `ibm` as a platinum sponsor in `data/events/2026/lima/main.yml`.