### PR TITLE
[HFX-2026] Add schedule link

### DIFF
--- a/content/events/2026-halifax/welcome.md
+++ b/content/events/2026-halifax/welcome.md
@@ -152,6 +152,7 @@ Description = "DevOpsDays Halifax 2026 — September 29, 2026 in downtown Halifa
 <p class="tagline">A day dedicated to learning, collaboration, and community for tech practitioners across Atlantic Canada and beyond.</p>
 <div class="hfx26-cta-row">
 <a class="hfx26-btn hfx26-btn-primary" href="https://tickets.devopsdays.org/devopsdays-halifax/2026/">Get Tickets</a>
+<a class="hfx26-btn hfx26-btn-secondary" href="https://talks.devopsdays.org/halifax-2026/schedule/">View Schedule</a>
 <a class="hfx26-btn hfx26-btn-secondary" href="../sponsor/">Become a Sponsor</a>
 </div>
 </div>
@@ -159,6 +160,7 @@ Description = "DevOpsDays Halifax 2026 — September 29, 2026 in downtown Halifa
 <h3>Explore</h3>
 <div class="nav-grid">
 <a class="hfx26-nav-link" href="../registration/">Get Tickets</a>
+<a class="hfx26-nav-link" href="https://talks.devopsdays.org/halifax-2026/schedule/">Schedule</a>
 <a class="hfx26-nav-link" href="../location/">Venue Info</a>
 <a class="hfx26-nav-link" href="../sponsor/">Become a Sponsor</a>
 <a class="hfx26-nav-link" href="../convince-your-boss/">Convince Your Boss</a>

--- a/data/events/2026/halifax/main.yml
+++ b/data/events/2026/halifax/main.yml
@@ -23,6 +23,8 @@ location_address: "1800 Argyle St Unit 801, Halifax, NS B3J 3N8"
 nav_elements:
   - name: location
   - name: registration
+  - name: schedule
+    url: "https://talks.devopsdays.org/halifax-2026/schedule/"
   - name: sponsor
   - name: contact
   - name: conduct


### PR DESCRIPTION
The schedule is published on Pretalx. Adding links to it from the site.

## Changes

- `data/events/2026/halifax/main.yml` - added `schedule` to `nav_elements` pointing at the Pretalx schedule
- `content/events/2026-halifax/welcome.md` - added a "View Schedule" button to the hero and a "Schedule" item in the Explore bar

All changes scoped to `content/` and `data/`.