### PR TITLE
[LA-2027] Remove Jay Cui from team members

### DIFF
--- a/data/events/2027/los-angeles/main.yml
+++ b/data/events/2027/los-angeles/main.yml
@@ -82,8 +82,6 @@ team_members: # Name is the only required field for team members.
   - name: "Rich Horace"
     image: "rich.jpg"
     linkedin: "https://www.linkedin.com/in/richhorace/"
-  - name: "Jay Cui"
-    image: "jay.jpg"
 
 organizer_email: "los-angeles@devopsdays.org" # Put your organizer email address here
 


### PR DESCRIPTION
**Summary of changes**
- Removed Jay Cui from the 2027 Los Angeles team members list in `data/events/2027/los-angeles/main.yml`

**Remaining team members:**
- Bryna Kirzner
- Jordan Schwartz
- Ilan Rabinovitch
- Omar Alva
- Rich Horace