### PR TITLE
[DEN-2026] Add Flox as 2026 silver sponsor for Denver.

### DIFF
--- a/data/events/2026/denver/main.yml
+++ b/data/events/2026/denver/main.yml
@@ -99,6 +99,8 @@ sponsors:
     level: gold
   - id: groundcover
     level: silver
+  - id: flox
+    level: silver
   - id: code-talent
     level: community
   - id: kubeevents


### PR DESCRIPTION
Added flox as a 2026 Silver Sponsor
