### PR TITLE
[DEN-2026] Add Mezmo as Gold Sponsor and Focused as Bronze

### DIFF
--- a/content/events/2026-denver/location.md
+++ b/content/events/2026-denver/location.md
@@ -17,8 +17,6 @@ This year’s event will be held in Downtown Denver at [Bierstadt Lagerhaus](htt
 ### Parking
 There is extremely limited parking at the brewery, with open street parking surrounding. 
 
-We also have parking available for attendees at no additional cost at the [LAZ Parking - Coors Field Garage - 2701 Blake Street Denver, CO 80205](https://maps.app.goo.gl/uGmJCMde2H5NW1hA6), 1 block away from the venue. A QR code will be sent out to attendees the night before the event which can be used for parking entry.
-
 If possible, we recommend carpooling or taking public transportation. Bierstadt is a 10-15 minute walk to numerous stations!
 
 <!--### Parking Location

--- a/data/events/2026/denver/main.yml
+++ b/data/events/2026/denver/main.yml
@@ -121,6 +121,8 @@ sponsors:
     level: silver
   - id: rave
     level: bronze
+  - id: focusedlabs
+    level: bronze
   - id: code-talent
     level: community
   - id: kubeevents

--- a/data/events/2026/denver/main.yml
+++ b/data/events/2026/denver/main.yml
@@ -101,6 +101,8 @@ sponsors:
     level: gold
   - id: devops-institute
     level: gold
+  - id: mezmo
+    level: gold
   - id: groundcover
     level: silver
   - id: flox


### PR DESCRIPTION
- Add Mezmo as Gold sponsor for Denver 2026
- Remove reference to specific parking garage.
- Add Focused.io as a Bronze sponsor for Denver 2026