### PR TITLE
[PT-2026] Change CFP deadline date

### DIFF
--- a/data/events/2026/portugal/main.yml
+++ b/data/events/2026/portugal/main.yml
@@ -15,7 +15,7 @@ enddate: 2026-11-20T23:59:59+01:00 # The end date of your event. Leave blank if 
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
 cfp_date_start: 2026-05-01T12:00:00+01:00 # start accepting talk proposals.
-cfp_date_end: 2026-07-15T23:00:00+01:00 # close your call for proposals.
+cfp_date_end: 2026-07-31T23:59:59+01:00 # close your call for proposals.
 cfp_date_announce: # inform proposers of status
 
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.


### PR DESCRIPTION
This PR changes the date for CFP Portugal 2026 edition