### PR TITLE
[LON-2026] add links page for the day

### DIFF
--- a/content/events/2026-london/links.md
+++ b/content/events/2026-london/links.md
@@ -1,0 +1,23 @@
++++
+Title = "Links"
+Type = "event"
+Description = "Useful links for DevOpsDays London 2026."
++++
+
+<h2>Program</h2>
+
+<p>Full program (speakers, schedule and Open Space slots): <a href="/events/2026-london/program">View the program</a>.</p>
+
+<h2>Open Spaces</h2>
+
+<p>See <a href="/pages/open-space-format">Open Space format</a> for how the sessions work.</p>
+
+<p>Optional pre-event Open Space suggestions form (if you want to collect topics before the event): <a href="https://forms.gle/JBHp8rKrqnQRdVuh9">Submit Open Space suggestions (Google Form)</a>.</p>
+
+<p>Open Space Miro board (used for scheduling & dot-voting during the conference): <a href="https://miro.com/app/board/uXjVJLhalNQ=/">Open Space Miro board</a>.</p>
+
+<h2>Job board</h2>
+
+<p>Job board submissions: We plan to host a job board during the event for companies and attendees to share open roles. To submit a role ahead of the event please use: <a href="https://forms.gle/eMrxiHEnicUe359x7">Job board submission form</a>.</p>
+
+<p>See the submissions! <a href="https://miro.com/app/board/uXjVJEsM4uM=/?share_link_id=257139665039">Job board Miro board</a>.</p>


### PR DESCRIPTION
Add links page to schedule, openspaces miro/form and jobboard miro/form