### PR TITLE
[BOG-2026] Add Oracle as a diamond sponsor

### DIFF
--- a/data/events/2026/bogota/main.yml
+++ b/data/events/2026/bogota/main.yml
@@ -102,6 +102,8 @@ sponsors:
     level: diamond
   - id: ibm
     level: diamond
+  - id: oracle
+    level: diamond
   - id: sigitat
     level: platinum
   - id: clickhouse


### PR DESCRIPTION
Added Oracle as a diamond sponsor for devopsdays Bogotá 2026.