### PR TITLE
[HFX-2026] Tickets are live — update homepage, registration, and nav

### DIFF
--- a/content/events/2026-halifax/registration.md
+++ b/content/events/2026-halifax/registration.md
@@ -1,7 +1,140 @@
 +++
 Title = "Registration"
 Type = "event"
-Description = "Registration for DevOpsDays Halifax 2026"
+Description = "Registration for DevOpsDays Halifax 2026 — get your tickets now."
 +++
-
-Registration for DevOpsDays Halifax 2026 is not yet open. Once it is open, we will update this page with the details. Stay tuned!
+<style type="text/css">
+.hfx26reg {
+  --bg: #0B1020;
+  --surface: #151A2F;
+  --text: #F5F7FF;
+  --text-2: #B8C0E0;
+  --accent-1: #7C5CFF;
+  --accent-2: #D946EF;
+  --accent-3: #6FE7FF;
+  --border: #2A3152;
+  background: var(--bg);
+  color: var(--text);
+  border-radius: 16px;
+  overflow: hidden;
+  margin: 1em 0;
+}
+.hfx26reg a { color: var(--accent-3); text-decoration: none; }
+.hfx26reg a:hover { text-decoration: underline; }
+.hfx26reg .hero {
+  position: relative;
+  padding: 3.5em 2em 3em;
+  text-align: center;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(124, 92, 255, 0.28), transparent 55%),
+    radial-gradient(circle at 80% 70%, rgba(217, 70, 239, 0.22), transparent 55%),
+    var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+.hfx26reg .meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65em;
+  background: rgba(21, 26, 47, 0.7);
+  border: 1px solid var(--border);
+  padding: 0.5em 1.15em;
+  border-radius: 999px;
+  font-size: 0.95em;
+  color: var(--text-2);
+  margin-bottom: 1.25em;
+}
+.hfx26reg .meta-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent-3);
+  box-shadow: 0 0 12px var(--accent-3);
+  animation: hfxpulse 2s ease-in-out infinite;
+}
+@keyframes hfxpulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+.hfx26reg h1 {
+  font-size: 2.4em;
+  font-weight: 800;
+  margin: 0.15em 0 0.4em;
+  line-height: 1.1;
+  background: linear-gradient(135deg, var(--accent-3) 0%, var(--accent-1) 50%, var(--accent-2) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  letter-spacing: -0.01em;
+}
+.hfx26reg .tagline { color: var(--text-2); font-size: 1.1em; max-width: 620px; margin: 0 auto 2em; line-height: 1.55; }
+.hfx26reg .cta-row { display: flex !important; flex-wrap: wrap; gap: 0.85em; justify-content: center; background: transparent !important; padding: 0 !important; margin: 0 !important; }
+.hfx26reg .btn {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9em 1.75em !important;
+  border-radius: 10px !important;
+  font-weight: 600 !important;
+  font-size: 1em !important;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  border: 1px solid var(--border) !important;
+  text-decoration: none !important;
+}
+.hfx26reg .btn:hover { text-decoration: none !important; transform: translateY(-2px); }
+.hfx26reg .btn-primary {
+  background: linear-gradient(135deg, var(--accent-1), var(--accent-2)) !important;
+  color: var(--text) !important;
+  border: none !important;
+  box-shadow: 0 4px 22px rgba(124, 92, 255, 0.45);
+}
+.hfx26reg .btn-primary:hover { box-shadow: 0 6px 30px rgba(124, 92, 255, 0.6); color: var(--text) !important; }
+.hfx26reg .body { padding: 3em 2em; background: var(--bg); }
+.hfx26reg .section { margin-bottom: 2em; }
+.hfx26reg .section h2 { font-size: 1.4em; margin: 0 0 0.65em; color: var(--text); font-weight: 700; }
+.hfx26reg .section p { color: var(--text-2); line-height: 1.7; font-size: 1.05em; margin: 0 0 1em; }
+.hfx26reg .section p strong { color: var(--text); }
+.hfx26reg .voucher-box {
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.12), rgba(217, 70, 239, 0.08));
+  border: 1px solid rgba(124, 92, 255, 0.35);
+  border-radius: 12px;
+  padding: 1.5em;
+  margin: 1.5em 0;
+}
+.hfx26reg .voucher-box h3 {
+  color: var(--text);
+  margin: 0 0 0.5em;
+  font-size: 1.05em;
+  font-weight: 600;
+}
+.hfx26reg .voucher-box p {
+  color: var(--text-2);
+  margin: 0 0 0.6em;
+  line-height: 1.65;
+  font-size: 0.98em;
+}
+.hfx26reg .voucher-box p:last-child { margin-bottom: 0; }
+@media (max-width: 760px) {
+  .hfx26reg h1 { font-size: 1.8em; }
+  .hfx26reg .hero { padding: 2.5em 1.25em 2em; }
+  .hfx26reg .body { padding: 2em 1.25em; }
+  .hfx26reg .cta-row { flex-direction: column !important; }
+  .hfx26reg .btn { width: 100%; }
+  .hfx26reg .meta { font-size: 0.85em; }
+}
+</style>
+<div class="hfx26reg">
+<div class="hero">
+<div class="meta"><span class="meta-dot"></span> Registration is now open</div>
+<h1>Get your tickets</h1>
+<p class="tagline">DevOpsDays Halifax 2026 — Tuesday, September 29 in downtown Halifax.</p>
+<div class="cta-row">
+<a class="btn btn-primary" href="https://tickets.devopsdays.org/devopsdays-halifax/2026/">Get Tickets</a>
+</div>
+</div>
+<div class="body">
+<div class="section">
+<p>Groups of 5 or more get 15% off in the same order.</p>
+</div>
+<div class="voucher-box">
+<h3>Discounted and inclusive access tickets</h3>
+<p>We have a limited number of discounted tickets for students and folks from underrepresented communities.</p>
+<p>If you're between jobs or facing financial hardship, we've got you covered with inclusive access tickets.</p>
+<p>Reach out to <a href="mailto:halifax@devopsdays.org">halifax@devopsdays.org</a> and we'll send you a voucher code.</p>
+</div>
+</div>
+</div>

--- a/content/events/2026-halifax/welcome.md
+++ b/content/events/2026-halifax/welcome.md
@@ -2,7 +2,7 @@
 Title = "DevOpsDays Halifax 2026"
 Type = "welcome"
 aliases = ["/events/2026-halifax/"]
-Description = "DevOpsDays Halifax 2026 — September 29, 2026 at Volta in downtown Halifax."
+Description = "DevOpsDays Halifax 2026 — September 29, 2026 in downtown Halifax."
 +++
 <style type="text/css">
 .hfx26 {
@@ -151,15 +151,15 @@ Description = "DevOpsDays Halifax 2026 — September 29, 2026 at Volta in downto
 <h1>DevOpsDays Halifax 2026</h1>
 <p class="tagline">A day dedicated to learning, collaboration, and community for tech practitioners across Atlantic Canada and beyond.</p>
 <div class="hfx26-cta-row">
-<a class="hfx26-btn hfx26-btn-primary" href="https://talks.devopsdays.org/halifax-2026/cfp">Propose a Talk</a>
+<a class="hfx26-btn hfx26-btn-primary" href="https://tickets.devopsdays.org/devopsdays-halifax/2026/">Get Tickets</a>
 <a class="hfx26-btn hfx26-btn-secondary" href="../sponsor/">Become a Sponsor</a>
 </div>
 </div>
 <div class="explore-bar">
 <h3>Explore</h3>
 <div class="nav-grid">
+<a class="hfx26-nav-link" href="../registration/">Get Tickets</a>
 <a class="hfx26-nav-link" href="../location/">Venue Info</a>
-<a class="hfx26-nav-link" href="https://talks.devopsdays.org/halifax-2026/cfp">Propose a Talk</a>
 <a class="hfx26-nav-link" href="../sponsor/">Become a Sponsor</a>
 <a class="hfx26-nav-link" href="../convince-your-boss/">Convince Your Boss</a>
 <a class="hfx26-nav-link" href="../conduct/">Code of Conduct</a>
@@ -195,10 +195,9 @@ Description = "DevOpsDays Halifax 2026 — September 29, 2026 at Volta in downto
 <p>DevOpsDays Halifax brings together a diverse and highly engaged group of professionals — senior technical leaders, executives, software engineers, platform teams, site reliability engineers, security specialists, and students. Whether you are shaping DevOps strategy at an organizational level or just getting started, this event offers a chance to connect, learn, and grow with peers across Atlantic Canada and beyond.</p>
 </div>
 <div class="section">
-<h2>Get involved</h2>
-<p>The Call for Proposals runs <strong>May 1 – June 8, 2026</strong>. If you have a story, lesson, or perspective to share, we encourage you to <a href="https://talks.devopsdays.org/halifax-2026/cfp">apply via Pretalx</a>.</p>
-<p>Registration details will be announced soon. Discounted tickets for students and folks from underrepresented communities will be available — please email <a href="mailto:halifax@devopsdays.org">halifax@devopsdays.org</a> once registration opens to request a voucher.</p>
-<p>Thank you to our venue sponsor, <strong>Volta</strong>, for hosting us in downtown Halifax.</p>
+<h2>Get your tickets</h2>
+<p>Tickets are now on sale — <a href="https://tickets.devopsdays.org/devopsdays-halifax/2026/">grab yours here</a>. Groups of 5 or more get 15% off in the same order.</p>
+<p>We also have discounted tickets for students and folks from underrepresented communities, plus inclusive access tickets for anyone between jobs or facing financial hardship. Email <a href="mailto:halifax@devopsdays.org">halifax@devopsdays.org</a> for a voucher code.</p>
 </div>
 <p class="conduct-note">By attending, you agree to the <a href="../conduct/">DevOpsDays Halifax Code of Conduct</a>.</p>
 </div>

--- a/data/events/2026/halifax/main.yml
+++ b/data/events/2026/halifax/main.yml
@@ -13,17 +13,16 @@ cfp_date_start: 2026-05-01
 cfp_date_end: 2026-06-08
 cfp_date_announce: 2026-08-01
 cfp_link: "https://talks.devopsdays.org/halifax-2026/cfp"
-registration_date_start:
+registration_date_start: 2026-07-09
 registration_date_end:
 registration_closed: ""
-registration_link: ""
+registration_link: "https://tickets.devopsdays.org/devopsdays-halifax/2026/"
 coordinates: ""
 location: "Trade Centre Office Tower"
 location_address: "1800 Argyle St Unit 801, Halifax, NS B3J 3N8"
 nav_elements:
   - name: location
   - name: registration
-  - name: propose
   - name: sponsor
   - name: contact
   - name: conduct


### PR DESCRIPTION
Tickets are on sale. Updating the site to reflect that.

## Changes

- `data/events/2026/halifax/main.yml` — set `registration_date_start` and `registration_link`; removed `propose` from nav_elements since CFP is closed
- `content/events/2026-halifax/registration.md` — replaced placeholder with tickets CTA, group discount info, and voucher path
- `content/events/2026-halifax/welcome.md` — swapped hero primary CTA from "Propose a Talk" to "Get Tickets"; updated Explore nav; rewrote Get Involved as Get Your Tickets

All changes scoped to `content/` and `data/`.