### PR TITLE
[DALLAS-2026] Add Teleport as silver sponsor

### DIFF
--- a/data/events/2026/dallas/main.yml
+++ b/data/events/2026/dallas/main.yml
@@ -199,6 +199,8 @@ sponsors:
     level: gold
   - id: rapidfort
     level: gold
+  - id: teleport
+    level: silver
   - id: iacconf
     level: media
   - id: softwaredefinedtalk


### PR DESCRIPTION
Add Teleport as silver sponsor for DevOps Days 2026
