### PR TITLE
[London-2025] Update London 2025 event details

### DIFF
--- a/content/events/2026-london/welcome.md
+++ b/content/events/2026-london/welcome.md
@@ -5,83 +5,33 @@ aliases = ["/events/2026-london/"]
 Description = "devopsdays London 2026"
 +++
 
-<!-- <div style="text-align:center;">
-  {{< event_logo >}}
-</div> -->
-
-<div class = "row">
-  <div class = "col-md-2">
-    <strong>Dates</strong>
+<div class="row">
+  <div class="col-md-4 text-center">
+    {{< event_logo >}}
+    <div class="d-flex flex-row">
+      <div class="col-md-12">
+        <div class="p-2">
+          <a class="btn btn-secondary btn-block" href="/events/2026-london/sponsor"> <i class="fa fa-money fa-lg"></i>&nbsp;&nbsp;&nbsp;Sponsor the Conference</a>
+        </div>
+        <div class="p-2">
+          <a class="btn btn-secondary btn-block" href="https://ti.to/devopsdays-london/2026"> <i class="fa fa-ticket fa-lg"></i>&nbsp;&nbsp;&nbsp;Get a ticket</a>
+        </div>
+        <div class="p-2">
+          <a class="btn btn-secondary btn-block" href="https://devopsdays.us18.list-manage.com/subscribe?u=6c07d2ff23793b0dda5929f46&id=7aba07ba8c"> <i class="fa fa-list fa-lg"></i>&nbsp;&nbsp;
+            &nbsp; Get the latest announcements</a>
+        </div>
+        <div class="p-2">
+          <a class="btn btn-secondary btn-block" href="/events/2025-london/contact"> <i class="fa fa-envelope-o fa-lg"></i>&nbsp;&nbsp;
+            &nbsp; Contact the Organizers</a>
+        </div>
+      </div>
+    </div>
   </div>
-  <div class = "col-md-8">
-    {{< event_start >}} - {{< event_end >}}
+
+  <div class="col-md-7">
+    <p>DevOpsDays London is proud to be part of the global DevOpsDays community. Over 15 years and through global crises we have built a lasting network of technical conferences organised by the community, for the community!</p>
+    <p>Our 2026 event will happen over a single day and a single track of speakers in the morning, followed by Ignite talks (5 minutes, auto forwarding slides every 20 seconds). The afternoon is then given up to <a href="https://devopsdays.org/open-space-format/">Open Spaces</a> which are what makes DevOpsDays events truly special. Open spaces are what allow us to come together as a community and discuss the pressing issues we face. From technical deep dives to driving cultural change, no topic is off the cards, what is important is that the conference decides what it wants to talk about.</p>
+    <p>For attendees and sponsors we offer a unique chance to engage on a significantly more personal level than the larger corporate conferences. With practitioners from across the spectrum on their DevOps journeys we have space to learn from one another in open conversation, building relationships and a community that can help drive forward change together.</p>
+    <p>We would love for you to join us in September whether it is your first ever time at DevOpsDays or if you have been attending since Ghent in 2009, we have Early Bird tickets available right now at discounted prices. We are committed to making our conference as accessible as possible – more details coming soon.</p>
   </div>
 </div>
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Location</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_location >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Register</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="registration" text="Register to attend the conference!" >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Propose</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="propose" text="Propose a talk!" >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Program</strong>
-  </div>
-  <div class = "col-md-8">
-    View the {{< event_link page="program" text="program." >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Speakers</strong>
-  </div>
-  <div class = "col-md-8">
-    Check out the {{< event_link page="speakers" text="speakers!" >}}
-  </div>
-</div> -->
-
-<div class = "row">
-  <div class = "col-md-2">
-    <strong>Sponsors</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="sponsor" text="Sponsor the conference!" >}}
-  </div>
-</div>
-
-<div class = "row">
-  <div class = "col-md-2">
-    <strong>Contact</strong>
-  </div>
-  <div class = "col-md-8">
-    {{< event_link page="contact" text="Get in touch with the organizers" >}}
-  </div>
-</div>
-
-<!-- Uncomment if you added your city twitter name -->
-<!--
-{{< event_twitter >}}
--->

--- a/data/events/2026/london/main.yml
+++ b/data/events/2026/london/main.yml
@@ -56,7 +56,7 @@ social_shares: ["email", "facebook", "linkedin"]
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: propose
   - name: location
-  # - name: registration
+  - name: registration
   # - name: program
   # - name: speakers
   - name: sponsor
@@ -108,11 +108,8 @@ organizer_email: "london@devopsdays.org" # Put your organizer email address here
 # List all of your sponsors here along with what level of sponsorship they have.
 # Check data/sponsors/ to use sponsors already added by others.
 sponsors:
-#  - id: samplesponsorname
-#   level: gold
-#  url: http://mysponsor.com/?campaign=me # Use this if you need to over-ride a sponsor URL.
-# - id: arresteddevops
-#  level: community
+  - id: minimus
+    level: gold
 
 sponsors_accepted: "yes" # Whether you want "Become a XXX Sponsor!" link
 
@@ -131,3 +128,5 @@ sponsor_levels:
     label: Bronze
   - id: community
     label: Community
+  - id: accessibility
+    label: Accessibility


### PR DESCRIPTION
Update London 2025 sponsor page and various other settings for the event.
The sponsorship page relies on https://github.com/devopsdays/devopsdays-assets/pull/242 being merged as well.