### PR TITLE
[LA-2027] Update 2027 Los Angeles event website

### DIFF
--- a/content/events/2026-los-angeles/program/arthur-freyman.md
+++ b/content/events/2026-los-angeles/program/arthur-freyman.md
@@ -5,6 +5,7 @@ Talk_end_time = "14:45"
 Title = "Build a Better Loop: A Guide to Platform Engineering"
 Type = "talk"
 Speakers = ["arthur-freyman"]
+Youtube = "S4gOWf96Lhg"
 +++
 
 From scrappy sysadmins and early SRE teams to DevOps and today's platform engineering wave, this talk traces how operations have evolved—and why the next frontier is treating your platform as a real internal product for developers. This talk will unpack what a modern platform actually is (and isn't), show how ideas like Team Topologies, golden paths, and "glue as a service" fit together, and share concrete strategies for success: adopting a product mindset, obsessing over developer experience, measuring with DevEx/DORA-style signals, and ruthlessly stripping away incidental complexity so autonomous teams can move faster with less coordination. You'll leave with a practical mental model and a set of patterns you can apply immediately to build a better loop between developers, platform, and the business.

--- a/content/events/2026-los-angeles/program/dondiego-aponte.md
+++ b/content/events/2026-los-angeles/program/dondiego-aponte.md
@@ -5,6 +5,7 @@ Talk_end_time = "13:45"
 Title = "Barns Don't Burn Down Because of One Loose Nail, But Yours Just Might"
 Type = "talk"
 Speakers = ["dondiego-aponte"]
+Youtube = "nNyYP1IclnE"
 +++
 
 Kubernetes is exceptionally good at keeping things running—and sometimes a little too good at hiding when they're not. Pods restart, nodes reschedule, alerts auto-resolve, and dashboards stay green long after the system has started misbehaving.

--- a/content/events/2026-los-angeles/program/dustin-kirkland.md
+++ b/content/events/2026-los-angeles/program/dustin-kirkland.md
@@ -5,6 +5,7 @@ Talk_end_time = "11:45"
 Title = "Agentic Pipelines for an OS Supply Chain"
 Type = "talk"
 Speakers = ["dustin-kirkland"]
+Youtube = "w5roQS0I3bE"
 +++
 
 <style>

--- a/content/events/2026-los-angeles/program/engin-diri.md
+++ b/content/events/2026-los-angeles/program/engin-diri.md
@@ -5,6 +5,7 @@ Talk_end_time = "14:00"
 Title = "The Ralph Wiggum Loop: How Autonomous AI Loops Built My Serverless SaaS While I Slept"
 Type = "talk"
 Speakers = ["engin-diri"]
+Youtube = "A_b1f1-mA4Q"
 +++
 
 You ask an AI assistant to build something, grab coffee, and return to find it stopped three steps in. "Should I continue?" it asks politely. You're not coding anymore. You're babysitting. Checking every five minutes saves nothing.

--- a/content/events/2026-los-angeles/program/john-willis.md
+++ b/content/events/2026-los-angeles/program/john-willis.md
@@ -5,6 +5,7 @@ Talk_end_time = "09:45"
 Title = "When AI agents go rogue: DevOps lessons from the rise of polymorphic AI"
 Type = "talk"
 Speakers = ["john-willis"]
+Youtube = "Ha8aH-nfjzU"
 +++
 
 As AI agents gain the ability to plan, adapt, and even rewrite themselves, they introduce both new power and new risk to software delivery. This talk looks at real incidents and emerging research to show how polymorphic agents can reconfigure behavior, bypass constraints, and challenge assumptions about "safe" automation. Attendees will learn to recognize red flags and rethink quality in a world where tools don't just follow instructions—they evolve.

--- a/content/events/2026-los-angeles/program/joshua-lee.md
+++ b/content/events/2026-los-angeles/program/joshua-lee.md
@@ -5,6 +5,7 @@ Talk_end_time = "10:45"
 Title = "DevOps is a Foreign Language (or Why There Are No Junior SREs)"
 Type = "talk"
 Speakers = ["joshua-lee"]
+Youtube = "058eX3byv6s"
 +++
 
 DevOps has a notoriously steep learning curve. Getting started in the field can feel like being dropped in a foreign country without the ability to understand *anything* about the language.

--- a/content/events/2026-los-angeles/program/scott-mabe.md
+++ b/content/events/2026-los-angeles/program/scott-mabe.md
@@ -5,6 +5,7 @@ Talk_end_time = "15:45"
 Title = "Gen AI for the Gen X Guy"
 Type = "talk"
 Speakers = ["scott-mabe"]
+Youtube = "hgelaM5UffU"
 +++
 
 GenAI for the GenX guy is a talk about how being a member of the forgotten apathetic generation has led to a healthy distrust of GenAI.

--- a/content/events/2026-los-angeles/program/shalini-sudarsan.md
+++ b/content/events/2026-los-angeles/program/shalini-sudarsan.md
@@ -5,6 +5,7 @@ Talk_end_time = "16:45"
 Title = "From DevOps to AIOps: The Next Leap in IT Operations"
 Type = "talk"
 Speakers = ["shalini-sudarsan"]
+Youtube = "Sx6pbz3CDMY"
 +++
 
 For years, DevOps improved delivery speed, automation, and feedback loops, which were effective until they began to fail. As the stacks expanded into microservices and multi-cloud environments, the alert stream evolved into a firehose. While additional dashboards and stricter thresholds enabled teams to respond more quickly, they did not stop recurring problems or decrease the overall noise. The solution was not "more tools." It was a playbook update. That update starts with the basics of clean data, consistent tagging, reliable telemetry, clear ownership, and real SLOs. Once the foundation is in place, apply AIOps where it excels.

--- a/content/events/2026-los-angeles/program/tom-howe.md
+++ b/content/events/2026-los-angeles/program/tom-howe.md
@@ -5,6 +5,7 @@ Talk_end_time = "17:45"
 Title = "How AI is Accelerating the Pace of Innovation (And Why Humans Still Matter)"
 Type = "talk"
 Speakers = ["tom-howe"]
+Youtube = "ejIDdULtcK4"
 +++
 
 The innovation cycle is compressing dramatically. At Hydrolix, a real-time analytics platform company, we're witnessing this transformation firsthand within our product development team. What once took months now takes days.

--- a/content/events/2027-los-angeles/about.md
+++ b/content/events/2027-los-angeles/about.md
@@ -3,26 +3,78 @@ Title = "About"
 Type = "event"
 Description = "About DevOpsDays Los Angeles 2027"
 +++
-
 <br>
-<hr>
-<h3>About Us</h3>
-<p>
-We are proud to announce the 16th Annual DevOpsDaysLA will be held Friday, April 2nd, 2027. DevOpsDaysLA is an annual event held in Southern California. The conference is volunteer-organized and dedicated to the DevOps community. DevOpsDaysLA is presented in cooperation with the Southern California Linux Expo (SCALE).
-
-<br>
-<br>
-
-<img alt="DevOps" src="/events/2027-los-angeles/devops-loop.svg" style="width:35%">
-
-<br>
-<br>
-
-<p>
-"DevOps is a set of practices that combines software development (Dev) and IT operations (Ops). It aims to shorten the systems development life cycle and provide continuous delivery with high software quality". [Loukides, Mike (7 June 2012). "What is DevOps?", http://radar.oreilly.com/2012/06/what-is-devops.html. O'Reilly Media)]
-
-<br>
-<hr>
+<div class = "row" id = "main-row">
+  <div class = "col-md-6 push-md-8" id = "left-col">
+    <hr>
+    <h3>About DevOpsDayLA</h3>
+    <h4>Our Story</h4>
+    <p>
+    Since our first event on July 14, 2010, DevOpsDayLA has been the heart of Southern California's DevOps community. Starting as the region's first DevOps meetup during the early, formative days of the DevOps movement, we became the first DevOps conference in SoCal when we joined SCaLE in 2011.
+    </p>
+    <p>
+    We started organizing just as the DevOps movement was gaining serious momentum, right after John Allspaw and Paul Hammond's legendary "10+ Deploys Per Day" talk had launched the movement at Velocity 2009, and just a month after Velocity 2010 where the DevOps community was really taking shape. We've been part of this revolution from nearly the very beginning.
+    </p>
+    <h4>16 Events, 17 Years Strong</h4>
+    <p>
+    2027 marks our 16th event, celebrating 17 years of Southern California DevOps community building. Even when COVID forced us to skip 2021, our community stayed strong and came back more connected than ever.
+    </p>
+    <p>
+    We've grown from a small meetup into an annual celebration of local innovation, shared learning, and community connection, while maintaining our core mission: showcasing the work of SoCal DevOps practitioners for SoCal DevOps practitioners.
+    </p>
+    <h4>Our Mission</h4>
+    <p>
+    DevOpsDayLA is <strong>BY the SoCal DevOps community, FOR the SoCal DevOps community.</strong>
+    </p>
+    <p>
+    We believe the best learning comes from practitioners sharing real experiences with their peers. Our goal is to provide a platform where Southern California's DevOps community can:
+    </p>
+    <ul>
+      <li>Share their transformation stories and lessons learned</li>
+      <li>Learn from challenges and successes happening right in their neighborhood</li>
+      <li>Build relationships that extend far beyond the conference</li>
+      <li>Celebrate the unique innovations happening across SoCal's diverse tech landscape</li>
+    </ul>
+    <hr>
+  </div>
+  <div class = "col-md-6 push-md-4" id = "right-col">
+    <hr>
+    <h4>Part of Something Bigger</h4>
+    <p>
+    As part of the global DevOpsDays movement and the SCaLE conference family, we connect local innovation to worldwide trends while maintaining our focus on community-driven learning and authentic experience sharing.
+    </p>
+    <ul>
+    <li><strong>DevOpsDays Global:</strong> One of 80+ DevOpsDays events worldwide, part of a movement that emphasizes practitioner-to-practitioner learning and community building.</li>
+    <li><strong>SCaLE Partnership:</strong> Co-located with the Southern California Linux Expo since 2011, leveraging shared infrastructure while maintaining our distinct DevOps community focus.</li>
+    </ul>
+    <h4>What Sets Us Apart</h4>
+    <p>
+    <strong>Local First</strong><br>
+    We prioritize talks from SoCal practitioners sharing experiences from Southern California companies and environments. Your neighborhood knowledge is our most valuable content.
+    </p>
+    <p>
+    <strong>Industry Diversity</strong><br>
+    Few tech regions match SoCal's diversity, from entertainment giants to aerospace innovators, from Venice Beach startups to established enterprises. This diversity creates unique DevOps challenges and solutions worth sharing.
+    </p>
+    <p>
+    <strong>Community Over Commerce</strong><br>
+    We're volunteer-organized with a focus on authentic knowledge sharing, not vendor pitches. Real practitioners solving real problems for real businesses.
+    </p>
+    <p>
+    <strong>Inclusive by Design</strong><br>
+    We actively work to ensure our community represents the full diversity of Southern California's tech ecosystem across geography, industry, company size, experience level, and identity.
+    </p>
+    <h4>Looking Forward</h4>
+    <p>
+    As we celebrate our 16th event, we're excited about the future of DevOps in Southern California. From agentic AI and spec-driven development to sustainable software delivery, from platform engineering evolution to edge computing challenges, our community continues to innovate and lead.
+    </p>
+    <p>
+    Join us in 2027 as we write the next chapter of SoCal DevOps history together.
+    </p>
+    <br>
+    <hr>
+  </div>
+</div>
 <style>
   p {
     text-align: justify;

--- a/content/events/2027-los-angeles/propose.md
+++ b/content/events/2027-los-angeles/propose.md
@@ -3,78 +3,188 @@ Title = "Propose"
 Type = "event"
 Description = "Propose a talk for DevOpsDays Los Angeles 2027"
 +++
-
 <br>
 <hr>
-<center><h3>Important Dates for DevOpsDaysLA 2027</h3></center>
-
-<br>
-{{< cfp_dates >}}
-
-<center><strong>DevOpsDaysLA 2027 Conference: 2nd April 2027</strong></center>
-
-<hr>
-
 <center>
-<h2><a href="https://www.socallinuxexpo.org/scale/24x/cfp" style="font-size: 1.5em; padding: 5 10px;text-decoration: none; border-radius: 5px;">>>> Submit your proposal here <<<</a></h2>
+<h3>Important Dates for DevOpsDaysLA 2027</h3>
+<br>
+<strong>Sept 1, 2026</strong>: CFP Opens
+<br>
+<strong>Nov 1, 2026</strong>: Proposal submission deadline
+<br>
+<strong>Dec 1, 2026</strong>: Acceptance notifications begin
+<br>
+<strong>Apr 2, 2027</strong>: DevOpsDayLA
+<br>
 </center>
-
+<hr>
+<center>
+  <h2><a href="https://www.socallinuxexpo.org/scale/24x/cfp" style="font-size: 1.5em; padding: 5 10px;text-decoration: none; border-radius: 5px;">&gt;&gt;&gt; Submit your proposal here &lt;&lt;&lt;</a></h2>
+</center>
 <hr>
 
+<div class = "row" id = "main-row">
+  <div class = "col-md-6 push-md-8" id = "left-col">
+<h3>DevOpsDayLA 2027 Call for Presentations</h3>
+<p><strong>Friday, April 2, 2027 | Pasadena Convention Center | 16th Annual Event</strong></p>
+<h4>What is DevOpsDayLA?</h4>
 <p>
-Calling all SoCal DevOps enthusiasts and practitioners! DevOpsDaysLA is your platform to share and learn.
- 
-There are three ways to propose a topic at DevOpsDaysLA:
-
-<p>
-
-- <strong>Conference Talk</strong>: A detailed 30-40 minute talk during the main event.
-- <strong>Lightning Talk</strong>: A quick, impactful 10-minute talk.
-- <strong>Open Space</strong>: If you'd like to lead or participate in a group discussion during the attendee-suggested Open Space lunch session, it is not necessary to propose it ahead of time. Those topics are suggested in person at the conference.
-
-If you'd like to demo your product or service, you should sponsor the event and demo it at your table.
-
-We invite you to submit your presentations on how the human factor enables, enhances, and optimizes various processes, such as:
-
-- Automation
-- Testing
-- Security
-- Platform Engineering
-- Reliability
-- Organizational Culture
-- CI/CD
-- DevOps Practices
-- Career Development in SoCal
-
-Our longstanding tradition continues, thanks to the SCaLE 24x team, who graciously donate the Pasadena Convention Center venue space, as well as their Call for Presenters submission process for our community's use.
-
-Be a part of the global DevOpsDays series and contribute to the vibrant SoCal tech community. Your voice matters, and we can't wait to hear it!
-
-Choosing talks is part art, part science; here are some factors we consider when trying to assemble the best possible program for our local audience:
-
-<p>
-
-- <strong>Broad appeal</strong>: How will your talk play out in a room of people with a variety of backgrounds? Technical deep dives need more levels to provide value for the whole room, some of whom might not use your specific tool.
-
-- <strong>New local presenters</strong>: You are the only one who can tell your story. We are very interested in the challenges and successes being experienced in our local area. We are happy to provide guidance/coaching for new speakers upon request.
-
-- <strong>Under-represented voices</strong>: We want to hear all voices, including those that may speak less frequently at similar events. Whether you're in a field not typically thought of as a technology field, you're in a large, traditional organization, or you're the only person at your organization with your background, we are interested in your unique experience.
-
-original content: We will consider talks that have already been presented elsewhere, but we prefer talks that the local area isn't likely to have already seen.
-
-- <strong>No third-party submissions</strong>: This is a community-driven event, and speakers need to be directly engaged with the organizers and attendees. If a PR firm or your marketing department is proposing the talk, you've already shown that as a speaker, you're distant from the process.
-
-- <strong>No vendor pitches</strong>: As much as we value vendors and sponsors, we will not accept a talk that appears to be a pitch for your product.
+DevOpsDayLA is Southern California's premier conference focused on the human side of technology delivery. For 16 years, we've brought together local practitioners, engineers, and leaders who know great software isn't just about tools and automation, it's about people working together effectively.
 </p>
-<strong>
+<p>
+As part of SCaLE (Southern California Linux Expo), we focus on culture, collaboration, and real-world implementation stories from local industry rather than pure technical deep-dives or vendor pitches.
+</p>
+<h4>The 2027 Lens: AI as a Boon, Not a Goon</h4>
+<p>
+AI has moved past experimentation. It's embedded in how your team codes, ships, and operates, and it's pushing a shift from "vibe coding" toward spec-driven development: clearer specifications, sandboxed agents, and the in-house harnesses teams are building to keep those agents accountable. We want to hear about yours.
+</p>
+<p>
+DevOpsDayLA 2027 isn't just another AI conference. We want the honest version (the boon and the goon) of how practitioners and organizations are adapting their mindsets, processes, and team dynamics as agentic AI, containers, token economics, and FinOps reshape day-to-day operations.
+</p>
+<h4>What We're Looking For</h4>
+<h5>Primary Focus Areas</h5>
+<p><strong>Rollout & Adoption Stories</strong></p>
 
-<br>
+- How far AI has actually gotten into your org, not just whether you tried it
+- What changed when you moved from experimenting to running AI in production
+- Honest accounts of what worked, what didn't, and what you'd do differently
+
+<p><strong>Spec-Driven Development & Agentic Workflows</strong></p>
+
+- Moving from vibe-driven to specification-driven, sandboxed AI development
+- Building and evolving your team's "harness" for agentic coding
+- Where agents speed teams up, and where they create new failure modes
+
+<p><strong>Platform Engineering & Internal Developer Platforms</strong></p>
+
+- Building IDPs and golden paths in an AI-augmented world
+- Platform SRE and reliability as a product, not just a function
+
+<p><strong>DevSecOps & Supply Chain Integrity</strong></p>
+
+- Securing AI-generated code and AI-touched supply chains
+- Embedding security inside agentic workflows, not bolting it on after
+
+<p><strong>Guardrails, Cost & Infrastructure</strong></p>
+
+- Real (not theoretical) guardrails for agentic AI in production
+- Token economics and FinOps: what AI costs you and how you manage it
+- Containers and IaC in an AI-driven pipeline
+
+<p><strong>The Human Element in an AI World</strong></p>
+
+- When humans stay critical in automated workflows
+- New skills beyond traditional DevOps; building the next generation when entry-level work is automated
+- Managing the cultural shift as AI changes daily work
+
+<p><strong>Cross-Industry SoCal Perspectives</strong></p>
+
+- DevOps in local entertainment, gaming, aerospace, retail, healthcare, and manufacturing
+- How Southern California companies are approaching these changes
+- Scaling DevOps culture across LA's diverse industries
+
+<h4>Talk Formats</h4>
+<p><strong>Full Talks (30–40 min)</strong>: In-depth case studies and implementation stories; strategic approaches to team and cultural challenges.</p>
+<p><strong>Lightning Talks (10 min)</strong>: Quick wins, practical tips, and brief "what we wish we'd known" lessons.</p>
+<p><strong>Open Spaces (at the Event)</strong>: Facilitated community discussions on emerging topics; problem-solving and networking around shared interests.</p>
+
+<h4>Example Talk Ideas</h4>
+<blockquote>
+<p>"From Vibes to Specs: How Our Team Rebuilt Development for AI": A practical story of shifting to spec-driven, sandboxed AI development.</p>
+<p>"The Harness We Built (and Rebuilt) for Agentic Coding": Real-world lessons keeping AI agents accountable in production.</p>
+<p>"What AI Is Actually Costing Us: A Token Economics Story": An honest FinOps account of AI spend, waste, and what got fixed.</p>
+<p>"Adoption, Not Adoption Theater: How Far AI Actually Got Into Our Org": A rollout story that goes past the pilot phase.</p>
+</blockquote>
+
+<h4>What We DON'T Want</h4>
+<p>Better suited for other SCaLE tracks:</p>
+
+- Pure infrastructure/cloud architecture → Infrastructure Track
+- AI/ML algorithms, model training, data science → AI Track
+- Kubernetes/Docker technical deep-dives → Cloud Native Track
+- Security tools and vulnerability scanning → Security Track
+- Linux system administration → General/Infrastructure Track
+- Database optimization and management → PostgreSQL Track
+- Pure development practices → Developer Track
+
+<p>We also avoid:</p>
+
+- Vendor pitches disguised as educational content
+- Tool demos without implementation stories
+- Abstract AI discussion without practical application
+- Content repeating previous years without fresh insight
+- Third-party submissions from PR firms or marketing. Speakers must be directly engaged with our community-driven event.
 
 <hr>
-</strong>
+  </div>
+  <div class = "col-md-6 push-md-4" id = "right-col">
+<h4>Ideal Speakers</h4>
 
-<br>
+- <strong>Southern California Practitioners First:</strong> We prioritize people doing the work locally over people selling solutions.
+- <strong>Local Industry Diversity:</strong> We especially encourage speakers from SoCal's gaming, entertainment, aerospace, healthcare, retail, manufacturing, and other established industries.
+- <strong>New Local Voices:</strong> You are the only one who can tell your story. We're happy to provide speaker coaching for first-time presenters.
+- <strong>Under-represented Perspectives:</strong> Whether you're in a non-traditional field, a large organization, or the only person at your company with your background, we want your unique experience.
+- <strong>All Experience Levels:</strong> From a seasoned architect at a major studio to someone who just solved their first DevOps challenge at a local startup, we want to hear your story.
+- <strong>SoCal Companies:</strong> We welcome speakers from Los Angeles, Orange County, Inland Empire, and San Diego companies of all sizes.
+
+<h4>What We Prioritize</h4>
+
+- Real-world experience over abstract theory
+- Before/after transformations backed by tangible metrics
+- Decisions and tradeoffs over pure tool demos
+- Unexpected lessons learned directly from practitioners
+
+<h4>Speaker Commitment Requirements</h4>
+
+- <strong>Attendance Confirmation:</strong> Accepted speakers must confirm in-person attendance with contact info (including phone number) to prevent no-shows.
+- <strong>Content Freshness:</strong> Confirm your talk offers new insights and hasn't been presented at DevOpsDayLA before without significant updates.
+- <strong>Vendor Disclosure:</strong> Clearly indicate if your talk includes vendor content, product demos, or commercial messaging.
+
+<h2>Submission Guidelines</h2>
+<h3>How to Submit</h3>
+<p>Submit your proposal through the SCALE 24x CFP system at <strong><a href="https://www.socallinuxexpo.org/scale/24x/cfp">www.socallinuxexpo.org/scale/24x/cfp</a></strong>.</p>
+<p><strong>New to SCaLE?</strong> Create an account at <strong><a href="https://www.socallinuxexpo.org/user/">https://www.socallinuxexpo.org/user/</a></strong>.</p>
+<p><strong>Returning speakers?</strong> Reset your password for 2027; your CFP account is separate from your speaker profile.</p>
+<p><strong>Note:</strong> DevOpsDayLA is part of SCaLE 24x. Submitting through the SCALE CFP system ensures your proposal reaches our review committee.</p>
+
+<h3>What You'll Need</h3>
+<h4>Required Information</h4>
+<p><strong>Talk Details:</strong></p>
+<ul>
+<li><strong>Title</strong></li>
+<li><strong>Topic:</strong> Select "DevOpsDayLA"</li>
+<li><strong>Tags:</strong> #devops #culture #socal #ai #agentic</li>
+<li><strong>Audience level</strong></li>
+<li><strong>Brief Description:</strong> One sentence, up to 255 characters</li>
+<li><strong>Short Abstract:</strong> 4–5 sentences, up to 600 characters</li>
+<li><strong>Long Abstract</strong> (up to 10,000 characters): background/context, specific implementation or lessons learned, key takeaways, and why it matters to the SoCal DevOps community</li>
+</ul>
+<p><strong>Speaker Information:</strong></p>
+<ul>
+<li>Speaker bio</li>
+<li>Primary contact email</li>
+<li>Confirmation that content is fresh</li>
+</ul>
+<h4>Optional but Recommended</h4>
+<ul>
+<li><strong>Presentation File:</strong> Slides or outline (max 55MB)</li>
+<li><strong>Message to Reviewers:</strong> Special context, A/V needs, or speaker diversity info</li>
+</ul>
+
+<h3>Timeline</h3>
+<ul>
+<li><strong>Sept 1, 2026:</strong> CFP Opens</li>
+<li><strong>Nov 1, 2026:</strong> Submission deadline</li>
+<li><strong>Dec 1, 2026:</strong> Acceptance notifications begin</li>
+<li><strong>Apr 2, 2027:</strong> DevOpsDayLA</li>
+</ul>
+
+<h3>Questions?</h3>
+<p>Contact the DevOpsDayLA organizing team via the SCALE CFP system or <strong>{{< email_organizers >}}</strong>.</p>
+<p><strong>DevOpsDayLA 2027: AI as a Boon, Not a Goon</strong></p>
 <hr>
+  </div>
+</div>
 <style>
   p {
     text-align: justify;

--- a/content/events/2027-los-angeles/registration.md
+++ b/content/events/2027-los-angeles/registration.md
@@ -7,18 +7,18 @@ Description = "Registration for DevOpsDays Los Angeles 2027"
 <br>
 <hr>
 <h3>Join the event</h3>
-DevOpsDaysLA is a co-located event at <a href="http://www.socallinuxexpo.org/scale/24x/">SCALE 24x</a>. Access to DevOpsDay LA is available with any level of <a href="https://register.socallinuxexpo.org/reg6/">SCALE registration</a>, including the expo only pass ($20) or the full access pass ($80 early-bird or $85 afterwards).
+DevOpsDaysLA is a co-located event at <a href="http://www.socallinuxexpo.org/scale/24x/">SCALE 24x</a>. Access to DevOpsDay LA is available with any level of <a href="https://register.socallinuxexpo.org/reg23/">SCALE registration</a>, including the expo only pass ($20) or the full access pass ($80 early-bird or $85 afterwards).
 <ul>
 <br>
 <li> <b>Expo Only</b>: The expo only pass will provide you with access to DevOpsDay, exhibitor area, and evening social activities.
 <li> <b>Full Access</b>: The full access pass will provide with access to all events Thursday - Sunday.
 </ul>
-Registration is available online via SCALE's <a href="https://register.socallinuxexpo.org/reg6/">website</a>.
+Registration is available online via SCALE's <a href="https://register.socallinuxexpo.org/reg23/">website</a>.
 <strong>
 <br>
 <hr>
 <div style="text-align: center">
-  <a href="https://register.socallinuxexpo.org/reg6/" style="font-size: 42px;">Register!</a>
+  <a href="https://register.socallinuxexpo.org/reg23/" style="font-size: 42px;">Register!</a>
 </div>
 </strong>
 <br>

--- a/content/events/2027-los-angeles/sponsor.md
+++ b/content/events/2027-los-angeles/sponsor.md
@@ -3,47 +3,100 @@ Title = "Sponsor"
 Type = "event"
 Description = "Sponsor DevOpsDays Los Angeles 2027"
 +++
-
 <br>
 <hr>
-<h3>Become A Sponsor</h3>
+<center><h2>Become A Sponsor</h2></center>
+<center><h3>AI as a Boon, Not a Goon: Celebrating 16 Years of Excellence</h3></center>
+<hr>
+<!-- <div style="text-align: center"><a href="https://assets.devopsdays.org/events/2027/los-angeles/devopsdayla2027_sponsor.pdf" style="font-size: 42px;">➡️ Download Our Sponsor Prospectus PDF ⬅️</a></div> -->
+<hr>
+<br>
 
-<p>
-Now in its 16th year, DevOpsDayLA is Southern California's only annual conference focused on the practice of DevOps - a proven, joint approach that emphasizes the need for collaboration between the Software Development (Dev) and Operations/IT Infrastructure (Ops) teams within an organization to continually deliver high-quality solutions.
+<div class = "row" id = "main-row">
+  <div class = "col-md-6 push-md-8" id = "left-col">
+<p>Now in its <strong>16th anniversary</strong> year, DevOpsDayLA is Southern California's premier conference focused on the human side of technology delivery. We bring together practitioners, engineers, and leaders who understand that great software isn't just about tools and automation, it's about <strong>people working together effectively</strong>.</p>
 
-It is a part of the worldwide series of DevOpsDays events held annually, sanctioned, and supported by the DevOpsDays global core team. DevOpsDayLA is volunteer-organized and offers a variety of opportunities to learn and share experiences about how the human factor enables, enhances, and optimizes technological processes, with a focus on :
+<p>Part of the global DevOpsDays movement and sanctioned by the DevOpsDays global core team, DevOpsDayLA is volunteer-organized and co-located with the Southern California Linux Expo (SCALE). We focus on how teams adapt and collaborate as technology rapidly evolves, with particular emphasis on:</p>
 
-- Automation
-- Testing
-- Security
-- Platform Engineering
-- Reliability
-- Organizational Culture
-- CI/CD
-- Devops Practices
-- And Career Development
+<ul>
+<li>DevOps transformation and culture change</li>
+<li>Platform engineering and developer experience</li>
+<li>Agentic AI, spec-driven development, and guardrails in production</li>
+<li>Cross-industry implementation patterns</li>
+<li>Security, supply chain integrity, and operational boundaries</li>
+<li>Career development and team building</li>
+<li>Modern collaboration practices</li>
+<li>Organizational change management</li>
+</ul>
 
-DevOpsDayLA sponsors have the opportunity to offer job opportunities, demonstrations of the latest tools, and world-class service offerings to facilitate organizations' DevOps journey. The conference is presented with the support of the Southern California Linux Expo (SCALE). It provides a relaxed, casual, and diverse environment where experienced professionals, evangelists, agile practitioners, developers, job seekers, business executives, educators, students, and curiosity seekers can connect and attend talks on current topics.
+<h3>Why Sponsor DevOpsDayLA 2027?</h3>
 
-For additional information, please contact us at los-angeles@devopsdays.org.
+<p><strong>Reach Your Target Audience:</strong> Connect with 400+ engaged DevOps practitioners, engineers, and decision-makers from across Southern California's diverse technology landscape, from entertainment and aerospace to startups and Fortune 500 companies.</p>
 
-<p>
-The best thing to do is send engineers to interact with the experts at DevOpsDays on their own terms.
+<p><strong>Community Impact:</strong> Position your brand as a contributor to Southern California's vibrant DevOps community while supporting diversity in technology and the development of the next generation of practitioners.</p>
 
-<strong>Note:</strong> We do not share attendee lists.
+<p><strong>Quality Engagement:</strong> Our sponsors benefit most when they send technical teams to interact authentically with attendees, participate in discussions, and build meaningful connections beyond traditional vendor relationships.</p>
 
-<div style="text-align: center"><a href="https://assets.devopsdays.org/events/2027/los-angeles/devopsdayla2027_sponsor.pdf" style="font-size: 42px;">➡️ Download Our Sponsor Prospectus PDF ⬅️</a></div>
+<h3>Sponsorship Opportunities</h3>
 
-<h3>Exclusive Sponsorships</h3>
+<p>We offer multiple sponsorship tiers designed to match your goals:</p>
 
-<img alt="Exclusive Sponsorships" src="/events/2027-los-angeles/exclusive_sponsorships.png" style="width:60%">
+<ul>
+<li><strong>Gold Sponsor ($4,000):</strong> Maximum visibility with dedicated display table, 1-minute audience introduction, and comprehensive marketing inclusion</li>
+<li><strong>Silver Sponsor ($2,500):</strong> Strong brand visibility with dedicated logo placement and social media promotion</li>
+<li><strong>Recruiting Sponsor ($2,000):</strong> Focused on talent acquisition with job board placement and networking hour sponsorship</li>
+<li><strong>Startup Sponsor ($750):</strong> Community-friendly pricing for early-stage companies</li>
+</ul>
 
-<h3>Sponsorship Packages</h3>
+<p>Add-on opportunities include lunch sponsorship, coffee breaks, social events, and our special 16th Anniversary commemorative sponsorship.</p>
+  </div>
+  
+  <div class = "col-md-6 pull-md-4" id = "right-col">
+<h3>Important Notes</h3>
 
-<img alt="Exclusive Sponsorships" src="/events/2027-los-angeles/sponsorship_packages.jpg" style="width:60%">
+<p><strong>No Sponsored Talks:</strong> We maintain our community-driven content model. Sponsors are welcome to submit talk proposals through our standard CFP process and propose Open Spaces topics (non-sales focused).</p>
 
+<p><strong>Authentic Engagement:</strong> The most successful sponsors bring engineers to interact with attendees, participate in technical discussions, and contribute to the community conversation.</p>
+
+<p><strong>Privacy Protection:</strong> We do not share attendee contact information. Sponsors collect information directly from interested attendees at their booths or through opt-in activities.</p>
+
+<h3>Ready to Sponsor DevOpsDayLA 2027?</h3>
+
+<p>Contact our sponsorship team at <strong>{{< email_organizers >}}</strong> for detailed sponsorship packages, custom opportunities, and to discuss how your sponsorship can support our community goals.</p>
+
+<p><strong>DevOpsDayLA 2027: AI as a Boon, Not a Goon</strong></p>
 
 <hr>
+<center>
+  <h2><a href="mailto:los-angeles@devopsdays.org?subject=DevOpsDayLA 2027 Sponsorship Inquiry" style="font-size: 1.5em; padding: 5 10px;text-decoration: none; border-radius: 5px;">&gt;&gt;&gt; Contact Us &lt;&lt;&lt;</a></h2>
+</center>
+<hr>
+
+<h4>Sponsorship Timeline</h4>
+
+<ul>
+<li><strong>October 2026:</strong> Sponsorship packages available</li>
+<li><strong>November 2026:</strong> Early sponsor commitment deadline</li>
+<li><strong>December 2026:</strong> Sponsor materials due</li>
+<li><strong>January 2027:</strong> Sponsor promotion begins</li>
+<li><strong>April 2, 2027:</strong> DevOpsDayLA Conference</li>
+</ul>
+
+<h4>Frequently Asked Questions</h4>
+
+<p><strong>Q: Can we present a sponsored talk?</strong><br>
+A: No, we maintain a community-driven content model. However, sponsors are welcome to submit talk proposals through our standard CFP process.</p>
+
+<p><strong>Q: Do you provide attendee contact lists?</strong><br>
+A: No, we protect attendee privacy. Sponsors collect information directly from interested attendees.</p>
+
+<p><strong>Q: What size is the expected audience?</strong><br>
+A: We expect 400+ DevOps practitioners, engineers, and decision-makers from across Southern California.</p>
+
+<p><strong>Q: Are there opportunities for custom sponsorship?</strong><br>
+A: Yes, please contact us to discuss custom sponsorship opportunities that align with your goals.</p>
+  </div>
+</div>
 <style>
   p {
     text-align: justify;

--- a/content/events/2027-los-angeles/volunteer.md
+++ b/content/events/2027-los-angeles/volunteer.md
@@ -3,34 +3,58 @@ Title = "Volunteer"
 Type = "event"
 Description = "About DevOpsDays Los Angeles 2027"
 +++
-
 <br>
-<hr>
-<h3>Become A Volunteer</h3>
-
-<p>
-DevOpsDaysLA, now in its 16th year, is Southern California's only annual conference focused on the practice of DevOps - a proven, joint approach that emphasizes the need for collaboration between the Development (Dev) and Operations/IT (Ops) teams within an organization to continually deliver high-quality solutions. The conference provides a relaxed, casual, and diverse environment where experienced professionals, evangelists, agile practitioners, developers, job seekers, business executives, educators, students, and curiosity seekers can connect and attend talks on current topics. DevOpsDaysLA sponsors offer job opportunities, demonstrations of the latest tools, and world-class service offerings to facilitate organizations' DevOps journey. The conference typically attracts 800 people.
-
-<p>
-
-We are seeking enthusiastic volunteers to help with conference setup, attendee management, and put away. Volunteering offers substantial career development benefits including:
-
-- Introductions to seasoned technology leaders & professionals
-- Opportunities to hear talks
-- Exceptional resume experience
-- Strong differentiation when applying for internships
-
-<p>
-
-The conference will provide volunteers with breakfast, lunch, and snacks throughout the day. They will also receive a special "Thank You" swag gift.
-
-<div class="row">
-<div class="alert alert-info" role="alert">
-<p>
-If you are interested in volunteering, please contact the DevOpsDaysLA organizers at {{< email_organizers >}}
+<div class="row" id="main-row">
+  <div class="col-md-6 push-md-8" id="left-col">
+    <hr>
+    <h3>Become A Volunteer</h3>
+    <h4>Join DevOpsDayLA 2027: AI as a Boon, Not a Goon</h4>
+    <p>DevOpsDayLA, now in its 16th anniversary year, is Southern California's premier conference focused on the human side of technology delivery. We bring together practitioners, engineers, and leaders who understand that great software isn't just about tools and automation, it's about people working together effectively.</p>
+    <p>As part of the global DevOpsDays movement and co-located with the Southern California Linux Expo (SCALE), the conference provides a welcoming environment where experienced professionals, evangelists, developers, students, and technology enthusiasts can connect and learn from authentic implementation stories. Our 2027 theme explores how teams adapt and collaborate as agentic AI and spec-driven development reshape the technology landscape.</p>
+    <h4>Why Volunteer with DevOpsDayLA?</h4>
+    <p>We're seeking enthusiastic volunteers to help both in the months leading up to the conference and during the event itself. Volunteering offers substantial career development benefits including:</p>
+    <ul>
+      <li><strong>Networking opportunities:</strong> Direct introductions to seasoned technology leaders and professionals from across Southern California's diverse tech ecosystem</li>
+      <li><strong>Learning access:</strong> Opportunities to attend talks and participate in discussions about modern DevOps practices</li>
+      <li><strong>Resume enhancement:</strong> Exceptional experience that demonstrates community involvement, event management, and professional communication skills</li>
+      <li><strong>Career differentiation:</strong> Strong advantage when applying for internships, jobs, or advancing in your current role</li>
+      <li><strong>Community connection:</strong> Become part of Southern California's vibrant DevOps community</li>
+    </ul>
+    <h4>Pre-Event (September 2026 - April 2027)</h4>
+    <ul>
+      <li><strong>CFP Review:</strong> Evaluate speaker submissions and help select talks that deliver practical value to the SoCal DevOps community</li>
+      <li><strong>Marketing & Social Media:</strong> Create content, manage LinkedIn presence, and amplify event messaging across professional networks</li>
+      <li><strong>Sponsor Outreach:</strong> Research potential sponsors, craft outreach emails, and help build relationships with companies that support our community</li>
+      <li><strong>Community Engagement:</strong> Connect with local DevOps meetups, user groups, and professional organizations to encourage attendance</li>
+    </ul>
+  </div>
+  <div class="col-md-6 pull-md-4" id="right-col">
+    <hr>
+    <h4>Volunteer Opportunities</h4>
+    <p>We need help throughout the planning process and during the event, including:</p>
+    <ul>
+      <li><strong>Student Outreach:</strong> Partner with universities and coding bootcamps to bring emerging talent to the conference</li>
+      <li><strong>Corporate Outreach:</strong> Engage with SoCal companies across entertainment, aerospace, healthcare, and tech to drive professional attendance</li>
+      <li><strong>Speaker Coordination:</strong> Help with speaker communications, logistics planning, and content promotion</li>
+    </ul>
+    <h4>Day-of-Event (April 2, 2027)</h4>
+    <ul>
+      <li><strong>Registration & Check-in:</strong> Welcome attendees, manage badge distribution, and provide event orientation</li>
+      <li><strong>Session Management:</strong> Support speakers, manage room logistics, and ensure smooth presentation flow</li>
+      <li><strong>Technical Support:</strong> Assist with A/V setup, livestream coordination, and troubleshooting</li>
+      <li><strong>Open Spaces Facilitation:</strong> Help attendees propose topics, organize discussions, and manage collaborative sessions</li>
+      <li><strong>Attendee Experience:</strong> Provide information, resolve issues, and ensure positive conference experience</li>
+      <li><strong>Event Logistics:</strong> Setup, breakdown, and general problem-solving throughout the day</li>
+    </ul>
+    <h4>What We Provide</h4>
+    <p>The conference will provide volunteers with coffee, lunch, and snacks throughout the day.</p>
+    <h4>Get Involved</h4>
+    <div class="alert alert-info" role="alert">
+      <p>If you're interested in volunteering and becoming part of our 16th anniversary celebration, please contact the DevOpsDayLA organizers at <strong>{{< email_organizers >}}</strong></p>
+    </div>
+    <h4>DevOpsDayLA 2027: AI as a Boon, Not a Goon</h4>
+  </div>
 </div>
-</div>
-
 <hr>
 <style>
   p {

--- a/content/events/2027-los-angeles/welcome.md
+++ b/content/events/2027-los-angeles/welcome.md
@@ -4,25 +4,63 @@ Type = "welcome"
 aliases = ["/events/2027-los-angeles/"]
 Description = "DevOpsDays Los Angeles 2027"
 +++
-
+<br>
+<div style="text-align: center"><a href="https://register.socallinuxexpo.org/reg23/" style="font-size: 42px;">➡️ Register and join us! ⬅️</a></div>
 <div class = "row" id = "main-row">
   <div class = "col-md-6 push-md-8" id = "left-col">
-    <h3>What is DevOpsDaysLA?</h3>
     <hr>
-    <p>
-    DevOpsDaysLA is Southern California's only annual conference focused on the practice of DevOps - a proven, joint approach that emphasizes the need for collaboration between the Software Development (Dev) and Operations/IT Infrastructure (Ops) teams within an organization to continually deliver high-quality solutions.
-    <br>
-    <p>
-    DevOpsDaysLA offers opportunities to learn and share experiences about how the human factor enables, enhances, and optimizes automation, testing, security, platform engineering, reliability, organizational culture, CI/CD, DevOps practices, and career development. It is a part of the worldwide series of DevOpsDays events held annually, sanctioned, and supported by the DevOpsDays global core team.
+    <h3>DevOpsDayLA 16x 2027: AI as a Boon, Not a Goon</h3>
+    <p><strong>Friday, April 2, 2027 | Pasadena Convention Center</strong></p>
+    <h4>Welcome Home, SoCal DevOps Community!</h4>
+    <p>DevOpsDayLA is Southern California's premier DevOps community gathering, celebrating our milestone 16th event in 2027. We're <strong>BY the SoCal DevOps community, FOR the SoCal DevOps community.</strong></p>
+    <p>Your chance to share your expertise, learn from your neighbors, and strengthen the bonds that make our local tech ecosystem so vibrant.</p>
+    <p>You're working in a world where AI has moved past the experimentation phase—it's writing code, provisioning infrastructure, and reshaping how teams work together, for better and for worse. Whether AI has been a boon on your team or has created new headaches to manage, your SoCal experience matters.</p>
+    <h4>Why Attend DevOpsDayLA 2027?</h4>
+    <ul>
+    <li><strong>Learn from Your SoCal Neighbors</strong> - Real stories from implementing DevOps across Southern California's incredibly diverse technology landscape—from entertainment and aerospace to startups and Fortune 500 companies. Discover how your fellow practitioners are adapting to agentic workflows, spec-driven development, and AI-driven infrastructure while maintaining focus on what makes teams successful.</li>
+    <li><strong>Share Your Experience</strong> - This is your platform to showcase the unique DevOps innovations happening right here in Southern California, from Venice Beach to Irvine and everywhere in between.</li>
+    <li><strong>Build Community</strong> - Connect with fellow practitioners who understand the specific challenges and opportunities of working in SoCal's high-cost, highly competitive, incredibly diverse tech environment.</li>
+    <li><strong>Celebrate Innovation</strong> - Discover how your fellow SoCal DevOps practitioners are tackling platform engineering, AI guardrails, token economics and FinOps, and the future of collaborative software delivery.</li>
+    </ul>
+    <h4>What Makes SoCal DevOps Special</h4>
+    <p>Southern California isn't just any tech region—we're home to an incredibly diverse technology landscape:</p>
+    <ul>
+    <li>Entertainment & Media: Disney, Netflix, Sony, Warner Bros</li>
+    <li>Aerospace & Defense: SpaceX, Northrop Grumman, Boeing</li>
+    <li>E-commerce & Consumer: Snap, Hulu, Activision Blizzard</li>
+    <li>Retail & Logistics: Target, ALDI, massive distribution networks</li>
+    <li>Robotics & Automation: Leading edge robotics companies and research</li>
+    <li>Emerging Tech: Self-driving cars, space technology, content creation</li>
+    <li>Traditional Industries Going Digital: Healthcare, manufacturing, supply chain</li>
+    <li>Startups to Fortune 500: From Santa Monica to Pasadena, everywhere in between</li>
+    </ul>
+    <p>Your experience implementing DevOps in these unique SoCal environments is exactly what your fellow practitioners need to hear.</p>
     <hr>
   </div>
   <div class = "col-md-6 push-md-4" id = "right-col">
+    <hr>
+    <h4>Event Details</h4>
+    <p><strong>Date:</strong> Friday, April 2, 2027<br>
+    <strong>Time:</strong> 9:00 AM - 6:00 PM<br>
+    <strong>Location:</strong> Pasadena Convention Center, 300 E Green St, Pasadena, CA 91101<br>
+    <strong>Format:</strong> In-person</p>
+    <p><em>Part of SCaLE 24x - Co-located with the Southern California Linux Expo</em></p>
+    <h4>Get Involved</h4>
+    <ul>
+    <li><strong>{{< event_link page="propose" text="Submit a Proposal" >}}</strong> - Share your SoCal DevOps story</li>
+    <li><strong><a href="https://register.socallinuxexpo.org/reg23/">Register to Attend</a></strong> - Join the conversation</li>
+    <li><strong>{{< event_link page="sponsor" text="Become a Sponsor" >}}</strong> - Support our community</li>
+    <li><strong>{{< event_link page="volunteer" text="Volunteer" >}}</strong> - Help make it happen</li>
+    </ul>
+    <p><strong>This is our community. These are our stories. Let's share them together.</strong></p>
+    <p>
+    Relive the brilliance of our <strong>2026 DevOps talks</strong> in our <a href="https://devopsdays.org/events/2026-los-angeles/program">video collection</a>. Immerse yourself in the wisdom shared by experts, rekindling innovative ideas and strategies. These timeless talks continue to illuminate the DevOps landscape.
+    </p>
     <div style="text-align: center; ">
       {{< event_logo >}}
     </div>
+    <hr>
   </div>
-
-  
 </div>
 
 <br><br>

--- a/data/events/2027/los-angeles/main.yml
+++ b/data/events/2027/los-angeles/main.yml
@@ -14,9 +14,9 @@ startdate: 2027-04-02T08:00:00-07:00 # The start date of your event. Leave blank
 enddate: 2027-04-02T22:00:00-07:00 # The end date of your event. Leave blank if you don't have a venue reserved yet.
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start:  # start accepting talk proposals.
-cfp_date_end:   # close your call for proposals.
-cfp_date_announce:  # inform proposers of status
+cfp_date_start: 2026-09-01T00:00:00-08:00 # start accepting talk proposals.
+cfp_date_end:   2026-11-01T00:00:00-08:00 # close your call for proposals.
+cfp_date_announce: 2026-12-01T00:00:00-08:00 # inform proposers of status
 
 cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
@@ -41,11 +41,11 @@ nav_elements: # List of pages you want to show up in the navigation of your page
     url: https://www.visitpasadena.com/convention-center/
   #- name: registration
   #  url: https://register.socallinuxexpo.org/reg6/
-  #- name: CFP
-  #  url: https://www.socallinuxexpo.org/scale/24x/cfp
+  - name: CFP
+    url: https://www.socallinuxexpo.org/scale/24x/cfp
   #- name: program
   #- name: speakers
-  #- name: propose
+  - name: propose
   - name: volunteer
   - name: sponsor
   - name: contact

--- a/data/events/2027/los-angeles/main.yml
+++ b/data/events/2027/los-angeles/main.yml
@@ -82,8 +82,6 @@ team_members: # Name is the only required field for team members.
   - name: "Rich Horace"
     image: "rich.jpg"
     linkedin: "https://www.linkedin.com/in/richhorace/"
-  - name: "Jay Cui"
-    image: "jay.jpg"
 
 organizer_email: "los-angeles@devopsdays.org" # Put your organizer email address here
 


### PR DESCRIPTION
**Summary of changes:**

- Updated 2027 Los Angeles event pages
- Updated registration links to SCALE 24x
- Enabled the CFP in `main.yml`

**Tested:**

- Locally
