### PR TITLE
Correct Hugo markdown parser config

### DIFF
--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -15,7 +15,7 @@ markup:
     renderer:
       unsafe: true
     parser:
-      attributes:
+      attribute:
         block: true
         title: true
 languages:


### PR DESCRIPTION
#15903 had a typo and so it never actually enabled block and title attributes (because the name should be singular). This PR corrects that.

One thing to note: The preview site build will need thorough checking. The previous PR was merged because there were no adverse effects... but that's because it didn't do anything (due to typo). This fix should enable the feature properly and might cause unwanted issues. If any negative effects are seen, we should roll back #15903 and add a comment to the Hugo config to document.