### PR TITLE
Feat: full_label field can be used instead of the label

### DIFF
--- a/themes/devopsdays-theme/layouts/partials/sponsors.html
+++ b/themes/devopsdays-theme/layouts/partials/sponsors.html
@@ -35,7 +35,9 @@
       <div class="row cta-row">
           <!--first sponsor row-->
           <div class="col-md-12">
-            {{- if eq $level.max 1 -}}
+            {{- if $level.full_label -}}
+              <h4 class="sponsor-cta">{{ $level.full_label }}</h4>
+            {{- else if eq $level.max 1 -}}
               <h4 class="sponsor-cta">{{ $level.label }} Sponsor</h4>
             {{- else -}}
               <h4 class="sponsor-cta">{{ $level.label }} Sponsors</h4>
@@ -54,7 +56,11 @@
                     {{- else -}}
                       <a href = '{{ (printf "/events/%s/sponsor" $e.name) }}' class="sponsor-cta">
                     {{- end -}}
-                      <i>Join as {{ $level.label }} Sponsor!</i>
+                      {{- if $level.full_label -}}
+                        <i>Join as {{ $level.full_label }}!</i>
+                      {{- else -}}
+                        <i>Join as {{ $level.label }} Sponsor!</i>
+                      {{- end -}}
                     </a>
                   {{- end -}}
                 {{- end -}}

--- a/utilities/examples/data/events/main.yml
+++ b/utilities/examples/data/events/main.yml
@@ -94,6 +94,8 @@ sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 # You may optionally include a "max" attribute to limit the number of sponsors per level. For
 # unlimited sponsors, omit the max attribute or set it to 0. If you want to prevent all
 # sponsorship for a specific level, it is best to remove the level.
+# You can also use "full_label" to override the default label generated for the level
+# which is adding "Sponsors" to the end of the label (e.g. "Gold" becomes "Gold Sponsors")
 sponsor_levels:
   - id: gold
     label: Gold
@@ -105,3 +107,4 @@ sponsor_levels:
     label: Bronze
   - id: community
     label: Community
+#    full_label: Community Partners  # Optional: Use this if you want a different label displayed on the page for the level


### PR DESCRIPTION
# Background 

Using the `label` field implies that in the template of the event, each section of the sponsors will show up as `[label] Sponsors` (with the _Sponsors_ suffix). Some events may want/need to add different types of partners that are not explicitly _Sponsors_, and adding an automatic suffix of Sponsors makes them look awkward.

# Proposal

To avoid that, this commit introduces a new field `full_label` which - when set - will be used in place of the `[label] Sponsors` (replacing it fully).

The same rule applies to the _Join as..._ link in the section. The `label` field is not required if `full_label` is used instead. 

**Backwards compatibility**

The default still falls into the `label` field to maintain old events.

# Example

<img width="651" height="459" alt="image" src="https://github.com/user-attachments/assets/6c49f733-aade-4bfd-ae5d-a2a69c539115" />

Closes #14456
