### PR TITLE
[RIO-2026]Fix Sponsor

### DIFF
--- a/data/events/2026/rio-de-janeiro/main.yml
+++ b/data/events/2026/rio-de-janeiro/main.yml
@@ -102,12 +102,13 @@ sponsors:
   - id: fiap
     level: diamond
 
+  - id: kaspersky
+    level: diamond
+
   #Gold Sponsors
   - id: stone
     level: gold
 
-  - id: kaspersky
-    level: gold
   #Silver Sponsors
 
   #Community


### PR DESCRIPTION
This pull request updates the sponsor list for the Rio de Janeiro 2026 event. The main change is that the sponsor `kaspersky` has been moved from the Gold tier to the Diamond tier.

Sponsor tier updates:

* Moved `kaspersky` from the Gold tier to the Diamond tier in `main.yml`.