### PR TITLE
Allow -before-NUMBER files in sponsors directory guard

### DIFF
--- a/.github/workflows/no-sponsors-changes.yml
+++ b/.github/workflows/no-sponsors-changes.yml
@@ -43,8 +43,17 @@ jobs:
               files = [];
             }
 
-            const fileList = files.length
-              ? files.map(f => `- \`${f}\``).join("\n")
+            // Allow files whose name contains "-before-<number>" (e.g. logo-before-2026.png)
+            const exemptPattern = /-before-\d+/;
+            const blockedFiles = files.filter(f => !exemptPattern.test(f));
+
+            if (files.length && blockedFiles.length === 0) {
+              core.info("All changed sponsor files match the '-before-NUMBER' exemption; skipping block.");
+              return;
+            }
+
+            const fileList = blockedFiles.length
+              ? blockedFiles.map(f => `- \`${f}\``).join("\n")
               : "- _(Unable to enumerate files, but changes were detected)_";
 
             const comments = await github.paginate(github.rest.issues.listComments, {


### PR DESCRIPTION
## Summary
- The sponsor-assets guard workflow blocks any PR touching `static/img/sponsors/**`.
- Adds an exception so files whose name contains `-before-<number>` (e.g. `logo-before-2026.png`) are allowed through without tripping the block or comment.
- If a change mixes exempt and non-exempt files, only the non-exempt files are listed in the block comment and the check still fails.

## Test plan
- [ ] Open a test PR that only adds/modifies a `*-before-2026.*` file under `static/img/sponsors/` and confirm the guard check passes with no comment.
- [ ] Open a test PR with a non-exempt file under `static/img/sponsors/` and confirm the guard still comments and fails as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)