### PR TITLE
[CAMPINAS-2025] update (last year's) splat)

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -22,7 +22,7 @@
 /buffalo/*		/events/2023-buffalo/:splat		302
 /caceres/*		/events/2024-caceres/:splat		302
 /cairo/*		/events/2026-cairo/:splat		302
-/campinas/*		/events/2024-campinas/:splat		302
+/campinas/*		/events/2025-campinas/:splat		302
 /cape-town/*		/events/2020-cape-town/:splat		302
 /charlotte/*		/events/2022-charlotte/:splat		302
 /chattanooga/*		/events/2024-chattanooga/:splat		302


### PR DESCRIPTION
updates the redirect for Campinas from 2024 to 2025 (2026 was cancelled)