### PR TITLE
[LIMA-2026] Add new sponsor gold

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -147,6 +147,9 @@ sponsors:
    - id: manage-engine
      level: gold
      url: https://manageengine.com/latam/
+   - id: fluidattacks
+     level: gold
+     url: https://www.fluidattacks.com/
 #Silver Sponsors
 #Bronze Sponsors
    - id: orexe


### PR DESCRIPTION
This pull request adds a new gold-level sponsor to the `data/events/2026/lima/main.yml` file.

* Added `fluidattacks` as a gold sponsor, including their URL.