### PR TITLE
[RIO-2026] Fix Event Address

### DIFF
--- a/content/events/2026-rio-de-janeiro/location.md
+++ b/content/events/2026-rio-de-janeiro/location.md
@@ -4,11 +4,11 @@ Type = "event"
 Description = "Location for DevOps Days Rio de Janeiro 2026"
 +++
 
-O evento será sediado no Arca Hub, em Ipanema, próximo a estação de Metro General Osório/Ipanema.
+O evento será sediado no FIAP, em Botafogo.
 
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3674.163584338189!2d-43.185255123591276!3d-22.944201839211402!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x997ff2e7d60c47%3A0xdb893c7058419dba!2sR.%20Marqu%C3%AAs%20de%20Olinda%2C%2011%20-%20Botafogo%2C%20Rio%20de%20Janeiro%20-%20RJ%2C%2022251-040!5e0!3m2!1spt-BR!2sbr!4v1782926799335!5m2!1spt-BR!2sbr" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="strict-origin-when-cross-origin"></iframe>
 <br>
-<h3>Endereço: <a href="https://maps.app.goo.gl/EgZgZCm17yzipa3h6">Rua Jangadeiros, 48 - Ipanema, Rio de Janeiro - RJ, 22420-010</a></h3>
+<h3>Endereço: <a href="https://maps.app.goo.gl/wMP6HVNJ4f6tt5xV8">R. Marquês de Olinda, 11 - Botafogo, Rio de Janeiro - RJ, 22251-040</a></h3>
 <!-- Uncomment this only if you have set the coordinates for your location in the config yaml. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html -->
 
 


### PR DESCRIPTION
This pull request updates the location details for the DevOps Days Rio de Janeiro 2026 event. The event venue and address have been changed to reflect a new location in Botafogo.

**Event Location Update:**

* Changed the venue from `Arca Hub, Ipanema` to `FIAP, Botafogo` in the event description.
* Updated the address and Google Maps embed to point to `R. Marquês de Olinda, 11 - Botafogo, Rio de Janeiro - RJ, 22251-040` instead of the previous Ipanema address.