### PR TITLE
[PDX 2026] Add note about the meetup discount

### DIFF
--- a/content/events/2026-portland-or/welcome.md
+++ b/content/events/2026-portland-or/welcome.md
@@ -59,6 +59,12 @@ Description = "devopsdays Portland, OR 2026"
         <a href="https://linkedin.com/company/devopsdays-pdx" class="fa-brands fa-linkedin social-li" target="_blank" title="Follow on Linkedin"></a>
       </div>
     </div>
+
+> <i class="fa-solid fa-money-bill-wave fa-2x" style="float: left; width: 48px; height: 48px;"></i>
+> Are you an organizer of a local meetup or tech group?<br>
+> <a href="mailto:portland-or@devopsdays.org">Email for a registration discount code!</a>
+{.alert .alert-info}
+
   </div>
   <div class="col-md-4">
     <div style="text-align:center; width:500px; height=auto;">


### PR DESCRIPTION
This adds a simple alert about the meetup discount to the welcome page.

<img width="596" height="261" alt="Screenshot 2026-07-15 at 4 43 19 PM" src="https://github.com/user-attachments/assets/96dcc060-a0f1-4cd5-ae87-f19ff3760d38" />

Signed-off-by: Ben Ford <binford2k@overlookinfratech.com>
