### PR TITLE
[LIMA-2026] Add new sponsors

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -140,6 +140,9 @@ sponsors:
    - id: ibm
      level: platinum
      url: https://www.ibm.com
+   - id: credicorp
+     level: platinum
+     url: https://grupocredicorp.com/
 #Gold Sponsors
    - id: thoughtworks
      level: gold
@@ -153,6 +156,9 @@ sponsors:
    - id: kyndryl
      level: gold
      url: https://www.kyndryl.com/
+   - id: interbank
+     level: gold
+     url: https://www.interbank.pe/
 #Silver Sponsors
 #Bronze Sponsors
    - id: orexe


### PR DESCRIPTION
This pull request adds new sponsors to the `data/events/2026/lima/main.yml` file for the 2026 Lima event. The changes introduce new platinum and gold level sponsors.

**New sponsors added:**

- Platinum Sponsors:
  * Added `credicorp` as a platinum sponsor with a link to their website.
- Gold Sponsors:
  * Added `interbank` as a gold sponsor with a link to their website.