### PR TITLE
[DEN-2026] Add Harness as 2026 Denver Silver Sponsor

### DIFF
--- a/data/events/2026/denver/main.yml
+++ b/data/events/2026/denver/main.yml
@@ -103,6 +103,8 @@ sponsors:
     level: silver
   - id: launch-darkly
     level: silver
+  - id: harness
+    level: silver
   - id: code-talent
     level: community
   - id: kubeevents


### PR DESCRIPTION
Add Harness as a 2026 sponsor