### PR TITLE
[HALIFAX-2026] Add Kube Events as community sponsor

### DIFF
--- a/content/events/2026-halifax/sponsor.md
+++ b/content/events/2026-halifax/sponsor.md
@@ -31,7 +31,7 @@ The best thing to do is send engineers to interact with the experts at DevOpsDay
       <td>1</td>
       <td>2</td>
       <td>2</td>
-      <td>1 (of 3)</td>
+      <td>2 (of 3)</td>
     </tr>
     <tr>
       <td>Price</td>

--- a/data/events/2026/halifax/main.yml
+++ b/data/events/2026/halifax/main.yml
@@ -55,6 +55,8 @@ sponsors:
     level: venue
   - id: devitjobs
     level: community
+  - id: kubeevents
+    level: community
 sponsors_accepted: "yes"
 sponsor_levels:
   - id: platinum


### PR DESCRIPTION
Add kube.events to the Halifax 2026 event and update the community sponsor slot count on the sponsor page.
