### PR TITLE
[BSB-2026] Open CFP

### DIFF
--- a/content/events/2026-brasilia/welcome.md
+++ b/content/events/2026-brasilia/welcome.md
@@ -35,7 +35,6 @@ Description = "DevOpsDays Brasília 2026"
         {{< event_link page="contact" text="Entre em contato com os organizadores" >}}
       </div>
     </div>
-    <!-- Uncomment when the CFP opens
     <div class="row">
       <div class="col-md-2">
         <strong>CFP</strong>
@@ -44,7 +43,6 @@ Description = "DevOpsDays Brasília 2026"
         {{< event_link url-key="cfp_link" text="Submeta a sua talk!" >}}
       </div>
     </div>
-    -->
     <!-- Uncomment when registration opens
     <div class="row">
       <div class="col-md-2">

--- a/data/events/2026/brasilia/main.yml
+++ b/data/events/2026/brasilia/main.yml
@@ -16,12 +16,12 @@ startdate: 2026-11-14T09:00:00-03:00
 enddate: 2026-11-14T19:00:00-03:00
 
 # Leave CFP dates blank if you don't know yet, or set all three at once.
-cfp_date_start: "" # start accepting talk proposals.
-cfp_date_end: "" # close your call for proposals.
+cfp_date_start: "2026-08-28T07:13:00-03:00" # start accepting talk proposals.
+cfp_date_end: "2026-09-17T08:59:00-03:00" # close your call for proposals.
 # cfp_date_announce: "" # inform proposers of status
 
 # cfp_open: "true"
-# cfp_link: "" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
+cfp_link: "https://cfp.ninja/e/devops-days-braslia-2026" #if you have a custom link for submitting proposals, add it here. This will control the Propose menu item as well as the "Propose" button.
 
 registration_date_start: # start accepting registration. Leave blank if registration is not open yet
 registration_date_end: # close registration. Leave blank if registration is not open yet.


### PR DESCRIPTION
Opened the CFP for DevOpsDays Brasília 2026:

- Set cfp_date_start / cfp_date_end (2026-08-28 to 2026-09-17, matching the CFP platform)
- Set cfp_link to our CFP page: https://cfp.ninja/e/devops-days-braslia-2026
- Restored the CFP row on the welcome page

This addresses the earlier review note on #16049 about the CFP fields being unset.