### PR TITLE
Switch to official mastodon sharing widget

### DIFF
--- a/themes/devopsdays-theme/layouts/partials/footer_scripts.html
+++ b/themes/devopsdays-theme/layouts/partials/footer_scripts.html
@@ -117,7 +117,7 @@
   jsSocials.shares.mastodon = {
     label: "Share",
     logo: "fa-brands fa-mastodon",
-    shareUrl: "https://mastodonshare.com/?text={text}&url={url}"
+    shareUrl: "https://share.joinmastodon.org/#text={text} {url}"
   };
 
 {{ $full_script | safeJS }}


### PR DESCRIPTION
Mastodonshare made a slightly better post, but this is the official one
and it's more reliable.
