### PR TITLE
[DEN-2026] Add sponsor and schedule, remove early bird references

### DIFF
--- a/content/events/2026-denver/program.md
+++ b/content/events/2026-denver/program.md
@@ -1,0 +1,16 @@
++++
+Title = "Program"
+Type = "event"
+Description = "Program for devopsdays Denver 2026"
++++
+
+<script type="text/javascript" src="https://talks.devopsdays.org/dodroxrox26/widgets/schedule.js"></script>
+<pretalx-schedule event-url="https://talks.devopsdays.org/dodroxrox26/" locale="en" format="grid" style="--pretalx-clr-primary: #3aa57c"></pretalx-schedule>
+<noscript>
+   <div class="pretalx-widget">
+        <div class="pretalx-widget-info-message">
+            JavaScript is disabled in your browser. To access our schedule without JavaScript,
+            please <a target="_blank" href="https://talks.devopsdays.org/dodroxrox26/schedule/">click here</a>.
+        </div>
+    </div>
+</noscript>

--- a/content/events/2026-denver/welcome.md
+++ b/content/events/2026-denver/welcome.md
@@ -4,7 +4,7 @@ Type = "welcome"
 aliases = ["/events/2026-denver/"]
 Description = "devopsdays Denver 2026"
 +++
-<h2><b>DevOpsDays Rockies will be back in 2026 at Bierstadt Lagerhaus in Downtown Denver! Save the dates for September 22-23, 2026 or </b>{{< event_link page="registration" text="purchase your Early Bird Ticket now!" >}}</h2>
+<h2><b>DevOpsDays Rockies is back in 2026 for our 10th year at Bierstadt Lagerhaus in Downtown Denver! September 22-23, 2026 </b>{{< event_link page="registration" text="Purchase your ticket now!" >}}</h2>
 <br><br>
 
 <!-- <h2>{{< event_link page="program" text="View the Program!" >}}</h2>
@@ -35,10 +35,28 @@ Description = "devopsdays Denver 2026"
 
 <div class = "row">
   <div class = "col-md-2">
-    <strong>Propose</strong>
+    <strong>Schedule</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_link url-key="cfp_link" text="Submit your talk today!" >}}
+    {{< event_link page="program" text="Check out the schedule!" >}}
+  </div>
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Speakers</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="speakers" text="Check out our speakers!" >}}
+  </div>
+</div>
+
+<div class = "row">
+  <div class = "col-md-2">
+    <strong>Talks</strong>
+  </div>
+  <div class = "col-md-8">
+    {{< event_link page="talks" text="Check out the talks!" >}}
   </div>
 </div>
 
@@ -79,20 +97,3 @@ Follow us below to stay in the know:
 {{< event_social_youtube >}}
 <br>
 <br><br>
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Program</strong>
-  </div>
-  <div class = "col-md-8">
-    View the {{< event_link page="program" text="program." >}}
-  </div>
-</div> -->
-
-<!-- <div class = "row">
-  <div class = "col-md-2">
-    <strong>Speakers</strong>
-  </div>
-  <div class = "col-md-8">
-    Check out the {{< event_link page="speakers" text="speakers!" >}}
-  </div>
-</div> -->

--- a/content/events/2026-denver/welcome.md
+++ b/content/events/2026-denver/welcome.md
@@ -4,7 +4,7 @@ Type = "welcome"
 aliases = ["/events/2026-denver/"]
 Description = "devopsdays Denver 2026"
 +++
-<h2><b>DevOpsDays Rockies is back in 2026 for our 10th year at Bierstadt Lagerhaus in Downtown Denver! September 22-23, 2026 </b>{{< event_link page="registration" text="Purchase your ticket now!" >}}</h2>
+<h2><b>DevOpsDays Rockies is back in 2026 for our 10th year!<br>Bierstadt Lagerhaus in Downtown Denver, September 22-23, 2026 </b><br>{{< event_link page="registration" text="Purchase your ticket now!" >}}</h2>
 <br><br>
 
 <!-- <h2>{{< event_link page="program" text="View the Program!" >}}</h2>
@@ -65,7 +65,7 @@ Description = "devopsdays Denver 2026"
     <strong>Register</strong>
   </div>
   <div class = "col-md-8">
-    {{< event_link page="registration" text="Limited Early bird tickets on sale!" >}}
+    {{< event_link page="registration" text="Buy your tickets now!" >}}
   </div>
 </div>
 

--- a/data/events/2026/denver/main.yml
+++ b/data/events/2026/denver/main.yml
@@ -51,7 +51,7 @@ event_social_youtube: "devopsdaysrockies" # Change this to the youtube channel h
 nav_elements: # List of pages you want to show up in the navigation of your page.
   - name: location
   - name: registration
- # - name: program
+  - name: program
   - name: speakers
   - name: talks
   - name: sponsor

--- a/data/events/2026/denver/main.yml
+++ b/data/events/2026/denver/main.yml
@@ -101,6 +101,7 @@ sponsors:
     level: silver
   - id: flox
     level: silver
+  - id: launch-darkly
   - id: code-talent
     level: community
   - id: kubeevents

--- a/data/events/2026/denver/main.yml
+++ b/data/events/2026/denver/main.yml
@@ -102,6 +102,7 @@ sponsors:
   - id: flox
     level: silver
   - id: launch-darkly
+    level: silver
   - id: code-talent
     level: community
   - id: kubeevents


### PR DESCRIPTION
Add Launch Darkly as a 2026 sponsor.
Removed early bird ticket references.
Added pretalx schedule.