### PR TITLE
[medellin-2026] fix alias in welcome frontmatter

### DIFF
--- a/content/events/2026-medellin/welcome.md
+++ b/content/events/2026-medellin/welcome.md
@@ -1,8 +1,8 @@
 +++
-Title = "DevOpsDays Medellín 2025"
+Title = "DevOpsDays Medellín 2026"
 Type = "welcome"
-aliases = ["/events/2025-medellin/"]
-Description = "Welcome to DevOpsDays Medellín 2025"
+aliases = ["/events/2026-medellin/"]
+Description = "Welcome to DevOpsDays Medellín 2026"
 +++
 <div class = "row">
   <div class="col-md-4">


### PR DESCRIPTION
The alias in the welcome frontmatter for Medellin 2026 was still pointing at 2025. So the site would build but the event page would fail silently. This solves that problem.