### PR TITLE
Enable markdown attributes

### DIFF
--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -14,6 +14,10 @@ markup:
   goldmark:
     renderer:
       unsafe: true
+    parser:
+      attributes:
+        block: true
+        title: true
 languages:
   en:
     disabled: false


### PR DESCRIPTION
This will allow pages like [this](https://devopsdays.org/events/2026-austin/sponsor) to be written in markdown and be 9000x easier to maintain.

See https://gohugo.io/content-management/markdown-attributes/
