### PR TITLE
[PDX-2026] Adding program and speakers

### DIFF
--- a/content/events/2026-portland-or/program.md
+++ b/content/events/2026-portland-or/program.md
@@ -1,0 +1,16 @@
++++
+Title = "Program"
+Type = "event"
+Description = "Speakers, sessions, ignites, meals"
++++
+
+<script type="text/javascript" src="https://talks.devopsdays.org/devopsdays-portland-2026/widgets/schedule.js"></script>
+<pretalx-schedule event-url="https://talks.devopsdays.org/devopsdays-portland-2026/" locale="en" format="grid" style="--pretalx-clr-primary: #3aa57c"></pretalx-schedule>
+<noscript>
+<div class="pretalx-widget">
+        <div class="pretalx-widget-info-message">
+            JavaScript is disabled in your browser. To access our schedule without JavaScript,
+            please <a target="_blank" href="https://talks.devopsdays.org/devopsdays-portland-2026/schedule/">click here</a>.
+        </div>
+    </div>
+</noscript>

--- a/content/events/2026-portland-or/speakers.md
+++ b/content/events/2026-portland-or/speakers.md
@@ -1,0 +1,60 @@
++++
+Title = "Speakers"
+Type = "speakers"
+Description = "Meet our speakers for DevOpsDays Portland 2026"
++++
+
+<div id="speakers" class="row"></div>
+<noscript>
+<div class="pretalx-widget">
+        <div class="pretalx-widget-info-message">
+            JavaScript is disabled in your browser. To access our speaker list without JavaScript,
+            please <a target="_blank" href="https://talks.devopsdays.org/devopsdays-portland-2026/speaker/">click here</a>.
+        </div>
+    </div>
+</noscript>
+
+<script>
+    const ul = document.getElementById('speakers');
+    const list = document.createDocumentFragment();
+    const url = 'https://talks.devopsdays.org/api/events/devopsdays-portland-2026/speakers/?limit=50';
+
+    fetch(url)
+        .then((response) => {
+            return response.json();
+        })
+        .then((data) => {
+            let speakers = data.results;
+
+            speakers.map(function(speaker) {
+                let li = document.createElement('div');
+                li.className = `col-lg-3 col-md-6 p-3`;
+                let name = document.createElement('h3');
+                let pic = document.createElement('img');
+                let bio = document.createElement('details');
+                bio.className = `p-1`;
+                let talk = document.createElement('a');
+
+                name.innerHTML = `${speaker.name}`;
+                pic.src = speaker.avatar_url != null ? `${speaker.avatar_url}`: '/img/speaker-default.jpg';
+                pic.className = `speakers-page`;
+                bio.innerHTML = `<summary><b>About ${speaker.name}</b></summary><p>${speaker.biography ? `${speaker.biography}`: `Ipsum`}</p>`;
+                talk.setAttribute('href', speaker.submissions[0] ? `https://talks.devopsdays.org/devopsdays-portland-2026/talk/${speaker.submissions[0]}` : ``);
+                talk.setAttribute('target', '_blank');
+                talk.className = `btn btn-primary`;
+                talk.innerHTML = `Link to talk`;
+
+                li.appendChild(name);
+                li.appendChild(pic);
+                li.appendChild(bio);
+                li.appendChild(talk);
+                list.appendChild(li);
+            });
+        })
+        .catch(function(error) {
+            console.log(error);
+        })
+        .finally(() => {
+            ul.appendChild(list);
+        });
+</script>

--- a/data/events/2026/portland-or/main.yml
+++ b/data/events/2026/portland-or/main.yml
@@ -53,11 +53,11 @@ event_social_youtube: "devopsdaysportland" # Change this to the youtube channel 
 social_shares: ["email", "bluesky", "mastodon", "twitter", "facebook", "linkedin"]
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: propose
+ # - name: propose
  # - name: location
   - name: registration
- # - name: program
- # - name: speakers
+  - name: program
+  - name: speakers
   - name: sponsor
   - name: contact
   - name: conduct


### PR DESCRIPTION
Removes the CFP link.
Adds Program and Speaker pages.
Speaker page totally stolen from Austin (but with a javascript fix)