### PR TITLE
[LIMA-2026] Add Google tab manager

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -3,7 +3,7 @@ year: "2026" # The year of the event. Make sure it is in quotes.
 city: "lima" # The displayed city name of the event. Capitalize it.
 event_twitter: "devopsdays" # Change this to the twitter handle for your event such as devopsdayschi or devopsdaysmsp
 description: "Devopsdays is coming to lima!" # Edit this to suit your preferences
-ga_tracking_id: "" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
+ga_tracking_id: "GTM-TZQLKXDB" # If you have your own Google Analytics tracking ID, enter it here. Example: "UA-74738648-1"
 event_logo: "logo-square.png"
 
 # All dates are in unquoted 2026-MM-DDTHH:MM:SS+TZ:TZ, like this:


### PR DESCRIPTION
This pull request updates the Google Analytics tracking configuration for the Lima 2026 event.

Analytics configuration:

* Updated the `ga_tracking_id` in `data/events/2026/lima/main.yml` to use the new tracking ID `"GTM-TZQLKXDB"` instead of an empty value.