### PR TITLE
Add support for modern social share platforms.

### DIFF
--- a/themes/devopsdays-theme/layouts/partials/footer_scripts.html
+++ b/themes/devopsdays-theme/layouts/partials/footer_scripts.html
@@ -76,6 +76,12 @@
     {{- $share_str = "\"facebook\"" -}}
   {{- else if eq $current_item "linkedin" -}}
     {{- $share_str = "\"linkedin\"" -}}
+  {{- else if eq $current_item "bluesky" -}}
+    {{- $share_str = "\"bluesky\"" -}}
+  {{- else if eq $current_item "threads" -}}
+    {{- $share_str = "\"threads\"" -}}
+  {{- else if eq $current_item "mastodon" -}}
+    {{- $share_str = "\"mastodon\"" -}}
   {{- else -}}
     {{- $twitter_share_val := index $current_item "share" -}}
     {{- if $twitter_share_val -}}
@@ -98,7 +104,21 @@
 
 <script>
 //shares
-
+  jsSocials.shares.bluesky = {
+    label: "Share",
+    logo: "fa-brands fa-bluesky",
+    shareUrl: "https://bsky.app/intent/compose?text={text} {url}"
+  };
+  jsSocials.shares.threads = {
+    label: "Share",
+    logo: "fa-brands fa-threads",
+    shareUrl: "https://threads.net/intent/post?text={text} {url}"
+  };
+  jsSocials.shares.mastodon = {
+    label: "Share",
+    logo: "fa-brands fa-mastodon",
+    shareUrl: "https://mastodonshare.com/?text={text}&url={url}"
+  };
 
 {{ $full_script | safeJS }}
 


### PR DESCRIPTION
The upstream library was abandoned, but it still works with some
tweaking. I'm not truly convinced of the utility of share icons
anymore, but if they're there then I want to use the modern platforms.

