### PR TITLE
[LIMA-2026] Add sponsors

### DIFF
--- a/data/events/2026/lima/main.yml
+++ b/data/events/2026/lima/main.yml
@@ -174,6 +174,9 @@ sponsors:
    - id: inetum
      level: silver
      url: https://inetum.com/pe/
+   - id: soaint
+     level: silver
+     url: https://www.soaint.com/
 #Bronze Sponsors
    - id: orexe
      level: bronze
@@ -185,6 +188,9 @@ sponsors:
    - id: practical-devsecops
      level: community
      url: https://www.practical-devsecops.com/
+   - id: mitocode
+     level: community
+     url: https://mitocode.com/
 
 sponsors_accepted : "yes" # Whether you want "Become a XXX Sponsor!" link
 


### PR DESCRIPTION
This pull request updates the sponsor list for the 2026 Lima event by adding new sponsors at the silver and community levels.

Sponsor additions:

**Silver Sponsors:**
* Added `soaint` as a silver sponsor with a link to their website.

**Community Sponsors:**
* Added `mitocode` as a community sponsor with a link to their website.