### PR TITLE
[FSA-2026] Change event location and event date

### DIFF
--- a/content/events/2026-feira-de-santana/location.md
+++ b/content/events/2026-feira-de-santana/location.md
@@ -7,7 +7,7 @@ Description = "Location for devopsdays feira-de-santana 2026"
 Watch this space for information about the venue including address, map/direction, parking/transit, and any hotel details.
 
 <!-- Uncomment this only if you have set the coordinates for your location in the config yaml. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html -->
-<!-- {{< event_map >}} -->
+{{< event_map >}}
 
 <!-- Edit and uncomment to let people know what accessibility features you have available -->
 <!-- 

--- a/content/events/2026-feira-de-santana/welcome.md
+++ b/content/events/2026-feira-de-santana/welcome.md
@@ -85,7 +85,7 @@ a.jssocials-share-link, a.event-cta-button {
 
 <br><br>
 <p></p>
-<p><a href="https://forms.gle/H93kiVEjofe2QwiF9" target="_blank"><button type="button">ENVIE SUA PALESTRA</button></a></p>
+<p><a href="https://talks.devopsdays.org/feira-de-santana-2026/" target="_blank"><button type="button">ENVIE SUA PALESTRA</button></a></p>
 <p><a href="https://dodfsa2026.eventize.com.br/" target="_blank"><button>INSCREVA-SE</button></a></p>
 <p><a href="https://forms.gle/iHXKxDBnugiWydCh7"><button>SEJA UM SPONSOR</button></a></p>
 <p><a href="/events/2026-feira-de-santana/contact/"><button>CONTATO</button></a></p>

--- a/data/events/2026/feira-de-santana/main.yml
+++ b/data/events/2026/feira-de-santana/main.yml
@@ -11,8 +11,8 @@ ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it
 # Note: we allow 2026-MM-DD for backward compatibility, but it can lead to unexpected behaviors (like your event disappearing from the front page during your last day)
 
 
-startdate: 2026-06-06T08:00:00-03:00
-enddate: 2026-06-06T18:00:00-03:00
+startdate: 2026-09-05T08:00:00-03:00
+enddate: 2026-09-05T18:00:00-03:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start:  # start accepting talk proposals.

--- a/data/events/2026/feira-de-santana/main.yml
+++ b/data/events/2026/feira-de-santana/main.yml
@@ -35,7 +35,7 @@ registration_link: "" # If you have a custom registration link, enter it here. T
 
 location: "Feira de Santana" # Defaults to city, but you can make it the venue name.
 #
-location_address: "" #Optional - use the street address of your venue. This will show up on the welcome page if set. Also used by the event_map shortcode!
+location_address: "Unex Feira de Santana, Av. Artêmia Pires Freitas, s/n - Sim, Feira de Santana - BA, 44085-370, Brazil" #Optional - use the street address of your venue. This will show up on the welcome page if set. Also used by the event_map shortcode!
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
  # - name: propose


### PR DESCRIPTION
- Changing the event location.
- Changing the event date (We had to reschedule the date because the venue didn’t confirm in time).
- The talk submission link has been updated.
