### PR TITLE
[VILNIUS-2026] Hide links to Call for Papers form

### DIFF
--- a/content/events/2026-vilnius/welcome.md
+++ b/content/events/2026-vilnius/welcome.md
@@ -49,12 +49,12 @@ Description = "devopsdays Vilnius 2026"
                     <a class="btn btn-secondary btn-block button-secondary"
                         style="background-color: #1bff9f; border-color: #1bff9f; color: #000000"
                         href="https://talks.devopsdays.org/devopsdays-vilnius-2026/schedule">Check Program</a>
-                </div>
+                </div><!--
                 <div class="d-flex p-2">
                     <a class="btn btn-secondary btn-block button-secondary"
                         style="background-color: #1bff9f; border-color: #1bff9f; color: #000000"
                         href="https://talks.devopsdays.org/devopsdays-vilnius-2026/cfp">Propose a Ignite talk</a>
-                </div>
+                </div> -->
                 <div class="d-flex p-2">
                     <a class="btn btn-secondary btn-block button-secondary"
                         style="background-color: #1bff9f; border-color: #1bff9f; color: #000000"

--- a/data/events/2026/vilnius/main.yml
+++ b/data/events/2026/vilnius/main.yml
@@ -32,8 +32,8 @@ nav_elements: # List of pages you want to show up in the navigation of your page
   - name: speakers
   - name: program
     url: "https://talks.devopsdays.org/devopsdays-vilnius-2026/schedule/"
-  - name: propose
-    url: "https://talks.devopsdays.org/devopsdays-vilnius-2026/cfp"
+#  - name: propose
+#    url: "https://talks.devopsdays.org/devopsdays-vilnius-2026/cfp"
   - name: sponsor
   - name: location
   - name: contact


### PR DESCRIPTION
Since deadlines for submitting papers/ignites have all closed, removing links to CFP form from navigation to avoid confusion
- Hidden `Propose` link from event page navigation
- Hidden button to `Submit an ignite` from event welcome page